### PR TITLE
chore: separate spec-redirections in _redirects

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -7,8 +7,11 @@ https://asyncapi.com/* https://www.asyncapi.com/:splat 301!
 /docs/tooling /docs/community/tooling 301!
 
 # Redirection will be handled automatically by Action.
-# SPEC-REDIRECTION:START
+# LATEST-SPEC-REDIRECTION:START
 /docs/specifications/latest /docs/specifications/v2.0.0 302!
+# LATEST-SPEC-REDIRECTION:END
+
+# SPEC-REDIRECTION:START
 /docs/specifications/2.0.0 /docs/specifications/v2.0.0 302! # The path was changed. We want to keep links pointing to the old path working.
 # SPEC-REDIRECTION:END
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- This PR separates the `latest` spec redirect and previous/current spec redirection.

**Reason:**
https://github.com/asyncapi/spec/pull/543

As the `latest` redirection will be update automatically by Github Actions, the way action is written will basically overwrite everything inside the `# SPEC-REDIRECTION:START` & `# SPEC-REDIRECTION:END` section.
So, we separate the `latest` redirection, thereby avoiding the removal of previous/current spec redirections.
