### PR TITLE
chore: add amf to list of tools in validators section

### DIFF
--- a/pages/docs/community/tooling.md
+++ b/pages/docs/community/tooling.md
@@ -88,3 +88,4 @@ The following is a list of tools that validate AsyncAPI documents.
 | [asyncapi-validator](https://github.com/WaleedAshraf/asyncapi-validator) | It allows you to validate schema of your messages against your AsyncAPI schema definition. You can use it with Kafka, RabbitMQ or any other messaging/queue. Thanks to [@waleedashraf](https://twitter.com/@waleedashraf01). | Javascript
 | [AsyncAPI Parser](https://github.com/asyncapi/parser) | It parses and validates AsyncAPI documents. | Go
 | [Spectral](https://github.com/stoplightio/spectral) | A command line linter for AsyncAPI & OpenAPI documents. | Javascript
+| [AMF](https://github.com/aml-org/amf) | Unified RAML / OAS / AsyncAPI parser and validator, including linting | ScalaJS / JVM and JS support


### PR DESCRIPTION
Reached GA support for AsyncAPI in our parser (AMF), adding it to the list of 'validators'

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->