### PR TITLE
Add bump.sh to Documentation Generators category

### DIFF
--- a/content/docs/tooling.md
+++ b/content/docs/tooling.md
@@ -27,10 +27,12 @@ The language you're looking for is not here? You have created a new code generat
 
 The following is a list of tools that generate human-readable documentation from an AsyncAPI document.
 
-| Link           | Description    |
-| :------------- | :------------- |
-| [AsyncAPI Generator](https://github.com/asyncapi/generator) | Use your AsyncAPI definition to generate literally anything. Markdown documentation, Node.js code, HTML documentation, anything!
-| [Widdershins](https://github.com/Mermade/widdershins) | OpenApi 3.0 / Swagger 2.0 / AsyncAPI 1.0 definition to Slate / Shins compatible markdown. Thanks to [@PermittedSoc](https://twitter.com/@Permittedsoc).
+| Link           | Description    | Language/Kind |
+| :------------- | :------------- | :------------ |
+| [AsyncAPI Generator](https://github.com/asyncapi/generator) | Use your AsyncAPI definition to generate literally anything. Markdown documentation, Node.js code, HTML documentation, anything! | Javascript
+| [Widdershins](https://github.com/Mermade/widdershins) | OpenApi 3.0 / Swagger 2.0 / AsyncAPI 1.0 definition to Slate / Shins compatible markdown. Thanks to [@PermittedSoc](https://twitter.com/@Permittedsoc). | Javascript
+| [Bump](https://bump.sh) | OpenApi 2 & 3 / AsyncAPI 2 documentation generator, with automatic changelog and visual diff. | SaaS
+
 
 # Validators {#validators}
 


### PR DESCRIPTION
As discussed in issue #30, this adds https://bump.sh to the tooling page. I added a new `Language/Kind` column to the `Documentation generators` category.

<img width="1396" alt="PR result" src="https://user-images.githubusercontent.com/30788/68288012-f509d700-0083-11ea-8c52-716be22510a7.png">
