### PR TITLE
fix: MessageObject, MessageObjectTrait have been updated with new description for examples property

### DIFF
--- a/pages/docs/specifications/2.0.0.md
+++ b/pages/docs/specifications/2.0.0.md
@@ -958,7 +958,7 @@ Field Name | Type | Description
 <a name="messageObjectTags"></a>tags | [Tags Object](#tagsObject) | A list of tags for API documentation control. Tags can be used for logical grouping of messages.
 <a name="messageObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this message.
 <a name="messageObjectBindings"></a>bindings | [Message Bindings Object](#messageBindingsObject) | A free-form map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the message.
-<a name="messageObjectExamples"></a>examples | [Map[`string`, `any`]] | An array with examples of valid message objects.
+<a name="messageObjectExamples"></a>examples | [Map[`string`, `any`]] | An array with examples of valid message objects.An array with examples of valid message objects. Examples MUST be located under fixed fields: `payload` for payload examples, `headers` for headers examples.
 <a name="messageObjectTraits"></a>traits | [[Message Trait Object](#messageTraitObject)] | A list of traits to apply to the message object. Traits MUST be merged into the message object using the [JSON Merge Patch](https://tools.ietf.org/html/rfc7386) algorithm in the same order they are defined here. The resulting object MUST be a valid [Message Object](#messageObject).
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
@@ -976,6 +976,33 @@ Name | Allowed values | Notes
 
 
 ##### Message Object Example
+
+```json
+{
+  "payload": {
+    "type": "object",
+    "properties": {
+      "displayName": {
+        "type": "string",
+        "description": "Name of the user"
+      },
+      "email": {
+        "type": "string",
+        "format": "email",
+        "description": "Email of the user"
+      }
+    }
+  },
+  "examples": [
+    {
+      "payload": {
+        "displayName": "Tom Tailor",
+        "email": "tailor@files.io"
+      }
+    }
+  ]
+}
+```
 
 ```json
 {
@@ -1117,10 +1144,38 @@ Field Name | Type | Description
 <a name="messageTraitObjectTags"></a>tags | [Tags Object](#tagsObject) | A list of tags for API documentation control. Tags can be used for logical grouping of messages.
 <a name="messageTraitObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this message.
 <a name="messageTraitObjectBindings"></a>bindings | Map[`string`, [Message Bindings Object](#messageBindingsObject)] | A free-form map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the message.
-<a name="messageTraitObjectExamples"></a>examples | [Map[`string`, `any`]] | An array with examples of valid message objects.
+<a name="messageTraitObjectExamples"></a>examples | [Map[`string`, `any`]] | An array with examples of valid message objects. Examples MUST be located under fixed fields: `payload` for payload examples, `headers` for headers examples
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
 
+##### Message Trait Object Example with examples
+
+```json
+{
+  "payload": {
+    "type": "object",
+    "properties": {
+      "displayName": {
+        "type": "string",
+        "description": "Name of the user"
+      },
+      "email": {
+        "type": "string",
+        "format": "email",
+        "description": "Email of the user"
+      }
+    }
+  },
+  "examples": [
+    {
+      "payload": {
+        "displayName": "Tom Tailor",
+        "email": "tailor@files.io"
+      }
+    }
+  ]
+}
+```
 ##### Message Trait Object Example
 
 ```json

--- a/pages/docs/specifications/2.0.0.md
+++ b/pages/docs/specifications/2.0.0.md
@@ -958,7 +958,7 @@ Field Name | Type | Description
 <a name="messageObjectTags"></a>tags | [Tags Object](#tagsObject) | A list of tags for API documentation control. Tags can be used for logical grouping of messages.
 <a name="messageObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this message.
 <a name="messageObjectBindings"></a>bindings | [Message Bindings Object](#messageBindingsObject) | A free-form map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the message.
-<a name="messageObjectExamples"></a>examples | [Map[`string`, `any`]] | An array with examples of valid message objects.An array with examples of valid message objects. Examples MUST be located under fixed fields: `payload` for payload examples, `headers` for headers examples.
+<a name="messageObjectExamples"></a>examples | [Map[`string`, `any`]] | An array of key/value pairs where keys MUST be either **headers** and/or **payload**. Values MUST contain examples that validate against the [headers](#messageObjectHeaders) or [payload](#messageObjectPayload) fields, respectively.
 <a name="messageObjectTraits"></a>traits | [[Message Trait Object](#messageTraitObject)] | A list of traits to apply to the message object. Traits MUST be merged into the message object using the [JSON Merge Patch](https://tools.ietf.org/html/rfc7386) algorithm in the same order they are defined here. The resulting object MUST be a valid [Message Object](#messageObject).
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
@@ -976,33 +976,6 @@ Name | Allowed values | Notes
 
 
 ##### Message Object Example
-
-```json
-{
-  "payload": {
-    "type": "object",
-    "properties": {
-      "displayName": {
-        "type": "string",
-        "description": "Name of the user"
-      },
-      "email": {
-        "type": "string",
-        "format": "email",
-        "description": "Email of the user"
-      }
-    }
-  },
-  "examples": [
-    {
-      "payload": {
-        "displayName": "Tom Tailor",
-        "email": "tailor@files.io"
-      }
-    }
-  ]
-}
-```
 
 ```json
 {
@@ -1046,6 +1019,22 @@ Name | Allowed values | Notes
   },
   "traits": [
     { "$ref": "#/components/messageTraits/commonHeaders" }
+  ],
+  "examples": [
+    {
+      "headers": {
+        "correlationId": "my-correlation-id",
+        "applicationInstanceId": "myInstanceId"
+      },
+      "payload": {
+        "user": {
+          "someUserKey": "someUserValue"
+        },
+        "signup": {
+          "someSignupKey": "someSignupValue"
+        }
+      }
+    }
   ]
 }
 ```
@@ -1081,6 +1070,15 @@ correlationId:
   location: $message.header#/correlationId
 traits:
   - $ref: "#/components/messageTraits/commonHeaders"
+examples:
+  - headers:
+      correlationId: my-correlation-id
+      applicationInstanceId: myInstanceId
+    payload:
+      user:
+        someUserKey: someUserValue
+      signup:
+        someSignupKey: someSignupValue
 ```
 
 Example using Avro to define the payload:
@@ -1144,38 +1142,10 @@ Field Name | Type | Description
 <a name="messageTraitObjectTags"></a>tags | [Tags Object](#tagsObject) | A list of tags for API documentation control. Tags can be used for logical grouping of messages.
 <a name="messageTraitObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this message.
 <a name="messageTraitObjectBindings"></a>bindings | Map[`string`, [Message Bindings Object](#messageBindingsObject)] | A free-form map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the message.
-<a name="messageTraitObjectExamples"></a>examples | [Map[`string`, `any`]] | An array with examples of valid message objects. Examples MUST be located under fixed fields: `payload` for payload examples, `headers` for headers examples
+<a name="messageObjectExamples"></a>examples | [Map[`string`, `any`]] | An array of key/value pairs where keys MUST be either **headers** and/or **payload**. Values MUST contain examples that validate against the [headers](#messageObjectHeaders) or [payload](#messageObjectPayload) fields, respectively.
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
 
-##### Message Trait Object Example with examples
-
-```json
-{
-  "payload": {
-    "type": "object",
-    "properties": {
-      "displayName": {
-        "type": "string",
-        "description": "Name of the user"
-      },
-      "email": {
-        "type": "string",
-        "format": "email",
-        "description": "Email of the user"
-      }
-    }
-  },
-  "examples": [
-    {
-      "payload": {
-        "displayName": "Tom Tailor",
-        "email": "tailor@files.io"
-      }
-    }
-  ]
-}
-```
 ##### Message Trait Object Example
 
 ```json

--- a/public/_redirects
+++ b/public/_redirects
@@ -15,3 +15,5 @@ https://asyncapi.com/* https://www.asyncapi.com/:splat 301!
 
 # Central Maven repository verification
 /OSSRH-63280 https://github.com/asyncapi/java-asyncapi
+# Central Gradle repository verification
+/asyncapi-gradle-plugin https://github.com/asyncapi/java-asyncapi

--- a/public/_redirects
+++ b/public/_redirects
@@ -15,5 +15,3 @@ https://asyncapi.com/* https://www.asyncapi.com/:splat 301!
 
 # Central Maven repository verification
 /OSSRH-63280 https://github.com/asyncapi/java-asyncapi
-# Central Gradle repository verification
-/asyncapi-gradle-plugin https://github.com/asyncapi/java-asyncapi


### PR DESCRIPTION
Helps to prevent miss understanding of [message|messageTrait].examples.

Inspired by personal experience and https://github.com/asyncapi/asyncapi-react/issues/254