### PR TITLE
feat: add blog authors links on avatars and names

### DIFF
--- a/components/AuthorAvatars.js
+++ b/components/AuthorAvatars.js
@@ -1,12 +1,14 @@
 export default function AuthorAvatars({ authors = [] }) {
   return (
-    authors.map((author, index) => (
-      <img
+    authors.map((author, index) => {
+      let avatar = <img
         key={index}
         title={author.name}
         className={`${index > 0 ? `absolute left-${index * 7} top-0` : `relative mr-${(authors.length - 1) * 7}`} z-${(authors.length - 1 - index) * 10} h-10 w-10 border-2 border-white rounded-full object-cover hover:z-50`}
         src={author.photo}
       />
-    ))
+
+      return author.link ? <a alt={author.name} href={author.link}>{avatar}</a> : {avatar}
+    })
   )
 }

--- a/components/layout/BlogLayout.js
+++ b/components/layout/BlogLayout.js
@@ -38,7 +38,7 @@ export default function BlogLayout({ post, children }) {
               <div className="ml-3">
                 <p className="text-sm leading-5 font-medium text-gray-900">
                   <span className="hover:underline">
-                    {post.authors.map(author => author.name).join(' & ')}
+                    {post.authors.map(author => author.link ? <a alt={author.name} href={author.link}>{author.name}</a> : author.name).reduce((prev, curr) => [ prev, ' & ', curr ])}
                   </span>
                 </p>
                 <div className="flex text-sm leading-5 text-gray-500">

--- a/components/navigation/BlogPostItem.js
+++ b/components/navigation/BlogPostItem.js
@@ -48,7 +48,7 @@ export default function BlogPostItem({ post, className = '' }) {
           <div className="ml-3">
             <p className="text-sm leading-5 font-medium text-gray-900">
               <span className="hover:underline">
-                {post.authors.map(author => author.name).join(' & ')}
+                {post.authors.map(author => author.link ? <a alt={author.name} href={author.link}>{author.name}</a> : author.name).reduce((prev, curr) => [ prev, ' & ', curr ])}
               </span>
             </p>
             <div className="flex text-sm leading-5 text-gray-500">


### PR DESCRIPTION
This PR adds a link to the blog author link (only if provided) on all avatars and names, including the view that lists all blog posts but also the blog post itself.

For example:

![image](https://user-images.githubusercontent.com/1083296/117172602-3d669a00-adcc-11eb-9cd6-a9b4c2db9adc.png)
