### PR TITLE
docs: add missing bindings field name

### DIFF
--- a/content/docs/specifications/2.0.0.md
+++ b/content/docs/specifications/2.0.0.md
@@ -617,10 +617,11 @@ subscribe:
         user:
           $ref: "#/components/schemas/user"
         signup:
-amqp:
-  is: queue
-  queue:
-    exclusive: true
+bindings:
+  amqp:
+    is: queue
+    queue:
+      exclusive: true
 ```
 
 Using `oneOf` to specify multiple messages per operation:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Add missing `bindings` field name in the `yaml` of the [Channel Item Object Example](https://www.asyncapi.com/docs/specifications/2.0.0/#channelItemObject). In comparison to the `json` example it is missing…

**Related issue(s)**

- No related issue as it seems to be a typo according to your [guidelines](https://github.com/asyncapi/.github/blob/master/CONTRIBUTING.md#pull-requests)