### PR TITLE
Downgrade React Syntax Highlighter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2769,14 +2769,8 @@
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
       "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
       "requires": {
+        "node-fetch": "2.6.0",
         "whatwg-fetch": "3.0.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-        }
       }
     },
     "cross-spawn": {
@@ -4573,9 +4567,9 @@
       "integrity": "sha512-n7xsIfyBkFChITGPh6FLtxNzAt2HxZLcQIY9hYH4gm2gmMQJHMguMH3E+jnmvUbSTF5QrmFnGab5Ippi+D7e/g=="
     },
     "highlight.js": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.2.1.tgz",
-      "integrity": "sha512-A+sckVPIb9zQTUydC9lpRX1qRFO/N0OKEh0NwIr65ckvWA/oMY8v9P3+kGRK3w2ULSh9E8v5MszXafodQ6039g=="
+      "version": "9.15.10",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
+      "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw=="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -5399,12 +5393,12 @@
       }
     },
     "lowlight": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.15.0.tgz",
-      "integrity": "sha512-GhG/R+2zt5Wg8kCfOhapH8wDdJSHSIvdDW/DOPXCeResVqgHYLnOHBp6g9DoUIPVIyBpvQYCG4SV7XeelYFpyA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.12.1.tgz",
+      "integrity": "sha512-OqaVxMGIESnawn+TU/QMV5BJLbUghUfjDWPAtFqDYDmDtr4FnB+op8xM+pR7nKlauHNUHXGt0VgWatFB8voS5w==",
       "requires": {
-        "fault": "^1.0.0",
-        "highlight.js": "~10.2.0"
+        "fault": "^1.0.2",
+        "highlight.js": "~9.15.0"
       }
     },
     "lru-cache": {
@@ -5457,12 +5451,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/markdown-to-txt/-/markdown-to-txt-1.0.1.tgz",
       "integrity": "sha512-PACe8GiGnJ5Nf/bkE+NWIMK36qRAGW6JP9mHLeiL6BBoUA51EqEmtJd9VEI0lGl74JYUUSoKHqX0FQV4ivo1nA==",
-      "dependencies": {
-        "marked": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-          "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
-        }
+      "requires": {
+        "marked": "^0.6.2"
       }
     },
     "markdown-toc": {
@@ -5497,6 +5487,11 @@
           }
         }
       }
+    },
+    "marked": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
+      "integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ=="
     },
     "math-random": {
       "version": "1.0.4",
@@ -6197,6 +6192,11 @@
       "requires": {
         "lodash.toarray": "^4.4.0"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -7550,15 +7550,15 @@
       }
     },
     "react-syntax-highlighter": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-14.0.0.tgz",
-      "integrity": "sha512-ljyAKAlHOhJLvv2Z6mHICz0va5Bn1G6tvBRe2qJHtZBxmu17PqaMRo+81br7zHQQW3+kb00MIqNyJTBNoR1rWg==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-12.2.1.tgz",
+      "integrity": "sha512-CTsp0ZWijwKRYFg9xhkWD4DSpQqE4vb2NKVMdPAkomnILSmsNBHE0n5GuI5zB+PU3ySVvXvdt9jo+ViD9XibCA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "highlight.js": "^10.1.1",
-        "lowlight": "^1.14.0",
-        "prismjs": "^1.21.0",
-        "refractor": "^3.1.0"
+        "highlight.js": "~9.15.1",
+        "lowlight": "1.12.1",
+        "prismjs": "^1.8.4",
+        "refractor": "^2.4.1"
       }
     },
     "react-text-truncate": {
@@ -7673,13 +7673,36 @@
       "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA="
     },
     "refractor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.1.0.tgz",
-      "integrity": "sha512-bN8GvY6hpeXfC4SzWmYNQGLLF2ZakRDNBkgCL0vvl5hnpMrnyURk8Mv61v6pzn4/RBHzSWLp44SzMmVHqMGNww==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
+      "integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
       "requires": {
         "hastscript": "^5.0.0",
-        "parse-entities": "^2.0.0",
-        "prismjs": "~1.21.0"
+        "parse-entities": "^1.1.2",
+        "prismjs": "~1.17.0"
+      },
+      "dependencies": {
+        "parse-entities": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+          "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+          "requires": {
+            "character-entities": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "character-reference-invalid": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        },
+        "prismjs": {
+          "version": "1.17.1",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
+          "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
+        }
       }
     },
     "regenerate": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-dom": "^16.13.1",
     "react-ga": "^3.1.2",
     "react-scrollspy": "^3.4.2",
-    "react-syntax-highlighter": "^14.0.0",
+    "react-syntax-highlighter": "^12.2.1",
     "react-text-truncate": "^0.16.0",
     "react-typing-animation": "^1.6.2",
     "react-youtube-embed": "^1.0.3",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

It's broken with the new version. I'm tracking this on the related issue.

**Related issue(s)**
https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/311