### PR TITLE
Maven central repository: Redirect for domain verification

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -12,3 +12,6 @@ https://asyncapi.com/* https://www.asyncapi.com/:splat 301!
 
 # Slack
 /slack-invite https://join.slack.com/t/asyncapi/shared_invite/enQtNDY3MzI0NjU5OTQyLTM5NTlkYzFmZDQyMGVkNzVkOTRhMGU2N2VmMWRlOTdkNWE0YzdjMGQ2NzRlOWU1NGJkYjUyZDEzMzM3ZGYzYzM 302!
+
+# Central Maven repository verification
+/OSSRH-63280 https://github.com/asyncapi/java-asyncapi


### PR DESCRIPTION
Redirect for domain verification. We need this redirect for proofing of domain owning

https://issues.sonatype.org/browse/OSSRH-63280