### PR TITLE
Add reusing messages and schemas

### DIFF
--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -18,6 +18,9 @@ Let's define an application that's capable of receiving a "hello {name}" message
 ```yaml
 asyncapi: '2.0.0-rc1'
 id: 'urn:hello-world-app'
+info:
+  title: Hello world application
+  version: '0.1.0'
 channels:
   hello:
     subscribe:
@@ -32,6 +35,9 @@ Let's get into the details of the sample specification:
 {{<code lang="yaml" lines="1,2">}}
 asyncapi: '2.0.0-rc1'
 id: 'urn:hello-world-app'
+info:
+  title: Hello world application
+  version: '0.1.0'
 channels:
   hello:
     subscribe:
@@ -45,9 +51,29 @@ The first line of the specification starts with the document type (AsyncAPI) and
 
 The second line identifies the application and is both required and unique. In a real environment using 'urn:com:mycompany:hello-world-app' is preferred rather than 'urn:hello-world-app', for example.
 
-{{<code lang="yaml" lines="3-9">}}
+{{<code lang="yaml" lines="3-5">}}
 asyncapi: '2.0.0-rc1'
 id: 'urn:hello-world-app'
+info:
+  title: Hello world application
+  version: '0.1.0'
+channels:
+  hello:
+    subscribe:
+      message:
+        payload:
+          type: string
+          pattern: '^hello .+$'
+{{</code>}}
+
+The "info" object contains the minimum required information about the application. It contains the title, which is a memorable name for the API, and the version. While it's not mandatory, it is strongly recommended to change the version whenever you make changes to the API.
+
+{{<code lang="yaml" lines="6-12">}}
+asyncapi: '2.0.0-rc1'
+id: 'urn:hello-world-app'
+info:
+  title: Hello world application
+  version: '0.1.0'
 channels:
   hello:
     subscribe:
@@ -61,9 +87,12 @@ The 'channels' section of the specification houses all of the mediums where mess
 
 In our example, we only have one channel called `hello`. The sample app subscribes to this channel to receive "hello {name}" messages.
 
-{{<code lang="yaml" lines="4-7">}}
+{{<code lang="yaml" lines="7-10">}}
 asyncapi: '2.0.0-rc1'
 id: 'urn:hello-world-app'
+info:
+  title: Hello world application
+  version: '0.1.0'
 channels:
   hello:
     subscribe:
@@ -75,9 +104,12 @@ channels:
 
 You can read the highlighted lines as "this is the **payload** of the **message** your app is **subscribed** to on the «**hello**» channel".
 
-{{<code lang="yaml" lines="7-9">}}
+{{<code lang="yaml" lines="10-12">}}
 asyncapi: '2.0.0-rc1'
 id: 'urn:hello-world-app'
+info:
+  title: Hello world application
+  version: '0.1.0'
 channels:
   hello:
     subscribe:

--- a/content/docs/getting-started/publishing.md
+++ b/content/docs/getting-started/publishing.md
@@ -25,9 +25,12 @@ A message broker is the infrastructure piece in charge of receiving the messages
 
 The publisher definition would look like the following:
 
-{{<code lang="yaml" lines="2,9">}}
+{{<code lang="yaml" lines="2,4,12">}}
 asyncapi: '2.0.0-rc1'
 id: 'urn:hello-world-publisher'
+info:
+  title: Hello world publisher application
+  version: '0.1.0'
 servers:
   - url: kafka.mycompany.com
     protocol: kafka
@@ -41,10 +44,10 @@ channels:
           pattern: '^hello .+$'
 {{</code>}}
 
-You probably have noticed that the only difference between this AsyncAPI definition and the one for the [Hello world application](/docs/getting-started/hello-world) are the lines 2 and 9. The id must be unique for each application, that's the reason it is different. In the case of the line 9, it is now `publish` because we're defining a publishing operation.
+You probably have noticed that the only difference between this AsyncAPI definition and the one for the [Hello world application](/docs/getting-started/hello-world) are the lines 2, 4, and 9. The id must be unique for each application, that's the reason it is different. Since it's a publisher application, we also wanted to make it obvious in the title. In the case of the line 9, it is now `publish` because we're defining a publishing operation.
 
 ## Conclusion
 
 From the AsyncAPI perspective, the differences between publishers and subscribers are very subtle. This level of expressiveness makes AsyncAPI documents highly explicit and self-documenting. However, it comes at the cost of duplicating a lot of information.
 
-Go to the next chapter and [learn how to reuse information](/docs/getting-started/reusing) and avoid duplication.
+Go to the next chapter and [learn how to reuse messages](/docs/getting-started/reusing-messages) and avoid duplication.

--- a/content/docs/getting-started/reusing-messages.md
+++ b/content/docs/getting-started/reusing-messages.md
@@ -1,0 +1,108 @@
+---
+title: "Reusing messages"
+date: 2019-04-15T10:56:52+01:00
+draft: true
+menu:
+  docs:
+    parent: 'getting-started'
+weight: 130
+---
+
+{{% notice %}}
+This article is about version 2.0.0-rc1 of the specification. Please note that documentation and tooling support are minimum or inexistent yet. We're working hard
+to update everything to version 2.0.0 as soon as possible. Thanks for your patience.
+{{% /notice %}}
+
+When defining the APIs of a producer and a consumer, we soon realize there's —at least— one thing that is repeated: the messages. In this chapter, you'll learn how to reuse message definitions so you don't have to maintain multiple copies of the same thing (with the problems it can carry.)
+
+Let's start with the publisher application. Instead of copying the definition above and pasting it over on the subscriber, let's use the "components" section as follows:
+
+{{<code lang="yaml" lines="15-20">}}
+asyncapi: '2.0.0-rc1'
+id: 'urn:hello-world-publisher'
+info:
+  title: Hello world publisher application
+  version: '0.1.0'
+servers:
+  - url: kafka.mycompany.com
+    protocol: kafka
+    description: This is "My Company" Kafka instance.
+channels:
+  hello:
+    publish:
+      message:
+        $ref: '#/components/messages/hello-msg'
+components:
+  messages:
+    hello-msg:
+      payload:
+        type: string
+        pattern: '^hello .+$'
+{{</code>}}
+
+The "components" section is an object that holds reusable parts of an AsyncAPI definition. We moved the definition of the message there and assigned it a name: "hello-msg". Why assigning a name? Check out line 14 of the definition:
+
+{{<code lang="yaml" lines="14">}}
+asyncapi: '2.0.0-rc1'
+id: 'urn:hello-world-publisher'
+info:
+  title: Hello world publisher application
+  version: '0.1.0'
+servers:
+  - url: kafka.mycompany.com
+    protocol: kafka
+    description: This is "My Company" Kafka instance.
+channels:
+  hello:
+    publish:
+      message:
+        $ref: '#/components/messages/hello-msg'
+components:
+  messages:
+    hello-msg:
+      payload:
+        type: string
+        pattern: '^hello .+$'
+{{</code>}}
+
+The "$ref" property allows us to indicate that our message is not here but, instead, it's defined in the URL provided. The URL is a JSON Pointer and reads as follow:
+
+1. The `#` (pound) symbol means the definition is in this same document.
+2. `/components` means the definition is placed in the components section, which is at the root of the document (notice the `/`).
+3. `/components/messages` means the definition is placed in the messages section inside components.
+4. `/components/messages/hello-msg` means the definition of the message can be finally found inside `hello-msg` inside the messages section.
+
+{{%hint%}}
+JSON Pointer is an IETF standard. Curious to know more about it? Check out {{%link "https://tools.ietf.org/html/rfc6901" %}}RFC 6901{{%/link%}}.
+{{%/hint%}}
+
+While this is cool for reusing messages inside the same document, it doesn't solve our problem when we want to reuse messages across AsyncAPI documents. Or does it? Check this out:
+
+{{<code lang="yaml" lines="14">}}
+asyncapi: '2.0.0-rc1'
+id: 'urn:hello-world-app'
+info:
+  title: Hello world application
+  version: '0.1.0'
+servers:
+  - url: kafka.mycompany.com
+    protocol: kafka
+    description: This is "My Company" Kafka instance.
+channels:
+  hello:
+    subscribe:
+      message:
+        $ref: 'https://helloworldapp.com/publisher.yaml#/components/messages/hello-msg'
+{{</code>}}
+
+Assuming the AsyncAPI file for the publisher can be found at `https://helloworldapp.com/publisher.yaml`, and going back to the subscriber application —the initial hello world application— we just need to change a single line to indicate that the message is defined in the publisher application. That way, you only have the definition in one place and reuse it all over.
+
+{{%remember%}}
+We made the subscriber message definition point to the one on the publisher. This is cool to keep it simple as an example but, on the long term, it creates coupling between the documents. {{%link "https://medium.com/asyncapi/organizing-your-asyncapi-documents-12bccecd9ced" %}}Read this article{{%/link%}} if you want to learn a better way of organizing your AsyncAPI documents.
+{{%/remember%}}
+
+## Conclusion
+
+Message reusability is possible inside the same document and across multiple ones. Move definitions to the components section and then use "$ref" to point to them wherever you need them.
+
+Go to the next chapter and [learn how to reuse schemas](/docs/getting-started/reusing-schemas).

--- a/content/docs/getting-started/reusing-schemas.md
+++ b/content/docs/getting-started/reusing-schemas.md
@@ -5,7 +5,7 @@ draft: true
 menu:
   docs:
     parent: 'getting-started'
-weight: 130
+weight: 140
 ---
 
 {{% notice %}}

--- a/content/docs/getting-started/reusing-schemas.md
+++ b/content/docs/getting-started/reusing-schemas.md
@@ -1,0 +1,155 @@
+---
+title: "Reusing schemas"
+date: 2019-04-15T10:56:52+01:00
+draft: true
+menu:
+  docs:
+    parent: 'getting-started'
+weight: 130
+---
+
+{{% notice %}}
+This article is about version 2.0.0-rc1 of the specification. Please note that documentation and tooling support are minimum or inexistent yet. We're working hard
+to update everything to version 2.0.0 as soon as possible. Thanks for your patience.
+{{% /notice %}}
+
+To illustrate how schema reusability works on AsyncAPI, we're going to enhance the [Hello world publisher application](/docs/getting-started/publishing) to make it, say, a bit less "hello world":
+
+{{<code lang="yaml" lines="19-26">}}
+asyncapi: '2.0.0-rc1'
+id: 'urn:hello-world-publisher'
+info:
+  title: Hello world publisher application
+  version: '0.1.0'
+servers:
+  - url: kafka.mycompany.com
+    protocol: kafka
+    description: This is "My Company" Kafka instance.
+channels:
+  hello:
+    publish:
+      message:
+        $ref: '#/components/messages/hello-msg'
+components:
+  messages:
+    hello-msg:
+      payload:
+        type: object
+        properties:
+          name:
+            type: string
+          sentAt:
+            type: string
+            description: The date and time a message was sent.
+            format: datetime
+{{</code>}}
+
+The payload is now a JSON object instead of a raw string. This object must contain the properties "name" and "sentAt". We'll use the name to know who we have to say hello to, and "sentAt" to register the date and time our application sent the message. An example of a valid object would be:
+
+{{<code lang="json">}}
+{
+  "name": "Jess",
+  "sentAt": "2018-11-13T20:20:39+00:00"
+}
+{{</code>}}
+
+{{%hint%}}
+Are you new to JSON Schema? Check out their guide {{%link "https://json-schema.org/understanding-json-schema/basics.html" %}}Understanding JSON Schema{{%/link%}}.
+{{%/hint%}}
+
+We updated our publisher to send a JSON object. Since the subscriber application is pointing to this definition, there's no need to change it on the subscriber side. Reusability at its best.
+
+However, it looks like the `sentAt` property is going to appear on every message. To keep it simple, we only have a message (hello-msg) but in real-world environment you'll have more than one and most probably across different channels too. Say, for instance, we want to add a "goodbye" message:
+
+{{<code lang="yaml" lines="15-18,31-38">}}
+asyncapi: '2.0.0-rc1'
+id: 'urn:hello-world-publisher'
+info:
+  title: Hello world publisher application
+  version: '0.1.0'
+servers:
+  - url: kafka.mycompany.com
+    protocol: kafka
+    description: This is "My Company" Kafka instance.
+channels:
+  hello:
+    publish:
+      message:
+        $ref: '#/components/messages/hello-msg'
+  goodbye:
+    publish:
+      message:
+        $ref: '#/components/messages/goodbye-msg'
+components:
+  messages:
+    hello-msg:
+      payload:
+        type: object
+        properties:
+          name:
+            type: string
+          sentAt:
+            type: string
+            description: The date and time a message was sent.
+            format: datetime
+    goodbye-msg:
+      payload:
+        type: object
+        properties:
+          sentAt:
+            type: string
+            description: The date and time a message was sent.
+            format: datetime
+{{</code>}}
+
+As you can see, the definition is almost the same as the one for `hello-msg`. The only difference is that the `goodbye-msg` message doesn't have a "name" property. However, it the definition of `sentAt` is repeated, so let's reuse this schema:
+
+{{<code lang="yaml" lines="28,34,35-39">}}
+asyncapi: '2.0.0-rc1'
+id: 'urn:hello-world-publisher'
+info:
+  title: Hello world publisher application
+  version: '0.1.0'
+servers:
+  - url: kafka.mycompany.com
+    protocol: kafka
+    description: This is "My Company" Kafka instance.
+channels:
+  hello:
+    publish:
+      message:
+        $ref: '#/components/messages/hello-msg'
+  goodbye:
+    publish:
+      message:
+        $ref: '#/components/messages/goodbye-msg'
+components:
+  messages:
+    hello-msg:
+      payload:
+        type: object
+        properties:
+          name:
+            type: string
+          sentAt:
+            $ref: '#/components/schemas/sent-at'
+    goodbye-msg:
+      payload:
+        type: object
+        properties:
+          sentAt:
+            $ref: '#/components/schemas/sent-at'
+  schemas:
+    sent-at:
+      type: string
+      description: The date and time a message was sent.
+      format: datetime
+{{</code>}}
+
+As we did with messages in the previous chapter, we moved the definition of the `sentAt` property to components > schemas > sent-at, and referenced it from the `hello-msg` and `goodbye-msg` messages.
+
+## Conclusion
+
+Schema reusability is possible inside the same document and across multiple ones too. Move schema definitions to the components section and then use "$ref" to point to them wherever you need them.
+
+Go to the next chapter and [learn how to add security to our API](/docs/getting-started/security).

--- a/content/docs/getting-started/servers.md
+++ b/content/docs/getting-started/servers.md
@@ -18,9 +18,12 @@ In the previous lesson, we learned how to create the definition of a simple [Hel
 In this article, we will learn how to add "servers" to our AsyncAPI document. Adding and defining servers is useful because it specifies where and how to connect. The connection facilitates where to send and receive messages.
 
 
-{{<code lang="yaml" lines="3-6">}}
+{{<code lang="yaml" lines="6-9">}}
 asyncapi: '2.0.0-rc1'
 id: 'urn:hello-world-app'
+info:
+  title: Hello world application
+  version: '0.1.0'
 servers:
   - url: kafka.mycompany.com
     protocol: kafka

--- a/resources/_gen/assets/sass/style.sass_5ad6f408b0e3e473c748aac88af0ea18.content
+++ b/resources/_gen/assets/sass/style.sass_5ad6f408b0e3e473c748aac88af0ea18.content
@@ -7162,7 +7162,9 @@ button:focus, button:active {
       color: white;
       text-decoration: underline; }
   .docs-content .hint {
-    display: flex; }
+    display: flex;
+    margin-top: 2em;
+    margin-bottom: 2em; }
     .docs-content .hint .hint__icon-wrapper {
       padding: 1em 1em 1em 0;
       border-right: #46a2c7 2px solid;

--- a/themes/hugo-fresh/assets/fresh/partials/_docs.scss
+++ b/themes/hugo-fresh/assets/fresh/partials/_docs.scss
@@ -241,7 +241,9 @@ $table-striped-row-even-hover-background-color: $white-ter !default;
 
     .hint {
         display: flex;
-        
+        margin-top: 2em;
+        margin-bottom: 2em;
+
         .hint__icon-wrapper {
             padding: 1em 1em 1em 0;
             border-right: #46a2c7 2px solid;

--- a/themes/hugo-fresh/layouts/partials/javascript.html
+++ b/themes/hugo-fresh/layouts/partials/javascript.html
@@ -16,6 +16,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
 <script charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/prism.js"></script>
 <script charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/components/prism-yaml.min.js"></script>
+<script charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/components/prism-json.min.js"></script>
 <script charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/plugins/line-numbers/prism-line-numbers.js"></script>
 <script charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 


### PR DESCRIPTION
Adds 2 new chapters to the getting started guide on how to reuse messages and schemas in an AsyncAPI document and across multiple ones.

Fixes #6 