### PR TITLE
Add new others section to list of tools

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -73,6 +73,8 @@ params:
       url: /docs/tooling#validators
     - title: Code-first tools
       url: /docs/tooling#code-first
+    - title: Others
+      url: /docs/tooling#others
   - title: Blog
     url: /blog
   - title: Help

--- a/content/docs/tooling.md
+++ b/content/docs/tooling.md
@@ -30,7 +30,7 @@ The following is a list of tools that generate human-readable documentation from
 | Link           | Description    | Language/Kind |
 | :------------- | :------------- | :------------- |
 | [AsyncAPI Generator](https://github.com/asyncapi/generator) | Use your AsyncAPI definition to generate literally anything. Markdown documentation, Node.js code, HTML documentation, anything! | CLI / Javascript
-| [AsyncAPI React](https://github.com/asyncapi/asyncapi-react) | React component for rendering documentation from your specification in real-time in the browser. | Javascript
+| [AsyncAPI React](https://github.com/asyncapi/asyncapi-react) | React component for rendering documentation from your specification in real-time in the browser. Thanks to [@Kyma team](https://kyma-project.io/). | Javascript
 | [Bump](https://bump.sh) | OpenApi 2 & 3 / AsyncAPI 2 documentation generator, with automatic changelog and visual diff. | SaaS
 | [Widdershins](https://github.com/Mermade/widdershins) | OpenApi 3.0 / Swagger 2.0 / AsyncAPI 1.0 definition to Slate / Shins compatible markdown. Thanks to [@PermittedSoc](https://twitter.com/@Permittedsoc). | CLI / Javascript
 
@@ -38,11 +38,12 @@ The following is a list of tools that generate human-readable documentation from
 
 The following is a list of tools that validate AsyncAPI documents.
 
-| Link           | Description    |
-| :------------- | :------------- |
-| [AsyncAPI Parser](https://github.com/asyncapi/parser-js) | It parses and validates AsyncAPI documents.
-| [Check-API](https://github.com/Mermade/check_api) | It allows you to validate a local file or remote URL with a single command-line or programmatic invocation. It returns an exitCode of 0 on success and 1 on failure, making it suitable for use in Continuous Integration environments. Thanks to [@PermittedSoc](https://twitter.com/@Permittedsoc).
-| [asyncapi-validator](https://github.com/WaleedAshraf/asyncapi-validator) | It allows you to validate schema of your messages against your AsyncAPI schema definition. You can use it with Kafka, RabbitMQ or any other messaging/queue. Thanks to [@waleedashraf](https://twitter.com/@waleedashraf01).
+| Link           | Description    | Language/Framework |
+| :------------- | :------------- | :----------------- |
+| [AsyncAPI Parser](https://github.com/asyncapi/parser-js) | It parses and validates AsyncAPI documents. | Javascript
+| [Check-API](https://github.com/Mermade/check_api) | It allows you to validate a local file or remote URL with a single command-line or programmatic invocation. It returns an exitCode of 0 on success and 1 on failure, making it suitable for use in Continuous Integration environments. Thanks to [@PermittedSoc](https://twitter.com/@Permittedsoc). | Javascript
+| [asyncapi-validator](https://github.com/WaleedAshraf/asyncapi-validator) | It allows you to validate schema of your messages against your AsyncAPI schema definition. You can use it with Kafka, RabbitMQ or any other messaging/queue. Thanks to [@waleedashraf](https://twitter.com/@waleedashraf01). | Javascript
+| [AsyncAPI Parser](https://github.com/asyncapi/parser) | It parses and validates AsyncAPI documents. | Go
 
 # Code-first tools {#code-first}
 
@@ -52,3 +53,12 @@ The following is a list of tools that generate AsyncAPI documents from your code
 | :------------- | :------------- | :----------------- |
 | [Go AsyncAPI](https://github.com/swaggest/go-asyncapi) | It uses reflection to translate Go structures in JSON Schema definitions and arrange them in AsyncAPI schema. Thanks to [@vearutop](https://github.com/vearutop). | Go
 | [Saunter](https://github.com/tehmantra/saunter) | Like [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) for AsyncAPI. Generates (and hosts) an AsyncAPI schema document from your code. Thanks to [@tehmantra](https://github.com/tehmantra). | C#/dotnet
+
+# Others {#others}
+
+The following is a list of tools that do not yet belong to any specific category but are also useful for the community.
+
+| Link           | Description    | Language/Framework |
+| :------------- | :------------- | :----------------- |
+| [Converter](https://github.com/asyncapi/converter) | Converts old versions of AsyncAPI files into the latest version. | Javascript
+| [Converter Go](https://github.com/asyncapi/converter-go) | Converts old versions of AsyncAPI files into the latest version. Thanks to [@Kyma team](https://kyma-project.io/). | Go


### PR DESCRIPTION
This PR adds a new Others section with other tools for AsyncAPI. As agreed in previous discussion for now it is called others but in future, it might evolve into different names once we get more tools of a specific category