### PR TITLE
fix: fixed typo in Getting started doc

### DIFF
--- a/pages/docs/getting-started/index.md
+++ b/pages/docs/getting-started/index.md
@@ -11,7 +11,7 @@ aliases:
 
 AsyncAPI is an open source initiative that seeks to improve the current state of Event-Driven Architectures (EDA). Our long-term goal is to make working with EDAs as easy as it is to work with REST APIs. That goes from documentation to code generation, from discovery to event management. Most of the processes you apply to your REST APIs nowadays would be applicable to your event-driven/asynchronous APIs too.
 
-To make this happen, the first step has been to create a specification that allows **developers, architects, and product managers** to define the interfaces of an async API. Much like [OpenAPI (fka Swagger)](https://github.com/OAI/OpenAPI-Specification) does for REST APIs.
+To make this happen, the first step has been to create a specification that allows **developers, architects, and product managers** to define the interfaces of an async API. Much like [OpenAPI (aka Swagger)](https://github.com/OAI/OpenAPI-Specification) does for REST APIs.
 
 **The AsyncAPI specification settles the base for a greater and better tooling ecosystem for EDA's**. We recently launched AsyncAPI specification 2.0.0 —the strongest version to date— that will sustain the event-driven architectures of tomorrow.
 


### PR DESCRIPTION
**Description**

- fixed typo in Getting started doc

**Related issue(s)**
- none