### PR TITLE
Improve getting started docs and some grammar adjustments

### DIFF
--- a/content/docs/getting-started/_index.md
+++ b/content/docs/getting-started/_index.md
@@ -8,7 +8,7 @@ aliases:
 - '/v1/guide/index.html'
 ---
 
-AsyncAPI is an open source initiative that seeks to improve the current state of Event-Driven Architectures (EDA). Our long-term goal is to make working with EDA's as easy as it is to work with REST APIs. That goes from documentation to code generation, from discovery to event management. Most of the processes we apply to our REST APIs nowadays would be applicable to our event-driven/asynchronous APIs too.
+AsyncAPI is an open source initiative that seeks to improve the current state of Event-Driven Architectures (EDA). Our long-term goal is to make working with EDA's as easy as it is to work with REST APIs. That goes from documentation to code generation, from discovery to event management. Most of the processes you apply to your REST APIs nowadays would be applicable to your event-driven/asynchronous APIs too.
 
 To make this happen, the first step has been to create a specification that allows **developers, architects, and product managers** to define the interfaces of an async API. Much like [OpenAPI (fka Swagger)](https://github.com/OAI/OpenAPI-Specification) does for REST APIs.
 

--- a/content/docs/getting-started/asyncapi-documents.md
+++ b/content/docs/getting-started/asyncapi-documents.md
@@ -40,6 +40,6 @@ The AsyncAPI document is a machine-readable definition of your event-driven API.
 
 Your API documentation is now machine-readable –easily parseable by code— so the myriad of useful applications is endless.
 
-Enough speaking, let's get our hands dirty with some examples. Learn how to create an AsyncAPI document defining a "Hello world" application.
+Enough speaking, let's get your hands dirty with some examples. Learn how to create an AsyncAPI document defining a "Hello world" application.
 
 {{%next-chapter url="/docs/getting-started/hello-world"%}}

--- a/content/docs/getting-started/coming-from-openapi.md
+++ b/content/docs/getting-started/coming-from-openapi.md
@@ -9,7 +9,7 @@ weight: 20
 
 If you're coming from OpenAPI, you must know that AsyncAPI [started as an adaptation of the OpenAPI specification](https://medium.com/asyncapi/whats-new-on-asyncapi-lots-2d9019a1869d). We wanted to have as much compatibility as possible between the two so users could reuse parts in both.
 
-You'll find lots of similarities between OpenAPI and AsyncAPI. Just bear in mind that, in the world of event-driven architectures, we have more than one protocol and therefore some things are different. Check out the following comparison chart, inspired by [Darrel Miller's blog post](https://www.openapis.org/news/blogs/2016/10/tdc-structural-improvements-explaining-30-spec-part-2):
+You'll find lots of similarities between OpenAPI and AsyncAPI. Just bear in mind that, in the world of event-driven architectures, you have more than one protocol and therefore some things are different. Check out the following comparison chart, inspired by [Darrel Miller's blog post](https://www.openapis.org/news/blogs/2016/10/tdc-structural-improvements-explaining-30-spec-part-2):
 
 {{<openapi-comparison>}}
 
@@ -22,8 +22,15 @@ Aside from structural differences you must know that:
 
 ## Conclusion
 
-As we have seen above, OpenAPI and AsyncAPI are very similar. In a real world environment, systems don't have just REST APIs or events but a mix of both. Most of the times, the information flowing in the events are very similar to the one the REST APIs have to handle in requests and responses, thus being able to reuse schemas is a huge win.
+As you have seen above, OpenAPI and AsyncAPI are very similar. In a real-world environment, systems don't have just REST APIs or events but a mix of both. Most of the time, the information flowing in the events is very similar to the one the REST APIs have to handle in requests and responses, thus being able to reuse schemas is a huge win.
 
-Enough speaking, let's get our hands dirty with some examples. Learn how to create an AsyncAPI document defining a "Hello world" application.
+Enough speaking, let's get your hands dirty with some examples. Learn how to create an AsyncAPI document defining a "Hello world" application.
 
-{{%next-chapter url="/docs/getting-started/hello-world"%}}
+{{<navigation-options>}}
+{{%navigation-option url="/docs/getting-started/asyncapi-documents/" style="cyan"%}}
+Learn the basics of the AsyncAPI specification.
+{{%/navigation-option%}}
+{{%navigation-option url="/docs/getting-started/hello-world/" style="purple"%}}
+Create your first AsyncAPI document.
+{{%/navigation-option%}}
+{{</navigation-options>}}

--- a/content/docs/getting-started/event-driven-architectures.md
+++ b/content/docs/getting-started/event-driven-architectures.md
@@ -37,11 +37,11 @@ A message broker (or _"broker"_) is a piece of infrastructure in charge of recei
 
 A publisher (a.k.a. _producer_) is an application that sends messages to the _broker_.
 
-A subscriber (a.k.a. _consumer_) is an application that connects to the _broker_, manifests interest in certain type of messages, and leaves the connection open so the _broker_ can push messages to them.
+A subscriber (a.k.a. _consumer_) is an application that connects to the _broker_, manifests an interest in a certain type of messages, and leaves the connection open so the _broker_ can push messages to them.
 
 ### Message
 
-A message is a piece of information that's sent by the publishers to the broker, and received by all the interested subscribers. The content of the message can be anything but they are frequently catalogued as _events_ and _commands_. As we saw above, _events_ communicate a fact that occurred. Instead, _commands_ are very much like _requests_ in REST APIs: they tell the subscribers "do this".
+A message is a piece of information that's sent by the publishers to the broker, and received by all the interested subscribers. The content of the message can be anything but they are frequently catalogued as _events_ and _commands_. As you saw above, _events_ communicate a fact that occurred. Instead, _commands_ are very much like _requests_ in REST APIs: they tell the subscribers "do this".
 
 **Technically speaking, _events_ and _commands_ are the same. The only difference is in their semantics.**
 
@@ -61,7 +61,7 @@ Theoretically, _"message-driven"_ is the most generic term, meaning you may use 
 
 ## Conclusion
 
-We've seen what an event-driven architecture is, how it works, and what are their components. AsyncAPI is all about defining and documenting each of these components. We'll go through it during the rest of this guide but, before we continue, please choose what's your next step:
+We've seen what an event-driven architecture is, how it works, and what are their components. AsyncAPI is all about defining and documenting each of these components. We'll go through it during the rest of this guide but, before you continue, please choose what's your next step:
 
 {{<navigation-options>}}
 {{%navigation-option url="/docs/getting-started/coming-from-openapi/" style="cyan"%}}

--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -71,7 +71,7 @@ channels:
           pattern: '^hello .+$'
 {{</code>}}
 
-The `channels` section of the specification houses all of the mediums where messages flow through. For example, some systems use `topi`, `event name` or `routing key`. Different kinds of information flow through each channel similar to the analogy of TV channels.
+The `channels` section of the specification houses all of the mediums where messages flow through. For example, some systems use `topic`, `event name` or `routing key`. Different kinds of information flow through each channel similar to the analogy of TV channels.
 
 In this example, you only have one channel called `hello`. The sample app subscribes to this channel to receive `hello {name}` messages.
 

--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -90,7 +90,7 @@ channels:
 {{</code>}}
 
 You can read the highlighted lines as:
-> This is the `payload` of the `message` your app `publish` to the `hello` channel.
+> This is the `payload` of the `message` that `Hello world application` is subscribed to. You can `publish` the `message` to `hello` channel and `Hello world application` app will receive it.
 
 {{<code lang="yaml" lines="9-11">}}
 asyncapi: 2.0.0

--- a/content/docs/getting-started/hello-world.md
+++ b/content/docs/getting-started/hello-world.md
@@ -39,7 +39,7 @@ channels:
           pattern: '^hello .+$'
 {{</code>}}
 
-The first line of the specification starts with the document type (AsyncAPI) and the version (2.0.0). This line doesn't have to be the first one but it's a recommended practice.
+The first line of the specification starts with the document type, `asyncapi`, and the version (2.0.0). This line doesn't have to be the first one but it's a recommended practice.
 
 {{<code lang="yaml" lines="2-4">}}
 asyncapi: 2.0.0
@@ -55,7 +55,7 @@ channels:
           pattern: '^hello .+$'
 {{</code>}}
 
-The "info" object contains the minimum required information about the application. It contains the title, which is a memorable name for the API, and the version. While it's not mandatory, it is strongly recommended to change the version whenever you make changes to the API.
+The `info` object contains the minimum required information about the application. It contains the `title`, which is a memorable name for the API, and the `version`. While it's not mandatory, it is strongly recommended to change the version whenever you make changes to the API.
 
 {{<code lang="yaml" lines="5-11">}}
 asyncapi: 2.0.0
@@ -71,9 +71,9 @@ channels:
           pattern: '^hello .+$'
 {{</code>}}
 
-The 'channels' section of the specification houses all of the mediums where messages flow through. For example, some systems use 'topic, 'event name' or 'routing key'. Different kinds of information flow through each channel similar to the analogy of TV channels.
+The `channels` section of the specification houses all of the mediums where messages flow through. For example, some systems use `topi`, `event name` or `routing key`. Different kinds of information flow through each channel similar to the analogy of TV channels.
 
-In our example, we only have one channel called `hello`. The sample app subscribes to this channel to receive "hello {name}" messages.
+In this example, you only have one channel called `hello`. The sample app subscribes to this channel to receive `hello {name}` messages.
 
 {{<code lang="yaml" lines="6-9">}}
 asyncapi: 2.0.0
@@ -89,7 +89,8 @@ channels:
           pattern: '^hello .+$'
 {{</code>}}
 
-You can read the highlighted lines as "this is the **payload** of the **message** your app can **publish** to the «**hello**» channel".
+You can read the highlighted lines as:
+> This is the `payload` of the `message` your app `publish` to the `hello` channel.
 
 {{<code lang="yaml" lines="9-11">}}
 asyncapi: 2.0.0
@@ -105,12 +106,12 @@ channels:
           pattern: '^hello .+$'
 {{</code>}}
 
-The 'payload' object defines how the message must be structured. In this example, the message must be a string and match the given regular expression in the format "hello {name}" string.
+The `payload` object defines how the message must be structured. In this example, the message must be a string and match the given regular expression in the format `hello {name}` string.
 
 ## Conclusion
 
-We've seen how to define our simple Hello World app but, **how do we send a message to our Hello World application?**
+We've seen how to define your simple Hello World app but, **how do you send a message to your Hello World application?**
 
-On the next chapter, you'll learn about the `servers` property.
+In the next chapter, you'll learn about the `servers` property.
 
 {{%next-chapter url="/docs/getting-started/servers"%}}

--- a/content/docs/getting-started/security.md
+++ b/content/docs/getting-started/security.md
@@ -19,7 +19,7 @@ If you're using AsyncAPI to define an API that connects to a message broker, you
 Continuing with the `hello world` application example, let's learn how to define a simple security scheme (mechanism) for it.
 
 {{<code lang="yaml" lines="10-11,42-44">}}
-asyncapi: '2.0.0-rc1'
+asyncapi: '2.0.0'
 id: 'urn:hello-world-publisher'
 info:
   title: Hello world application
@@ -71,7 +71,7 @@ The example above shows how to specify that your server (the Kafka broker) requi
 2. We've added a new section called `securitySchemes` under `components`. Inside it, you can find the definition of your `user-password` mechanism. This section makes it clear that you're speaking about a `user/password` mechanism is the `type: userPassword` in line 44.
 
 {{%hint%}}
-There are many more security schemes. Learn more about them {{%link "/docs/specifications/2.0.0-rc1/#securitySchemeObject" %}}here{{%/link%}}.
+There are many more security schemes. Learn more about them {{%link "/docs/specifications/2.0.0/#securitySchemeObject" %}}here{{%/link%}}.
 {{%/hint%}}
 
 ## Conclusion

--- a/content/docs/getting-started/security.md
+++ b/content/docs/getting-started/security.md
@@ -16,13 +16,13 @@ In production environments, your API may have to access a message broker that's 
 
 If you're using AsyncAPI to define an API that connects to a message broker, you'll most probably make use of user/password or certificates. Traditionally, message brokers are infrastructure pieces that serve an internal purpose and they're not exposed to the public. That's why their security mechanisms are also simpler than what we're used to with REST APIs. However, AsyncAPI also helps you define your HTTP streaming APIs and therefore it supports more sophisticated mechanisms like OAuth2 or OpenID.
 
-Continuing with the "hello world" application example, let's learn how to define a simple security scheme (mechanism) for it.
+Continuing with the `hello world` application example, let's learn how to define a simple security scheme (mechanism) for it.
 
 {{<code lang="yaml" lines="10-11,42-44">}}
 asyncapi: '2.0.0-rc1'
 id: 'urn:hello-world-publisher'
 info:
-  title: Hello world publisher application
+  title: Hello world application
   version: '0.1.0'
 servers:
   - url: broker.mycompany.com
@@ -65,10 +65,10 @@ components:
       type: userPassword
 {{</code>}}
 
-The example above shows how to specify that our server (the Kafka broker) requires a user and a password to establish a connection. Let's break this down:
+The example above shows how to specify that your server (the Kafka broker) requires a user and a password to establish a connection. Let's break this down:
 
-1. There's a new property in the server object called `security`. It's an array and can contain multiple security mechanisms. We chose to add one called "user-password". This is simply a memorable name that we give this security scheme but, whatever name we choose, it must be defined in the `components/securitySchemes` section. You might have also noticed its value is an empty array. It's because some security schemes allow for extra configuration but, since this is not the case, we leave the array empty.
-2. We've added a new section called "securitySchemes" under components. Inside it, you can find the definition of our "user-password" mechanism. What really makes it clear that we're speaking about a `user/password` mechanism is the `type: userPassword` on line 44.
+1. There's a new property in the server object called `security`. It's an array and can contain multiple security mechanisms. You chose to add one called "user-password". This is simply a memorable name that you give to this `security` scheme but, whatever name you choose, it must be defined in the `components/securitySchemes` section. You might have also noticed its value is an empty array. It's because some security schemes allow for extra configuration but, since this is not the case in this example, leave the array empty.
+2. We've added a new section called `securitySchemes` under `components`. Inside it, you can find the definition of your `user-password` mechanism. This section makes it clear that you're speaking about a `user/password` mechanism is the `type: userPassword` in line 44.
 
 {{%hint%}}
 There are many more security schemes. Learn more about them {{%link "/docs/specifications/2.0.0-rc1/#securitySchemeObject" %}}here{{%/link%}}.
@@ -76,8 +76,8 @@ There are many more security schemes. Learn more about them {{%link "/docs/speci
 
 ## Conclusion
 
-We're now able to define what security mechanisms our application needs to connect to the server. We've seen how to define the requirement of a user and a password, which is the most common use case.
+You're now able to define what security mechanisms your application needs to connect to the server. You've seen how to define the requirement of a user and a password, which is the most common use case.
 
-At this point, you know AsyncAPI well enough to create a simple hello world application. However, real use cases are more complicated than that. Our tutorials can teach you how to create real world use cases, from zero to production.
+At this point, you know AsyncAPI well enough to create a simple `Hello world application`. However, real use cases are more complicated than that. Next tutorials can teach you how to create real-world use cases, from zero to production.
 
 {{%next-chapter url="/docs/tutorials" text="Go to the tutorials page"%}}

--- a/content/docs/getting-started/servers.md
+++ b/content/docs/getting-started/servers.md
@@ -7,9 +7,9 @@ menu:
 weight: 110
 ---
 
-In the previous lesson, we learned how to create the definition of a simple [Hello World application](/docs/getting-started/hello-world), so let's take it from there.
+In the previous lesson, you learned how to create the definition of a simple [Hello World application](/docs/getting-started/hello-world), so let's take it from there.
 
-In this article, we will learn how to add "servers" to our AsyncAPI document. Adding and defining servers is useful because it specifies where and how to connect. The connection facilitates where to send and receive messages.
+In this article, you learn how to add `servers` to your AsyncAPI document. Adding and defining servers is useful because it specifies where and how to connect. The connection facilitates where to send and receive messages.
 
 
 {{<code lang="yaml" lines="5-8">}}
@@ -31,21 +31,21 @@ channels:
           pattern: '^hello .+$'
 {{</code>}}
 
-We added a new section called "servers" in our AsyncAPI document.
+You added a new section called `servers` in your AsyncAPI document.
 
-You might have noticed that the example mentions "amqp". This protocol is very common and was popularized by RabbitMQ (among others). You can use any protocol. For example, the most common are `mqtt` (widely adopted by the Internet of Things and mobile apps), `kafka` (popular for its streaming solution), `ws` (WebSockets are frequently used in browsers), and `http` (used in HTTP streaming APIs.)
+You might have noticed that the example mentions `amqp`. This protocol is very common and was popularized by RabbitMQ (among others). You can use any protocol. For example, the most common are `mqtt` (widely adopted by the Internet of Things and mobile apps), `kafka` (popular for its streaming solution), `ws` (WebSockets are frequently used in browsers), and `http` (used in HTTP streaming APIs).
 
 {{%remember%}}
-The "servers" section defines where your application should connect to start sending and receiving messages. 
+The `servers` section defines where your application should connect to start sending and receiving messages. 
 
 1. If you are using a {{<link "https://fmvilas.com/event-driven-architectures-asyncapi/">}}broker-centric architecture{{</link>}} such as Kafka or RabbitMQ, usually you specify the URL of the broker. 
-2. If you have the classic client-server model such as for REST APIs, then your server should be the URL of the server.
+2. If you have the classic client-server model such as for REST APIs, then your `server` should be the URL of the server.
 {{%/remember%}}
 
 ## Conclusion
 
-Now we know where to connect to start receiving "hello {name}" messages.
+Now you know where `Hello world application` app connects to, to start receiving `hello {name}` messages.
 
-On the next chapter, you'll learn how to add security requirements to a server.
+In the next chapter, you'll learn how to add security requirements to a server.
 
 {{%next-chapter url="/docs/getting-started/security"%}}

--- a/content/docs/tutorials/streetlights.md
+++ b/content/docs/tutorials/streetlights.md
@@ -11,24 +11,24 @@ categories:
 - tutorials
 ---
 
-In this tutorial I want to help you get started with actual code and a (could-be) real world use case. <!--more-->
-Let's pretend we have a company called Smarty Lighting and we do smart-city lighting systems.
+In this tutorial, you get started with actual code and a (could-be) real-world use case. <!--more-->
+Let's pretend you have a company called Smarty Lighting and you do smart-city lighting systems.
 
 # System Description
 
-We want to create a system capable of turning on/off the streetlights depending on the environmental conditions of each of them:
+You want to create a system capable of turning on/off the streetlights depending on the environmental conditions of each of them:
 
-- We're going to implement a event-driven architecture, with a Message Broker in its "center".
+- You're going to implement an event-driven architecture, with a Message Broker in its "center".
 - Streetlights will send information about its environmental lighting to the broker.
-- None of the services will wait for any kind of response. Think about it as fire and forget. We'll publish messages to the broker and that's it. Our service don't know who will receive them.
+- None of the services waits for any kind of response. Think about it as _fire and forget_. You publish messages to the broker and that's it. Your service doesn't know who receives them.
 
 # Technology
 
-We'll use Node.js to code our APIs and Mosquitto as our message broker. Please note this is just my choice for the tutorial but what is going to be explained here is applicable to any other programming language and message brokers.
+You'll use Node.js to code APIs and Mosquitto as the message broker. Selected technology is irrelevant here, as things explained here in this tutorial are applicable to any other programming language and message brokers.
 
 # The AsyncAPI file
 
-Let's start by creating an AsyncAPI file to describe our API. It will help us generate the code and the documentation later.
+Let's start by creating an AsyncAPI file to describe your API. It will help you generate the code and the documentation later.
 
 ```yaml
 asyncapi: '2.0.0'
@@ -85,10 +85,10 @@ info:
     url: 'https://www.apache.org/licenses/LICENSE-2.0'
 ```
 
-- The `asyncapi` field indicates we want to use AsyncAPI version 2.0.0.
-- Inside the `info` field we can find information about the API, like its name, version, a description and its license.
+- The `asyncapi` field indicates you use AsyncAPI version 2.0.0.
+- Inside the `info` field you find information about the API, like its name, version, description, and its license.
 
-We're now going for the channels section. It is used to describe the event names your API will be publishing and/or subscribing to.
+We're now going for the `channels` section. It is used to describe the event names your API will be publishing and/or subscribing to.
 
 ```yaml
 channels:
@@ -98,7 +98,7 @@ channels:
       operationId: onLightMeasured
 ```
 
-In this example, `light/measured` is the channel name your API will allow you to `publish` to. The `operationId` property, describes what will be the name of function or method that will take care of this functionality in the case we generate code (which is the case). To understand how the event should look like when publishing to that channel, there is the `payload` property:
+In this example, `light/measured` is the channel name your API `publish` to. The `operationId` property, describes what will be the name of function or method that takes care of this functionality in generated code. To understand how the event should look like when publishing to that channel, there is the `payload` property:
 
 ```yaml
       payload:
@@ -118,75 +118,99 @@ In this example, `light/measured` is the channel name your API will allow you to
             description: Date and time when the message was sent.
 ```
 
-It defines the content of the event using AsyncAPI schemas. It means that our event payload should contain an `id` and a `lumens` property —which are integers bigger than zero—, and a `sentAt` property that should be a string containing a date and time.
+`Payload` property defines the content of the event using AsyncAPI schemas. It means that your event payload should contain an `id` and a `lumens` property —which are integers bigger than zero—, and a `sentAt` property that should be a string containing a date and time.
 
 > JSON Schema Draft 07 is 100% compatible with AsyncAPI schemas.
 
-Cool! So we're done with our AsyncAPI file! Let's get into generating code.
+Cool! So you're done with your AsyncAPI file! Let's get into generating code.
 
 # Generating code
 
-To generate our code we'll use the [AsyncAPI Generator](https://github.com/asyncapi/generator) Node.js template.
+To generate your code you'll use the [AsyncAPI Generator](https://github.com/asyncapi/generator) Node.js template.
 
-```bash
-npm install -g asyncapi-generator
-```
+1. Install the generator to use is at a command-line tool
+    ```bash
+    npm install -g asyncapi-generator
+    ```
 
-(You might need to use sudo)
+2. Create a directory for your projects and enter it:
+    ```bash
+    mkdir streetlights && cd "$_"
+    ```
+3. Create a file with the AsyncAPI machine-readable description you defined before:
+    ```bash
+    cat <<EOT >> asyncapi.yaml
+    asyncapi: '2.0.0'
+    info:
+      title: Streetlights API
+      version: '1.0.0'
+      description: |
+        The Smartylighting Streetlights API allows you
+        to remotely manage the city lights.
+      license:
+        name: Apache 2.0
+        url: 'https://www.apache.org/licenses/LICENSE-2.0'
 
-Create a directory for your projects and step into it:
+    servers:
+      mosquitto:
+        url: mqtt://test.mosquitto.org
+        protocol: mqtt
 
-```bash
-mkdir streetlights && cd "$_"
-```
-
-Create a file with the AsyncAPI machine-readable description we created before:
-
-```bash
-touch asyncapi.yaml
-# Open asyncapi.yaml and paste the definition
-```
-
-And now let's generate the code for it:
-```bash
-ag asyncapi.yaml nodejs -p server=mosquitto
-```
-
-And voilà!
+    channels:
+      light/measured:
+        publish:
+          summary: Inform about environmental lighting conditions for a particular streetlight.
+          operationId: onLightMeasured
+          message:
+            payload:
+              type: object
+              properties:
+                id:
+                  type: integer
+                  minimum: 0
+                  description: Id of the streetlight.
+                lumens:
+                  type: integer
+                  minimum: 0
+                  description: Light intensity measured in lumens.
+                sentAt:
+                  type: string
+                  format: date-time
+                  description: Date and time when the message was sent.
+    EOT
+    ```
+4. Trigger generation of the Node.js code:
+    ```bash
+    ag asyncapi.yaml nodejs -p server=mosquitto
+    ```
+5. And voilà! List all files in directory and notice that Node.js application is generated:
+    ```bash
+    ls
+    ```
 
 # Running our code
 
-Before running your code don't forget to install the dependencies on every project:
-
-```bash
-npm install
-```
-
-Run the code:
-
-```bash
-npm start
-```
-
-Now that you have your code running you'll want to test it, right? Go and install the mqtt library:
-
-```bash
-npm install mqtt -g
-```
-
-(You might need to use sudo)
-
-Try to send messages to your service using the command line:
-
-```bash
-mqtt pub -t 'light/measured' -h 'test.mosquitto.org' -m '{"id": 1, "lumens": 3, "sentAt": "2017-06-07T12:34:32.000Z"}'
-```
-
-You should see our application logging the message you just sent.
+1. Install dependencies of newly generated application:
+    ```bash
+    npm install
+    ```
+2. Start the application:
+    ```bash
+    npm start
+    ```
+3. In another terminal install the MQTT.js library:
+    ```bash
+    npm install mqtt -g
+    ```
+4. Send message to your application:
+    ```bash
+    mqtt pub -t 'light/measured' -h 'test.mosquitto.org' -m '{"id": 1, "lumens": 3, "sentAt": "2017-06-07T12:34:32.000Z"}'
+    ```
+5. Go back to previous terminal and notice that your application logs the message you just sent.
 
 # Conclusions
 
-We've learned how to create an AsyncAPI description file and how to generate code from it. The code is just a bootstrap and you'll need to add your business logic into it. Take some time to play with it.
-There are still lots of things to be covered but I kept the tutorial simple on purpose, so you get an idea of the potential.
+You've learned how to create an AsyncAPI description file and how to generate code from it. The code is a bootstrap and you'll need to add your business logic into it. Take some time to play with it.
+There are still lots of things to be covered but intent of this tutorial is to be simple so you get an idea of the potential.
 
-We would also like to see what you create with AsyncAPI. As an open-source project we're open to proposals, questions, suggestions and contributions. If you don't feel in the mood to contribute but you're using AsyncAPI, just raise your hand [creating a issue in our Github repo](https://github.com/asyncapi/asyncapi/issues/new) or [join our Slack channel](https://async-apis-slack.herokuapp.com/). Don't be shy :)
+We would also like to see what you create with AsyncAPI. As an open-source project, we're open to proposals, questions, suggestions, and contributions. If you don't feel in the mood to contribute but you're using AsyncAPI, just raise your hand [creating a issue in our Github repo](https://github.com/asyncapi/asyncapi/issues/new) or [join our Slack channel](https://www.asyncapi.com/slack-invite/). Don't be shy :)

--- a/content/docs/tutorials/streetlights.md
+++ b/content/docs/tutorials/streetlights.md
@@ -138,7 +138,7 @@ To generate your code you'll use the [AsyncAPI Generator](https://github.com/asy
     mkdir streetlights && cd "$_"
     ```
 
-3. Create a file with the AsyncAPI machine-readable description you defined before:
+3. Create a file with the AsyncAPI machine-readable description you defined before. On Windows use `type` instead of `cat`:
     ```bash
     cat <<EOT >> asyncapi.yaml
     asyncapi: '2.0.0'
@@ -191,7 +191,7 @@ To generate your code you'll use the [AsyncAPI Generator](https://github.com/asy
     ls
     ```
 
-# Running our code
+# Running your code
 
 1. Install dependencies of newly generated application:
     ```bash

--- a/content/docs/tutorials/streetlights.md
+++ b/content/docs/tutorials/streetlights.md
@@ -137,6 +137,7 @@ To generate your code you'll use the [AsyncAPI Generator](https://github.com/asy
     ```bash
     mkdir streetlights && cd "$_"
     ```
+
 3. Create a file with the AsyncAPI machine-readable description you defined before:
     ```bash
     cat <<EOT >> asyncapi.yaml
@@ -179,10 +180,12 @@ To generate your code you'll use the [AsyncAPI Generator](https://github.com/asy
                   description: Date and time when the message was sent.
     EOT
     ```
+
 4. Trigger generation of the Node.js code:
     ```bash
     ag asyncapi.yaml nodejs -p server=mosquitto
     ```
+
 5. And voilà! List all files in directory and notice that Node.js application is generated:
     ```bash
     ls
@@ -194,18 +197,22 @@ To generate your code you'll use the [AsyncAPI Generator](https://github.com/asy
     ```bash
     npm install
     ```
+
 2. Start the application:
     ```bash
     npm start
     ```
+
 3. In another terminal install the MQTT.js library:
     ```bash
     npm install mqtt -g
     ```
+
 4. Send message to your application:
     ```bash
     mqtt pub -t 'light/measured' -h 'test.mosquitto.org' -m '{"id": 1, "lumens": 3, "sentAt": "2017-06-07T12:34:32.000Z"}'
     ```
+    
 5. Go back to previous terminal and notice that your application logs the message you just sent.
 
 # Conclusions


### PR DESCRIPTION
I reviewed all the getting started guides and went through the tutorials and at the same time was doing some improvements for consistency reasons, and some grammar:
- missing articles
- some minor grammar
- change from we/our to you/your. This is a standard in writing docs, you face reader directly unless it is not possible (like where you write why we did something this way and not the other)
- instead of using " I switched to ` for the sake of standard and consistency
- I made some improvements in the streetlight tutorial to make it fully copy/paste with numbered list flow

Only unclear part:
I have problem with this sentence https://github.com/asyncapi/website/pull/49/files#diff-c776dcc151f09a89aa6367cfff05c516L92
This example is an app that describes `publish` channel. If `publish` means that hello app is subscribed to this channel and another application can publish to it, and then hello app will receive the message - this means sentence would have to rather sound something like
> This is the `payload` of the `message` that `Hello world application` is subscribed to. You can `publish` the `message` to `hello` channel and `Hello world application` app will receive it.