### PR TITLE
Servers is an object

### DIFF
--- a/content/docs/specifications/2.0.0.md
+++ b/content/docs/specifications/2.0.0.md
@@ -387,43 +387,46 @@ The following shows how multiple servers can be described, for example, at the A
 
 ```json
 {
-  "servers": [
-    {
+  "servers": {
+    "development": {
       "url": "development.gigantic-server.com",
       "description": "Development server",
       "protocol": "amqp",
       "protocolVersion": "0.9.1"
     },
-    {
+    "staging": {
       "url": "staging.gigantic-server.com",
       "description": "Staging server",
       "protocol": "amqp",
       "protocolVersion": "0.9.1"
     },
-    {
+    "production": {
       "url": "api.gigantic-server.com",
       "description": "Production server",
       "protocol": "amqp",
       "protocolVersion": "0.9.1"
     }
-  ]
+  }
 }
 ```
 
 ```yaml
 servers:
-- url: development.gigantic-server.com
-  description: Development server
-  protocol: amqp
-  protocolVersion: 0.9.1
-- url: staging.gigantic-server.com
-  description: Staging server
-  protocol: amqp
-  protocolVersion: 0.9.1
-- url: api.gigantic-server.com
-  description: Production server
-  protocol: amqp
-  protocolVersion: 0.9.1
+  development:
+    url: development.gigantic-server.com
+    description: Development server
+    protocol: amqp
+    protocolVersion: 0.9.1
+  staging:
+    url: staging.gigantic-server.com
+    description: Staging server
+    protocol: amqp
+    protocolVersion: 0.9.1
+  production:
+    url: api.gigantic-server.com
+    description: Production server
+    protocol: amqp
+    protocolVersion: 0.9.1
 ```
 
 The following shows how variables can be used for a server configuration:


### PR DESCRIPTION
It seems like the examples here weren't changed from 2.0.0-RC1 to 2.0.0 when `servers` changed from an array to an object.