### PR TITLE
Fix banner on homepage for mobile

### DIFF
--- a/themes/hugo-asyncapi/layouts/home.html
+++ b/themes/hugo-asyncapi/layouts/home.html
@@ -6,7 +6,7 @@
 
         <div class="container">
             <div class="row">
-                <div class="col-10 offset-1" style="margin-top: 40px;">
+                <div class="col-12 col-md-10 offset-md-1" style="margin-top: 40px;">
                     <a href="https://www.asyncapiconf.com" target="_blank">
                         <img src="/img/asyncapi-conf-banner.jpg">
                     </a>


### PR DESCRIPTION
It makes the banner full-width on mobile. Otherwise, it's impossible to read.