### PR TITLE
chore: add regex to remove `a` tags from headings

### DIFF
--- a/components/TOC.js
+++ b/components/TOC.js
@@ -10,7 +10,7 @@ export default function TOC({
 }) {
   if (!toc || !toc.length) return null
   const minLevel = toc.reduce((mLevel, item) => (!mLevel || item.lvl < mLevel) ? item.lvl : mLevel, 0)
-  const tocItems = toc.filter(item => item.lvl <= minLevel + 2).map(item => ({ ...item, content: item.content.replace(/[\s]?\{\#[\w\d\-_]+\}$/, '') }))
+  const tocItems = toc.filter(item => item.lvl <= minLevel + 2).map(item => ({ ...item, content: item.content.replace(/[\s]?\{\#[\w\d\-_]+\}$/, '').replace(/<a name="[\w\d\-_]*"><\/a>/, '') }))
 
   const [open, setOpen] = useState(false)
 

--- a/components/TOC.js
+++ b/components/TOC.js
@@ -10,7 +10,7 @@ export default function TOC({
 }) {
   if (!toc || !toc.length) return null
   const minLevel = toc.reduce((mLevel, item) => (!mLevel || item.lvl < mLevel) ? item.lvl : mLevel, 0)
-  const tocItems = toc.filter(item => item.lvl <= minLevel + 2).map(item => ({ ...item, content: item.content.replace(/[\s]?\{\#[\w\d\-_]+\}$/, '').replace(/<a name="[\w\d\-_]*"><\/a>/, '') }))
+  const tocItems = toc.filter(item => item.lvl <= minLevel + 2).map(item => ({ ...item, content: item.content.replace(/[\s]?\{\#[\w\d\-_]+\}$/, '').replace(/(<([^>]+)>)/gi, '') }))
 
   const [open, setOpen] = useState(false)
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Add regex to remove `<a name="*"></a>` from Table of Contents
