### PR TITLE
fix: preview build on PRs must ignore roadmap build

### DIFF
--- a/pages/roadmap.js
+++ b/pages/roadmap.js
@@ -8,6 +8,18 @@ export default function RoadmapPage() {
   const description = 'Long-term vision and plans for the AsyncAPI Initiative.'
   const image = '/img/social/roadmap.png'
 
+  if (Object.keys(roadmapData).length === 0) { 
+    return (
+      <GenericLayout
+        title="Vision & Roadmap"
+        description={description}
+        image={image}
+        wide
+      >
+      </GenericLayout>
+    )
+  }
+
   return (
     <GenericLayout
       title="Vision & Roadmap"

--- a/scripts/build-roadmap.js
+++ b/scripts/build-roadmap.js
@@ -114,6 +114,7 @@ async function start() {
     writeFileSync(resolve(__dirname, '..', 'roadmap.json'), JSON.stringify(result, null, '  '))
   } catch (e) {
     console.error(e)
+    writeFileSync(resolve(__dirname, '..', 'roadmap.json'), '{}')
   }
 }
 


### PR DESCRIPTION
Long story here.

Once upon a time, something new showed up on the website, a roadmap view. It is a view that is built dynamically using GH GraphQL API and ZenHub API.

Tokens are needed, tokens are secrets, tokens should not be available for anyone. True story.

---

Another side of this story is that we provide PR preview builds. Cool huh? But we work on forks, everybody works on forks. Preview builds need to build a website with your changes so run in the scope of the fork. This basically means that someone can `console.log` the environment variables with secrets and 😨 yup, we are doomed. 

---

Netlify is a good angel here. Then noticed we have secrets and immediately reconfigured our builds in the way that we need to manually approve PR preview builds after reviewing the code and checking if someone console.logs secrets.

All good, but long term, well, who wants to click `Admit` over and over. Especially that changes to roadmap view are super rare, while other changes are done ofter, like new blog posts etc.

--- 

I changes settings that we would always build without a need to `Admit` the build, but we just need to run those builds without secrets.

<img width="876" alt="Screenshot 2021-04-29 at 09 44 27" src="https://user-images.githubusercontent.com/6995927/116517700-9798c400-a8cf-11eb-801c-a5b794a81db7.png">

All good, right? no, because now preview builds always fail as we have a bug. Every build fails as `roadmap.json` file is not available because it was not created due to fail in communication with the API. You know, because we do not pass secrets.

---

This PR makes sure that PR preview build runs without problem on a fork. When there is no token, empty `roadmap.json` file is created and empty roadmap view rendered. I think it is acceptable looking on the amount of PR related to roadmap vs amound of PRs related to !roadmap

> side story, when I write `roadmap` and `!roadmap` I immediately remind myself about [this](https://www.youtube.com/watch?v=pqTntG1RXSY) 🤣 