### PR TITLE
feat: add RSS icon to blog and improve configuration

### DIFF
--- a/components/Head.js
+++ b/components/Head.js
@@ -21,7 +21,8 @@ export default function HeadComponent({
       <meta httpEquiv="x-ua-compatible" content="ie=edge" />
       <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
       <meta name="description" content={description} />
-      
+      <link rel="alternate" type="application/rss+xml" title="RSS Feed for AsyncAPI Initiative" href="/rss.xml" />
+
       {/* Google / Search Engine Tags */}
       <meta itemProp="name" content={title} />
       <meta itemProp="description" content={description} />

--- a/components/Head.js
+++ b/components/Head.js
@@ -21,7 +21,7 @@ export default function HeadComponent({
       <meta httpEquiv="x-ua-compatible" content="ie=edge" />
       <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
       <meta name="description" content={description} />
-      <link rel="alternate" type="application/rss+xml" title="RSS Feed for AsyncAPI Initiative" href="/rss.xml" />
+      <link rel="alternate" type="application/rss+xml" title="RSS Feed for AsyncAPI Initiative Blog" href="/rss.xml" />
 
       {/* Google / Search Engine Tags */}
       <meta itemProp="name" content={title} />

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -42,6 +42,9 @@ export default function BlogIndexPage() {
               Want to publish a blog post? We love community stories.
               <a className="ml-1 text-primary-500 hover:text-primary-400" href="https://github.com/asyncapi/website/issues/new?template=blog.md" target="_blank" rel="noreferrer">Submit yours!</a>
             </p>
+            <p className="max-w-2xl mx-auto text-md leading-7 text-gray-400">
+              We have an <img className="ml-1 text-primary-500 hover:text-primary-400" style={{ display: 'inline' }} src="/img/logos/rss.svg" height="18px" width="18px" /> <a className="ml-1 text-primary-500 hover:text-primary-400" href="/rss.xml">RSS Feed</a> too!
+            </p>
           </div>
           <div className="mt-12 grid gap-5 max-w-lg mx-auto lg:grid-cols-3 lg:max-w-none">
             {

--- a/public/img/logos/rss.svg
+++ b/public/img/logos/rss.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+aria-label="RSS" role="img"
+viewBox="0 0 512 512"><rect
+width="512" height="512"
+rx="15%"
+fill="#f80"/><circle cx="145" cy="367" r="35" fill="#fff"/><path fill="none" stroke="#fff" stroke-width="60" d="M109 241c89 0 162 73 162 162m114 0c0-152-124-276-276-276"/></svg>

--- a/scripts/build-rss.js
+++ b/scripts/build-rss.js
@@ -49,7 +49,21 @@ function rssFeed() {
   rss.channel.item = []
 
   for (let post of posts) {
-    rss.channel.item.push({ title: post.title, description: clean(post.excerpt), link: base+post.slug, category: 'blog', guid: { '@isPermaLink': true, '': base+post.slug }, pubDate: new Date(post.date).toUTCString() })
+    const item = { title: post.title, description: clean(post.excerpt), link: base+post.slug, category: 'blog', guid: { '@isPermaLink': true, '': base+post.slug }, pubDate: new Date(post.date).toUTCString() }
+    if (post.cover) {
+      const enclosure = {};
+      enclosure["@url"] = base+post.cover;
+      enclosure["@length"] = 15026; // dummy value, anything works
+      enclosure["@type"] = 'image/jpeg';
+      if (typeof enclosure["@url"] === 'string') {
+        let tmp = enclosure["@url"].toLowerCase();
+        if (tmp.indexOf('.png')>=0) enclosure["@type"] = 'image/png';
+        if (tmp.indexOf('.svg')>=0) enclosure["@type"] = 'image/svg+xml';
+        if (tmp.indexOf('.webp')>=0) enclosure["@type"] = 'image/webp';
+      }
+      item.enclosure = enclosure;
+    }
+    rss.channel.item.push(item)
   }
 
   feed.rss = rss

--- a/scripts/build-rss.js
+++ b/scripts/build-rss.js
@@ -28,6 +28,7 @@ function rssFeed() {
     })
 
   const base = 'https://www.asyncapi.com'
+  const tracking = '?utm_source=rss';
 
   const feed = {}
   const rss = {}
@@ -49,7 +50,8 @@ function rssFeed() {
   rss.channel.item = []
 
   for (let post of posts) {
-    const item = { title: post.title, description: clean(post.excerpt), link: base+post.slug, category: 'blog', guid: { '@isPermaLink': true, '': base+post.slug }, pubDate: new Date(post.date).toUTCString() }
+    const link = `${base}${post.slug}${tracking}`;
+    const item = { title: post.title, description: clean(post.excerpt), link, category: 'blog', guid: { '@isPermaLink': true, '': link }, pubDate: new Date(post.date).toUTCString() }
     if (post.cover) {
       const enclosure = {};
       enclosure["@url"] = base+post.cover;

--- a/scripts/build-rss.js
+++ b/scripts/build-rss.js
@@ -6,7 +6,13 @@ function getAllPosts() {
 }
 
 function clean(s) {
-  return s.split('&amp').join('&')
+  s = s.split('&ltspan&gt').join('')
+  s = s.split('&amp').join('&')
+  s = s.split('&#39;').join("'")
+  s = s.split('&lt;').join('<')
+  s = s.split('&gt;').join('>')
+  s = s.split('&quot;').join('"')
+  return s
 }
 
 function rssFeed() {
@@ -21,7 +27,7 @@ function rssFeed() {
       return i2Date - i1Date
     })
 
-  const base = 'https://asyncapi.com'
+  const base = 'https://www.asyncapi.com'
 
   const feed = {}
   const rss = {}
@@ -29,12 +35,14 @@ function rssFeed() {
   rss["@xmlns:atom"] = 'http://www.w3.org/2005/Atom'
   rss.channel = {}
   rss.channel.title = 'AsyncAPI Initiative Blog RSS Feed'
-  rss.channel.link = base+'/rss'
+  rss.channel.link = base+'/rss.xml'
   rss.channel["atom:link"] = {}
   rss.channel["atom:link"]["@rel"] = 'self'
   rss.channel["atom:link"]["@href"] = rss.channel.link
   rss.channel["atom:link"]["@type"] = 'application/rss+xml'
   rss.channel.description = 'AsyncAPI Initiative Blog'
+  rss.channel.language = 'en-gb';
+  rss.channel.copyright = 'Made with :love: by the AsyncAPI Initiative.';
   rss.channel.webMaster = 'info@asyncapi.io (AsyncAPI Initiative)'
   rss.channel.pubDate = new Date().toUTCString()
   rss.channel.generator = 'next.js'


### PR DESCRIPTION
.**Description**

- fixes the link:rel:self attribute within the RSS feed to hopefully make Slack and other consumers happy
- adds a language tag, which some consumers might want to see
- adds a 'copyright' tag, ditto
- adds a link rel alternate to `Head.js` to aid autodiscovery of the RSS feed
- adds a link and icon image to the `blog` main page 

![5306058E-F9A3-4FD8-BEC4-3138B7C31CF8_4_5005_c](https://user-images.githubusercontent.com/21603/116272159-986b1200-a778-11eb-8bad-4713400efea4.jpeg)

