### PR TITLE
Add hello-world example

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,9 +5,13 @@ theme: hugo-fresh
 
 menu:
   docs:
+    - identifier: getting-started
+      name: Getting started
+      url: /docs/getting-started/
+      weight: 100
     - identifier: tutorials
       name: Tutorials
-      url: /docs/tutorials
+      url: /docs/tutorials/
       weight: 200
     - identifier: spec
       name: Specification

--- a/content/docs/getting-started/_index.md
+++ b/content/docs/getting-started/_index.md
@@ -1,9 +1,8 @@
 ---
 title: "Getting started"
 date: 2019-02-16T13:56:52+01:00
-menu:
-  docs:
-weight: 100
+categories:
+- getting-started
 aliases:
 - '/v1/guide/'
 - '/v1/guide/index.html'

--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -21,7 +21,7 @@ channels:
           pattern: '^hello .+$'
 ```
 
-Let's get into the details of what we have here:
+Let's get into the details of the sample specification:
 
 <pre class="language-yaml line-numbers" data-line="1,2"><code>asyncapi: '2.0.0'
 id: hello-world-app
@@ -33,9 +33,9 @@ channels:
           type: string
           pattern: '^hello .+$'</code></pre>
 
-The first line tells us this is an AsyncAPI document and it's using version 2.0.0 of the specification. This line doesn't have to be the first one but it's a recommended practice.
+The first line of the specification starts with the document type (AsyncAPI) and the version (2.0.0) as a recommended practice.
 
-The second line is an identifier for our application. It is mandatory and must be unique so, when doing real stuff, don't use `hello-world-app` but instead something more "unique" like `urn:com:mycompany:hello-world-app`.
+The second line identifies the application and is both required and unique. In a real environment using 'urn:com:mycompany:hello-world-app' is considered unique and preferred rather than 'hello-world-app', for example.
 
 <pre class="language-yaml line-numbers" data-line="3-9"><code>asyncapi: '2.0.0'
 id: hello-world-app
@@ -47,9 +47,9 @@ channels:
           type: string
           pattern: '^hello .+$'</code></pre>
 
-And here is the `channels` section. A channel is the medium where the messages flow through. In some systems this is known as `topic`, `event name` or `routing key`. Like in TV channels, you may receive different kind of information on each one.
+The 'channels' section of the specification houses all of the mediums where messages flow through. For example, some systems use 'topic, 'event name' or 'routing key'. Different kinds of information flow through each channel similar to the analogy of TV channels.
 
-In our example, we only have one channel called `hello`. Our app is subscribing to this channel to receive "hello {name}" messages.
+In our example, we only have one channel called `hello`. The sample app subscribes to this channel to receive "hello {name}" messages.
 
 <pre class="language-yaml line-numbers" data-line="4-7"><code>asyncapi: '2.0.0'
 id: hello-world-app
@@ -73,7 +73,7 @@ channels:
           type: string
           pattern: '^hello .+$'</code></pre>
 
-And last but not least, the `payload` object defines how our message would have to look like. In our case, it must be a string and match the given regular expression. In other words, it must be a "hello {name}" string.
+The 'payload' object defines how the message must be structured. In this example, the message must be a string and match the given regular expression in the format "hello {name}" string.
 
 ## Conclusion
 

--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -1,0 +1,82 @@
+---
+title: "Hello world"
+date: 2019-04-01T10:56:52+01:00
+menu:
+  docs:
+    parent: 'getting-started'
+weight: 101
+---
+
+Let's define an application that's capable of receiving a "hello {name}" message.
+
+```yaml
+asyncapi: '2.0.0'
+id: hello-world-app
+channels:
+  hello:
+    subscribe:
+      message:
+        payload:
+          type: string
+          pattern: '^hello .+$'
+```
+
+Let's get into the details of what we have here:
+
+<pre class="language-yaml line-numbers" data-line="1,2"><code>asyncapi: '2.0.0'
+id: hello-world-app
+channels:
+  hello:
+    subscribe:
+      message:
+        payload:
+          type: string
+          pattern: '^hello .+$'</code></pre>
+
+The first line tells us this is an AsyncAPI document and it's using version 2.0.0 of the specification. This line doesn't have to be the first one but it's a recommended practice.
+
+The second line is an identifier for our application. It is mandatory and must be unique so, when doing real stuff, don't use `hello-world-app` but instead something more "unique" like `urn:com:mycompany:hello-world-app`.
+
+<pre class="language-yaml line-numbers" data-line="3-9"><code>asyncapi: '2.0.0'
+id: hello-world-app
+channels:
+  hello:
+    subscribe:
+      message:
+        payload:
+          type: string
+          pattern: '^hello .+$'</code></pre>
+
+And here is the `channels` section. A channel is the medium where the messages flow through. In some systems this is known as `topic`, `event name` or `routing key`. Like in TV channels, you may receive different kind of information on each one.
+
+In our example, we only have one channel called `hello`. Our app is subscribing to this channel to receive "hello {name}" messages.
+
+<pre class="language-yaml line-numbers" data-line="4-7"><code>asyncapi: '2.0.0'
+id: hello-world-app
+channels:
+  hello:
+    subscribe:
+      message:
+        payload:
+          type: string
+          pattern: '^hello .+$'</code></pre>
+
+You can read the highlighted lines as "this is the **payload** of the **message** your app is **subscribed** to on the «**hello**» channel".
+
+<pre class="language-yaml line-numbers" data-line="7-9"><code>asyncapi: '2.0.0'
+id: hello-world-app
+channels:
+  hello:
+    subscribe:
+      message:
+        payload:
+          type: string
+          pattern: '^hello .+$'</code></pre>
+
+And last but not least, the `payload` object defines how our message would have to look like. In our case, it must be a string and match the given regular expression. In other words, it must be a "hello {name}" string.
+
+## Conclusion
+
+We've seen how to define our simple Hello World app but, **how do we send a message to our Hello World application?**
+
+Go to the next chapter to [learn more about the `servers` property](/docs/servers).

--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -35,7 +35,7 @@ channels:
 
 The first line of the specification starts with the document type (AsyncAPI) and the version (2.0.0) as a recommended practice.
 
-The second line identifies the application and is both required and unique. In a real environment using 'urn:com:mycompany:hello-world-app' is considered unique and preferred rather than 'hello-world-app', for example.
+The second line identifies the application and is both required and unique. In a real environment using 'urn:com:mycompany:hello-world-app' is preferred rather than 'hello-world-app', for example.
 
 <pre class="language-yaml line-numbers" data-line="3-9"><code>asyncapi: '2.0.0'
 id: hello-world-app

--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -33,7 +33,7 @@ channels:
           type: string
           pattern: '^hello .+$'</code></pre>
 
-The first line of the specification starts with the document type (AsyncAPI) and the version (2.0.0) as a recommended practice.
+The first line of the specification starts with the document type (AsyncAPI) and the version (2.0.0). This line doesn't have to be the first one but it's a recommended practice.
 
 The second line identifies the application and is both required and unique. In a real environment using 'urn:com:mycompany:hello-world-app' is preferred rather than 'hello-world-app', for example.
 

--- a/themes/hugo-fresh/layouts/_default/list.html
+++ b/themes/hugo-fresh/layouts/_default/list.html
@@ -1,17 +1,21 @@
 {{ define "main" }}
 <div class="container" style="padding:0 2rem;margin-top:30px;">
     <div class="columns">
-        <div class="column is-3 is-hidden-mobile is-hidden-tablet-only">
+        <div class="column is-3">
             {{ partial "docs/sidebar.html" . }}
         </div>
         <div class="column is-9 is-centered-tablet-portrait">
-            <h1 class="title section-title">{{ .Title }}</h1>
-            <div class="docs-content">
-                {{ range .Pages }}
-                <a href="{{.URL}}">{{.Title}}</a>
-                {{ .Render "summary"}}
-                {{ end }}
-            </div>
+            {{ if .Content }}
+                {{ partial "docs/content.html" . }}
+            {{ else }}
+                <h1 class="title section-title">{{ .Title }}</h1>
+                <div class="docs-content">
+                    {{ range .Pages }}
+                    <a href="{{.URL}}">{{.Title}}</a>
+                    {{ .Render "summary"}}
+                    {{ end }}
+                </div>
+            {{ end }}
         </div>
     </div>
 </div>

--- a/themes/hugo-fresh/layouts/docs/single.html
+++ b/themes/hugo-fresh/layouts/docs/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div class="container" style="padding:0 2rem;margin-top:30px;">
     <div class="columns">
-        <div class="column is-3 is-hidden-mobile is-hidden-tablet-only">
+        <div class="column is-3">
             {{ partial "docs/sidebar.html" . }}
         </div>
         <div class="column is-9 is-centered-tablet-portrait">

--- a/themes/hugo-fresh/layouts/partials/docs/sidebar.html
+++ b/themes/hugo-fresh/layouts/partials/docs/sidebar.html
@@ -5,10 +5,14 @@
         {{ range .Site.Menus.docs }}
         {{ if .HasChildren }}
         <li>
-            <a href="{{ .URL }}">
-                {{ .Pre }}
-                <span>{{ .Name }}</span>
-            </a>
+            {{ if $currentPage.IsMenuCurrent "docs" . }}
+                <span class="active">{{ .Name }}</span>
+            {{ else }}
+                <a href="{{ .URL }}">
+                    {{ .Pre }}
+                    <span>{{ .Name }}</span>
+                </a>
+            {{ end }}
         </li>
         <ul class="sub-menu">
             {{ range .Children }}


### PR DESCRIPTION
### What?
It adds an example of how to create a Hello World AsyncAPI document.

### Why?
This is part of the getting started guide I'd like to write for version 2.

### Notes

The reason I'm using code blocks like `<pre class="language-yaml line-numbers" data-line="4-7"><code>` is because it allows me to highlight lines on the code block. See an example:

![Screen Shot 2019-04-01 at 15 13 37](https://user-images.githubusercontent.com/242119/55330215-c5ad3f00-5490-11e9-8327-00f23c0670f5.png)

### Request for Help

Can someone help me adding better explanations and improving the introduction paragraph? Please, remember this is a Hello World and we should be very concise and straight to the point.