### PR TITLE
feat: redirect /docs/specifications/2.0.0 to /docs/specifications/v2.0.0

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -9,6 +9,7 @@ https://asyncapi.com/* https://www.asyncapi.com/:splat 301!
 # Redirection will be handled automatically by Action.
 # SPEC-REDIRECTION:START
 /docs/specifications/latest /docs/specifications/v2.0.0 302!
+/docs/specifications/2.0.0 /docs/specifications/v2.0.0 301! # The path was changed. We want to keep links pointing to the old path working.
 # SPEC-REDIRECTION:END
 
 /docs/specifications/1.0.0 https://github.com/asyncapi/asyncapi/blob/master/versions/1.0.0/asyncapi.md 302!


### PR DESCRIPTION
**Description**

Recently, we changed the spec URL path from `/docs/specifications/v2.0.0` to `/docs/specifications/2.0.0` . See https://github.com/asyncapi/website/issues/275

The old URL is not working anymore and returns a `404` now. That might end up breaking links from third parties (such as blog posts, bookmarks, etc) as @dedoussis stated in a [Slack message](https://asyncapi.slack.com/archives/C34F2JV0U/p1623353571249300?thread_ts=1623314701.229800&cid=C34F2JV0U)
This PR adds a redirect from `/docs/specifications/2.0.0` to `/docs/specifications/v2.0.0`, to keep it at least until we get a conclusion on https://github.com/asyncapi/website/issues/275.

**Related issue(s)**
https://github.com/asyncapi/website/issues/275