### PR TITLE
feat: add the ability to show a release candidate as pre-release in the UI

### DIFF
--- a/components/layout/DocsLayout.js
+++ b/components/layout/DocsLayout.js
@@ -2,7 +2,6 @@ import { useState } from 'react'
 import { useRouter } from 'next/router'
 import ErrorPage from 'next/error'
 import sortBy from 'lodash/sortBy'
-import { basename } from 'path'
 import Head from '../Head'
 import DocsContext from '../../context/DocsContext'
 import TOC from '../TOC'
@@ -83,6 +82,11 @@ export default function DocsLayout({ post, navItems = {}, children }) {
               </div>
             )}
             <h1 className="px-4 text-4xl font-normal text-gray-800 font-sans antialiased sm:px-6 md:px-8">{post.title}</h1>
+            {
+              post.isPrerelease 
+              ? <h3 className="px-4 text-lxl font-normal text-gray-800 font-sans antialiased sm:px-6 md:px-8">To be released on {post.releaseDate}</h3> 
+              : null
+            }
             <div className="px-4 sm:px-6 md:px-8">
               <p className="text-sm font-normal text-gray-400 font-sans antialiased">
                 Found an error? Have a suggestion? 

--- a/scripts/build-post-list.js
+++ b/scripts/build-post-list.js
@@ -59,12 +59,12 @@ function walkDirectories(directories, result, sectionWeight = 0, sectionTitle) {
         details.isIndex = fileName.endsWith('/index.md')
         details.slug = details.isIndex ? sectionSlug : slug.replace(/\.md$/, '')
         if(details.slug.includes('/specifications/') && !details.title) {
-          let fileName = basename(data.slug)
+          const fileBaseName = basename(data.slug)  // ex. v2.0.0 | v2.1.0-2021-06-release
+          const fileName = fileBaseName.split('-')[0] // v2.0.0 | v2.1.0
 
-          if(fileName.includes('release')) {
+          if(fileBaseName.includes('release')) {
             details.isPrerelease = true
-            details.releaseDate = getReleaseDate(fileName)
-            fileName = fileName.split('-')[0]
+            details.releaseDate = getReleaseDate(fileBaseName)
           }
 
           details.weight = specWeight--
@@ -102,7 +102,7 @@ function capitalize(text) {
 }
 
 function getReleaseDate(text) {
- // ex. filename = v2.1.0-2021-06-release.md
+ // ex. filename = v2.1.0-2021-06-release
  const splittedText = text.split('-') // ['v2.1.0', '2021', '06', 'release']
  const releaseDate = `${splittedText[1]}-${splittedText[2]}` // '2021-06'
  return releaseDate


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- This PR will mark a release candidate/pre-release as pre-release for next version, with release date

**Screeshots**
![Screenshot_2021-06-16_14 50 55](https://user-images.githubusercontent.com/54525741/122194551-2d55d600-ceb3-11eb-80e3-638373fa8c7b.png)
![Screenshot_2021-06-16_14 51 09](https://user-images.githubusercontent.com/54525741/122194558-2e870300-ceb3-11eb-9607-1fc4ae60ddbb.png)

**Related issue(s)**
https://github.com/asyncapi/website/issues/86