### PR TITLE
Fixed spelling of company (previously 'comap').

### DIFF
--- a/content/docs/getting-started/publishing.md
+++ b/content/docs/getting-started/publishing.md
@@ -31,7 +31,7 @@ info:
   title: Hello world publisher application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
 channels:

--- a/content/docs/getting-started/reusing-messages.md
+++ b/content/docs/getting-started/reusing-messages.md
@@ -23,7 +23,7 @@ info:
   title: Hello world publisher application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
 channels:
@@ -48,7 +48,7 @@ info:
   title: Hello world publisher application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
 channels:
@@ -84,7 +84,7 @@ info:
   title: Hello world application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
 channels:

--- a/content/docs/getting-started/reusing-schemas.md
+++ b/content/docs/getting-started/reusing-schemas.md
@@ -21,7 +21,7 @@ info:
   title: Hello world publisher application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
 channels:
@@ -67,7 +67,7 @@ info:
   title: Hello world publisher application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
 channels:
@@ -110,7 +110,7 @@ info:
   title: Hello world publisher application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
 channels:

--- a/content/docs/getting-started/security.md
+++ b/content/docs/getting-started/security.md
@@ -30,7 +30,7 @@ info:
   title: Hello world publisher application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
     security:

--- a/content/docs/getting-started/servers.md
+++ b/content/docs/getting-started/servers.md
@@ -24,7 +24,7 @@ info:
   title: Hello world application
   version: '0.1.0'
 servers:
-  - url: broker.mycomapny.com
+  - url: broker.mycompany.com
     protocol: amqp
     description: This is "My Company" broker.
 channels:


### PR DESCRIPTION
In the "getting-started" section, many of the server URLs contained a typo.