### PR TITLE
Add edit link to documentation 

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,6 +22,7 @@ menu:
       weight: 800
 params:
   google_analytics_id: UA-109278936-1
+  content_sources_location: https://github.com/asyncapi/website/edit/master/content/
   meta: 
     description: Create machine-readable definitions of your message-driven systems.
     og:

--- a/themes/hugo-asyncapi/assets/layout/_docs.scss
+++ b/themes/hugo-asyncapi/assets/layout/_docs.scss
@@ -73,7 +73,7 @@ $table-striped-row-even-hover-background-color: $light-grey !default;
     font-weight: 400;
     letter-spacing: -.003em;
     line-height: 1.58;
-    margin-bottom: 10rem;
+    margin-bottom: 1rem;
 
     h1, h2, h3, h4, h5, h6 {
         margin: 1em 0;

--- a/themes/hugo-asyncapi/layouts/docs/single.html
+++ b/themes/hugo-asyncapi/layouts/docs/single.html
@@ -5,7 +5,8 @@
             {{ partial "docs/sidebar.html" . }}
         </div>
         <div class="col-md-9">
-        {{ partial "docs/content.html" . }}
+            {{ partial "docs/content.html" . }}
+            {{ partial "docs/edit-hint.html" . }}
         </div>
     </div>
 </div>

--- a/themes/hugo-asyncapi/layouts/docs/single.html
+++ b/themes/hugo-asyncapi/layouts/docs/single.html
@@ -6,8 +6,8 @@
         </div>
         <div class="col-md-9">
             {{ partial "docs/content.html" . }}
-            {{ partial "docs/edit-hint.html" . }}
         </div>
+        {{ partial "docs/edit-hint.html" . }}
     </div>
 </div>
 {{ partial "footer.html" . }}

--- a/themes/hugo-asyncapi/layouts/partials/docs/content.html
+++ b/themes/hugo-asyncapi/layouts/partials/docs/content.html
@@ -8,5 +8,13 @@
         {{- with .Content -}}
         {{ . | replaceRE "(<h[1-9] id=\"([^\"]+)\".+)(</h[1-9]+>)" `${1}<a href="#${2}" class="hanchor" ariaLabel="Anchor"> #&#xFE0E;</a> ${3}` | safeHTML }}
         {{- end -}}
+        <div class="hint">
+            <div class="hint__icon-wrapper">
+                <i class="hint__icon-wrapper__icon fa fa-question-circle"></i>
+            </div>
+            <div class="hint__body">
+                Improve this page by providing edits suggestions <a target="_blank" href="{{ .Site.Params.content_sources_location }}{{ .File.Path }}">here</a>. After providing suggestions to the text, submit a Pull Request using <a target="_blank" href="https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request">this</a> instruction. Feel free to contact us on <a target="_blank" href="https://asyncapi.com/slack-invite">Slack</a> for questions.
+            </div>
+        </div>
     </div>
 </div>

--- a/themes/hugo-asyncapi/layouts/partials/docs/content.html
+++ b/themes/hugo-asyncapi/layouts/partials/docs/content.html
@@ -13,7 +13,9 @@
                 <i class="hint__icon-wrapper__icon fa fa-question-circle"></i>
             </div>
             <div class="hint__body">
-                Improve this page by providing edits suggestions <a target="_blank" href="{{ .Site.Params.content_sources_location }}{{ .File.Path }}">here</a>. After providing suggestions to the text, submit a Pull Request using <a target="_blank" href="https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request">this</a> instruction. Feel free to contact us on <a target="_blank" href="https://asyncapi.com/slack-invite">Slack</a> for questions.
+                Improve this page by providing edits suggestions <a target="_blank" href="{{ .Site.Params.content_sources_location }}{{ .File.Path }}">here</a>. After providing suggestions to the text, submit a Pull Request using <a target="_blank" href="https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request">this</a> instruction. You can also suggest changes by <a target="_blank" href="https://github.com/asyncapi/website/issues/new">reporting an issue</a>.
+                <br>
+                Feel free to contact us on <a target="_blank" href="https://asyncapi.com/slack-invite">Slack</a> for questions.
             </div>
         </div>
     </div>

--- a/themes/hugo-asyncapi/layouts/partials/docs/content.html
+++ b/themes/hugo-asyncapi/layouts/partials/docs/content.html
@@ -8,15 +8,5 @@
         {{- with .Content -}}
         {{ . | replaceRE "(<h[1-9] id=\"([^\"]+)\".+)(</h[1-9]+>)" `${1}<a href="#${2}" class="hanchor" ariaLabel="Anchor"> #&#xFE0E;</a> ${3}` | safeHTML }}
         {{- end -}}
-        <div class="hint">
-            <div class="hint__icon-wrapper">
-                <i class="hint__icon-wrapper__icon fa fa-question-circle"></i>
-            </div>
-            <div class="hint__body">
-                Improve this page by providing edits suggestions <a target="_blank" href="{{ .Site.Params.content_sources_location }}{{ .File.Path }}">here</a>. After providing suggestions to the text, submit a Pull Request using <a target="_blank" href="https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request">this</a> instruction. You can also suggest changes by <a target="_blank" href="https://github.com/asyncapi/website/issues/new">reporting an issue</a>.
-                <br>
-                Feel free to contact us on <a target="_blank" href="https://asyncapi.com/slack-invite">Slack</a> for questions.
-            </div>
-        </div>
     </div>
 </div>

--- a/themes/hugo-asyncapi/layouts/partials/docs/edit-hint.html
+++ b/themes/hugo-asyncapi/layouts/partials/docs/edit-hint.html
@@ -1,11 +1,6 @@
-<div class="docs-content">
-    <div class="hint">
-        <div class="hint__icon-wrapper">
-            <i class="hint__icon-wrapper__icon fa fa-question-circle"></i>
-        </div>
-        <div class="hint__body">
-            Improve this page by providing edits suggestions <a target="_blank" href="{{ .Site.Params.content_sources_location }}{{ .File.Path }}">here</a>. After providing suggestions to the text, submit a Pull Request using <a target="_blank" href="https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request">this</a>            instruction. You can also suggest changes by <a target="_blank" href="https://github.com/asyncapi/website/issues/new">reporting an issue</a>.
-            <br> Feel free to contact us on <a target="_blank" href="https://asyncapi.com/slack-invite">Slack</a> for questions.
-        </div>
+<div class="hint">
+    <div class="hint__body">
+        <hr>Improve this page by providing edits suggestions <a target="_blank" href="{{ .Site.Params.content_sources_location }}{{ .File.Path }}">here</a>. After providing suggestions to the text, submit a Pull Request using <a target="_blank" href="https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request">this</a>        instruction. You can also suggest changes by <a target="_blank" href="https://github.com/asyncapi/website/issues/new">reporting an issue</a>.
+        <br> Feel free to contact us on <a target="_blank" href="https://asyncapi.com/slack-invite">Slack</a> for questions.
     </div>
 </div>

--- a/themes/hugo-asyncapi/layouts/partials/docs/edit-hint.html
+++ b/themes/hugo-asyncapi/layouts/partials/docs/edit-hint.html
@@ -1,6 +1,5 @@
 <div class="hint">
     <div class="hint__body">
-        <hr>Improve this page by providing edits suggestions <a target="_blank" href="{{ .Site.Params.content_sources_location }}{{ .File.Path }}">here</a>. After providing suggestions to the text, submit a Pull Request using <a target="_blank" href="https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request">this</a>        instruction. You can also suggest changes by <a target="_blank" href="https://github.com/asyncapi/website/issues/new">reporting an issue</a>.
-        <br> Feel free to contact us on <a target="_blank" href="https://asyncapi.com/slack-invite">Slack</a> for questions.
+        <hr>Improve this page by providing edits suggestions <a target="_blank" href="{{ .Site.Params.content_sources_location }}{{ .File.Path }}">here</a>. After providing suggestions to the text, submit a Pull Request using <a target="_blank" href="https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request">this</a>        instruction. You can also suggest changes by <a target="_blank" href="https://github.com/asyncapi/website/issues/new">reporting an issue</a>. Feel free to contact us on <a target="_blank" href="https://asyncapi.com/slack-invite">Slack</a> for questions.
     </div>
 </div>

--- a/themes/hugo-asyncapi/layouts/partials/docs/edit-hint.html
+++ b/themes/hugo-asyncapi/layouts/partials/docs/edit-hint.html
@@ -1,0 +1,11 @@
+<div class="docs-content">
+    <div class="hint">
+        <div class="hint__icon-wrapper">
+            <i class="hint__icon-wrapper__icon fa fa-question-circle"></i>
+        </div>
+        <div class="hint__body">
+            Improve this page by providing edits suggestions <a target="_blank" href="{{ .Site.Params.content_sources_location }}{{ .File.Path }}">here</a>. After providing suggestions to the text, submit a Pull Request using <a target="_blank" href="https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request">this</a>            instruction. You can also suggest changes by <a target="_blank" href="https://github.com/asyncapi/website/issues/new">reporting an issue</a>.
+            <br> Feel free to contact us on <a target="_blank" href="https://asyncapi.com/slack-invite">Slack</a> for questions.
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
The purpose of this PR is to enable easier contributions to documentation with a direct link to the content. 

I started a review of documentation and realized that for a new AsyncAPI user it might not be so easy to find sources of documentation and suggest fixes.

I thought first about adding an edit button in the right-top corner of the page as others do it (for example https://kubernetes.io/docs/concepts/overview/components/) but I'm too stupid for CSS and making sure a button shows up where I want with respect to standards. The advantage of such a button at the bottom is that there can be a nice informative description.

What do you think?
Preview of how it works and looks like is here at the bottom https://deploy-preview-48--asyncapi-website.netlify.com/docs/getting-started/security/. I tried `Notice` first but `Hint` is probably less aggressive.