### PR TITLE
feat: change redirect type for spec 2.0.0

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -9,7 +9,7 @@ https://asyncapi.com/* https://www.asyncapi.com/:splat 301!
 # Redirection will be handled automatically by Action.
 # SPEC-REDIRECTION:START
 /docs/specifications/latest /docs/specifications/v2.0.0 302!
-/docs/specifications/2.0.0 /docs/specifications/v2.0.0 301! # The path was changed. We want to keep links pointing to the old path working.
+/docs/specifications/2.0.0 /docs/specifications/v2.0.0 302! # The path was changed. We want to keep links pointing to the old path working.
 # SPEC-REDIRECTION:END
 
 /docs/specifications/1.0.0 https://github.com/asyncapi/asyncapi/blob/master/versions/1.0.0/asyncapi.md 302!


### PR DESCRIPTION
Redirect type from /docs/specifications/2.0.0 to /docs/specifications/v2.0.0 is a `301`, however, for SEO reasons it will be better to have a `302` since we are not 100% sure if this change is gonna be permanent (See https://github.com/asyncapi/website/issues/275).

With `302` Google won't remove the old link and will keep the ranking by now.

**Related issue(s)**
https://github.com/asyncapi/website/issues/275