### PR TITLE
fix: use original anchor tags from the spec

### DIFF
--- a/components/TOC.js
+++ b/components/TOC.js
@@ -7,10 +7,11 @@ export default function TOC({
   cssBreakingPoint = 'xl',
   toc,
   contentSelector,
+  depth = 2,
 }) {
   if (!toc || !toc.length) return null
   const minLevel = toc.reduce((mLevel, item) => (!mLevel || item.lvl < mLevel) ? item.lvl : mLevel, 0)
-  const tocItems = toc.filter(item => item.lvl <= minLevel + 2).map(item => ({ ...item, content: item.content.replace(/[\s]?\{\#[\w\d\-_]+\}$/, '').replace(/(<([^>]+)>)/gi, '') }))
+  const tocItems = toc.filter(item => item.lvl <= minLevel + depth).map(item => ({ ...item, content: item.content.replace(/[\s]?\{\#[\w\d\-_]+\}$/, '').replace(/(<([^>]+)>)/gi, '') }))
 
   const [open, setOpen] = useState(false)
 

--- a/components/layout/DocsLayout.js
+++ b/components/layout/DocsLayout.js
@@ -94,7 +94,7 @@ export default function DocsLayout({ post, navItems = {}, children }) {
               </p>
             </div>
             <div className={`xl:flex ${post.toc && post.toc.length ? 'xl:flex-row-reverse' : ''}`}>
-              <TOC toc={post.toc} className="bg-blue-100 mt-4 p-4 sticky top-0 overflow-y-auto max-h-screen xl:bg-transparent xl:mt-0 xl:pt-0 xl:pb-8 xl:top-4 xl:max-h-(screen-16) xl:w-72" />
+              <TOC toc={post.toc} depth={3} className="bg-blue-100 mt-4 p-4 sticky top-0 overflow-y-auto max-h-screen xl:bg-transparent xl:mt-0 xl:pt-0 xl:pb-8 xl:top-4 xl:max-h-(screen-16) xl:w-72" />
               <div className="mt-8 px-4 sm:px-6 xl:px-8 xl:flex-1 xl:max-w-184">
                 <article className="mb-32">
                   <Head

--- a/pages/docs/specifications/v2.0.0.md
+++ b/pages/docs/specifications/v2.0.0.md
@@ -29,49 +29,6 @@ It means that the [application](#definitionsApplication) allows [consumers](#def
 
 **The AsyncAPI specification does not assume any kind of software topology, architecture or pattern.** Therefore, a server MAY be a message broker, a web server or any other kind of computer program capable of sending and/or receiving data. However, AsyncAPI offers a mechanism called "bindings" that aims to help with more specific information about the protocol and/or the topology.
 
-## Table of Contents
-<!-- TOC depthFrom:2 depthTo:4 withLinks:1 updateOnSave:0 orderedList:0 -->
-
-- [Definitions](#definitions)
-  - [Application](#definitionsApplication)
-  - [Producer](#definitionsProducer)
-  - [Consumer](#definitionsConsumer)
-  - [Message](#definitionsMessage)
-  - [Channel](#definitionsChannel)
-  - [Protocol](#definitionsProtocol)
-- [Specification](#specification)
-	- [Format](#format)
-	- [File Structure](#file-structure)
-	- [Schema](#schema)
-      - [AsyncAPI Object](#A2SObject)
-      - [AsyncAPI Version String](#A2SVersionString)
-      - [Info Object](#infoObject)
-      - [Contact Object](#contactObject)
-      - [License Object](#licenseObject)
-      - [Servers Object](#serversObject)
-      - [Channels Object](#channelsObject)
-      - [Channel Item Object](#channelItemObject)
-      - [Operation Object](#operationObject)
-      - [Operation Trait Object](#operationTraitObject)
-      - [Message Object](#messageObject)
-      - [Message Trait Object](#messageTraitObject)
-      - [Tags Object](#tagsObject)
-      - [External Documentation Object](#externalDocumentationObject)
-      - [Components Object](#componentsObject)
-      - [Reference Object](#referenceObject)
-      - [Schema Object](#schemaObject)
-      - [Security Scheme Object](#securitySchemeObject)
-      - [Parameters Object](#parametersObject)
-      - [Parameter Object](#parameterObject)
-      - [Server Bindings Object](#serverBindingsObject)
-      - [Channel Bindings Object](#channelBindingsObject)
-      - [Operation Bindings Object](#operationBindingsObject)
-      - [Message Bindings Object](#messageBindingsObject)
-      - [Correlation ID Object](#correlationIdObject)
-      - [Specification Extensions](#specificationExtensions)
-
-<!-- /TOC -->
-
 ## <a name="definitions"/>Definitions
 
 #### <a name="definitionsApplication"></a>Application

--- a/pages/docs/specifications/v2.0.0.md
+++ b/pages/docs/specifications/v2.0.0.md
@@ -329,43 +329,46 @@ The following shows how multiple servers can be described, for example, at the A
 
 ```json
 {
-  "servers": [
-    {
+  "servers": {
+    "development": {
       "url": "development.gigantic-server.com",
       "description": "Development server",
       "protocol": "amqp",
       "protocolVersion": "0.9.1"
     },
-    {
+    "staging": {
       "url": "staging.gigantic-server.com",
       "description": "Staging server",
       "protocol": "amqp",
       "protocolVersion": "0.9.1"
     },
-    {
+    "production": {
       "url": "api.gigantic-server.com",
       "description": "Production server",
       "protocol": "amqp",
       "protocolVersion": "0.9.1"
     }
-  ]
+  }
 }
 ```
 
 ```yaml
 servers:
-- url: development.gigantic-server.com
-  description: Development server
-  protocol: amqp
-  protocolVersion: 0.9.1
-- url: staging.gigantic-server.com
-  description: Staging server
-  protocol: amqp
-  protocolVersion: 0.9.1
-- url: api.gigantic-server.com
-  description: Production server
-  protocol: amqp
-  protocolVersion: 0.9.1
+  development:
+    url: development.gigantic-server.com
+    description: Development server
+    protocol: amqp
+    protocolVersion: 0.9.1
+  staging:
+    url: staging.gigantic-server.com
+    description: Staging server
+    protocol: amqp
+    protocolVersion: 0.9.1
+  production:
+    url: api.gigantic-server.com
+    description: Production server
+    protocol: amqp
+    protocolVersion: 0.9.1
 ```
 
 The following shows how variables can be used for a server configuration:
@@ -556,10 +559,11 @@ subscribe:
         user:
           $ref: "#/components/schemas/user"
         signup:
-amqp:
-  is: queue
-  queue:
-    exclusive: true
+bindings:
+  amqp:
+    is: queue
+    queue:
+      exclusive: true
 ```
 
 Using `oneOf` to specify multiple messages per operation:
@@ -833,7 +837,7 @@ Map describing protocol-specific definitions for a server.
 Field Name | Type | Description
 ---|:---:|---
 <a name="serverBindingsObjectHTTP"></a>`http` | [HTTP Server Binding](https://github.com/asyncapi/bindings/blob/master/http#server) | Protocol-specific information for an HTTP server.
-<a name="serverBindingsObjectWebSockets"></a>`ws` | [WebSockets Server Binding](https://github.com/asyncapi/bindings/blob/master/ws#server) | Protocol-specific information for a WebSockets server.
+<a name="serverBindingsObjectWebSockets"></a>`ws` | [WebSockets Server Binding](https://github.com/asyncapi/bindings/blob/master/websockets#server) | Protocol-specific information for a WebSockets server.
 <a name="serverBindingsObjectKafka"></a>`kafka` | [Kafka Server Binding](https://github.com/asyncapi/bindings/blob/master/kafka#server) | Protocol-specific information for a Kafka server.
 <a name="serverBindingsObjectAMQP"></a>`amqp` | [AMQP Server Binding](https://github.com/asyncapi/bindings/blob/master/amqp#server) | Protocol-specific information for an AMQP 0-9-1 server.
 <a name="serverBindingsObjectAMQP1"></a>`amqp1` | [AMQP 1.0 Server Binding](https://github.com/asyncapi/bindings/blob/master/amqp1#server) | Protocol-specific information for an AMQP 1.0 server.
@@ -858,7 +862,7 @@ Map describing protocol-specific definitions for a channel.
 Field Name | Type | Description
 ---|:---:|---
 <a name="channelBindingsObjectHTTP"></a>`http` | [HTTP Channel Binding](https://github.com/asyncapi/bindings/blob/master/http/README.md#channel) | Protocol-specific information for an HTTP channel.
-<a name="channelBindingsObjectWebSockets"></a>`ws` | [WebSockets Channel Binding](https://github.com/asyncapi/bindings/blob/master/ws/README.md#channel) | Protocol-specific information for a WebSockets channel.
+<a name="channelBindingsObjectWebSockets"></a>`ws` | [WebSockets Channel Binding](https://github.com/asyncapi/bindings/blob/master/websockets/README.md#channel) | Protocol-specific information for a WebSockets channel.
 <a name="channelBindingsObjectKafka"></a>`kafka` | [Kafka Channel Binding](https://github.com/asyncapi/bindings/blob/master/kafka/README.md#channel) | Protocol-specific information for a Kafka channel.
 <a name="channelBindingsObjectAMQP"></a>`amqp` | [AMQP Channel Binding](https://github.com/asyncapi/bindings/blob/master/amqp/README.md#channel) | Protocol-specific information for an AMQP 0-9-1 channel.
 <a name="channelBindingsObjectAMQP1"></a>`amqp1` | [AMQP 1.0 Channel Binding](https://github.com/asyncapi/bindings/blob/master/amqp1/README.md#channel) | Protocol-specific information for an AMQP 1.0 channel.
@@ -883,7 +887,7 @@ Map describing protocol-specific definitions for an operation.
 Field Name | Type | Description
 ---|:---:|---
 <a name="operationBindingsObjectHTTP"></a>`http` | [HTTP Operation Binding](https://github.com/asyncapi/bindings/blob/master/http/README.md#operation) | Protocol-specific information for an HTTP operation.
-<a name="operationBindingsObjectWebSockets"></a>`ws` | [WebSockets Operation Binding](https://github.com/asyncapi/bindings/blob/master/ws/README.md#operation) | Protocol-specific information for a WebSockets operation.
+<a name="operationBindingsObjectWebSockets"></a>`ws` | [WebSockets Operation Binding](https://github.com/asyncapi/bindings/blob/master/websockets/README.md#operation) | Protocol-specific information for a WebSockets operation.
 <a name="operationBindingsObjectKafka"></a>`kafka` | [Kafka Operation Binding](https://github.com/asyncapi/bindings/blob/master/kafka/README.md#operation) | Protocol-specific information for a Kafka operation.
 <a name="operationBindingsObjectAMQP"></a>`amqp` | [AMQP Operation Binding](https://github.com/asyncapi/bindings/blob/master/amqp/README.md#operation) | Protocol-specific information for an AMQP 0-9-1 operation.
 <a name="operationBindingsObjectAMQP1"></a>`amqp1` | [AMQP 1.0 Operation Binding](https://github.com/asyncapi/bindings/blob/master/amqp1/README.md#operation) | Protocol-specific information for an AMQP 1.0 operation.
@@ -910,7 +914,7 @@ Map describing protocol-specific definitions for a message.
 Field Name | Type | Description
 ---|:---:|---
 <a name="messageBindingsObjectHTTP"></a>`http` | [HTTP Message Binding](https://github.com/asyncapi/bindings/blob/master/http/README.md#message) | Protocol-specific information for an HTTP message, i.e., a request or a response.
-<a name="messageBindingsObjectWebSockets"></a>`ws` | [WebSockets Message Binding](https://github.com/asyncapi/bindings/blob/master/ws/README.md#message) | Protocol-specific information for a WebSockets message.
+<a name="messageBindingsObjectWebSockets"></a>`ws` | [WebSockets Message Binding](https://github.com/asyncapi/bindings/blob/master/websockets/README.md#message) | Protocol-specific information for a WebSockets message.
 <a name="messageBindingsObjectKafka"></a>`kafka` | [Kafka Message Binding](https://github.com/asyncapi/bindings/blob/master/kafka/README.md#message) | Protocol-specific information for a Kafka message.
 <a name="messageBindingsObjectAMQP"></a>`amqp` | [AMQP Message Binding](https://github.com/asyncapi/bindings/blob/master/amqp/README.md#message) | Protocol-specific information for an AMQP 0-9-1 message.
 <a name="messageBindingsObjectAMQP1"></a>`amqp1` | [AMQP 1.0 Message Binding](https://github.com/asyncapi/bindings/blob/master/amqp1/README.md#message) | Protocol-specific information for an AMQP 1.0 message.

--- a/pages/docs/specifications/v2.0.0.md
+++ b/pages/docs/specifications/v2.0.0.md
@@ -1,3 +1,5 @@
+# AsyncAPI Specification
+
 #### Disclaimer
 
 Part of this content has been taken from the great work done by the folks at the [OpenAPI Initiative](https://openapis.org). Mainly because **it's a great work** and we want to keep as much compatibility as possible with the [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification).
@@ -27,29 +29,72 @@ It means that the [application](#definitionsApplication) allows [consumers](#def
 
 **The AsyncAPI specification does not assume any kind of software topology, architecture or pattern.** Therefore, a server MAY be a message broker, a web server or any other kind of computer program capable of sending and/or receiving data. However, AsyncAPI offers a mechanism called "bindings" that aims to help with more specific information about the protocol and/or the topology.
 
-## Definitions {#definitions}
+## Table of Contents
+<!-- TOC depthFrom:2 depthTo:4 withLinks:1 updateOnSave:0 orderedList:0 -->
 
-#### Application {#definitionsApplication}
+- [Definitions](#definitions)
+  - [Application](#definitionsApplication)
+  - [Producer](#definitionsProducer)
+  - [Consumer](#definitionsConsumer)
+  - [Message](#definitionsMessage)
+  - [Channel](#definitionsChannel)
+  - [Protocol](#definitionsProtocol)
+- [Specification](#specification)
+	- [Format](#format)
+	- [File Structure](#file-structure)
+	- [Schema](#schema)
+      - [AsyncAPI Object](#A2SObject)
+      - [AsyncAPI Version String](#A2SVersionString)
+      - [Info Object](#infoObject)
+      - [Contact Object](#contactObject)
+      - [License Object](#licenseObject)
+      - [Servers Object](#serversObject)
+      - [Channels Object](#channelsObject)
+      - [Channel Item Object](#channelItemObject)
+      - [Operation Object](#operationObject)
+      - [Operation Trait Object](#operationTraitObject)
+      - [Message Object](#messageObject)
+      - [Message Trait Object](#messageTraitObject)
+      - [Tags Object](#tagsObject)
+      - [External Documentation Object](#externalDocumentationObject)
+      - [Components Object](#componentsObject)
+      - [Reference Object](#referenceObject)
+      - [Schema Object](#schemaObject)
+      - [Security Scheme Object](#securitySchemeObject)
+      - [Parameters Object](#parametersObject)
+      - [Parameter Object](#parameterObject)
+      - [Server Bindings Object](#serverBindingsObject)
+      - [Channel Bindings Object](#channelBindingsObject)
+      - [Operation Bindings Object](#operationBindingsObject)
+      - [Message Bindings Object](#messageBindingsObject)
+      - [Correlation ID Object](#correlationIdObject)
+      - [Specification Extensions](#specificationExtensions)
+
+<!-- /TOC -->
+
+## <a name="definitions"/>Definitions
+
+#### <a name="definitionsApplication"></a>Application
 An application is any kind of computer program or a group of them. It MUST be a [producer](#definitionsProducer), a [consumer](#definitionsConsumer) or both. An application MAY be a microservice, IoT device (sensor), mainframe process, etc. An application MAY be written in any number of different programming languages as long as they support the selected [protocol](#definitionsProtocol). An application MUST also use a protocol supported by the server in order to connect and exchange [messages](#definitionsMessage).
 
-#### Producer {#definitionsProducer}
+#### <a name="definitionsProducer"></a>Producer
 A producer is a type of application, connected to a server, that is creating [messages](#definitionsMessage) and addressing them to [channels](#definitionsChannel). A producer MAY be publishing to multiple channels depending on the server, protocol, and use-case pattern. 
 
-#### Consumer {#definitionsConsumer}
+#### <a name="definitionsConsumer"></a>Consumer
 A consumer is a type of application, connected to a server via a supported [protocol](#definitionsProtocol), that is consuming [messages](#definitionsMessage) from [channels](#definitionsChannel). A consumer MAY be consuming from multiple channels depending on the server, protocol, and the use-case pattern. 
 
-#### Message {#definitionsMessage}
+#### <a name="definitionsMessage"></a>Message
 A message is the mechanism by which information is exchanged via a channel between servers and applications. A message MUST contain a payload and MAY also contain headers. The headers MAY be subdivided into [protocol](#definitionsProtocol)-defined headers and header properties defined by the application which can act as supporting metadata. The payload contains the data, defined by the application, which MUST be serialized into a format (JSON, XML, Avro, binary, etc.). Since a message is a generic mechanism, it can support multiple interaction patterns such as event, command, request, or response. 
 
-#### Channel {#definitionsChannel}
+#### <a name="definitionsChannel"></a>Channel
 A channel is an addressable component, made available by the server, for the organization of [messages](#definitionsMessage). [Producer](#definitionsProducer) applications send messages to channels and [consumer](#definitionsConsumer) applications consume messages from channels. Servers MAY support many channel instances, allowing messages with different content to be addressed to different channels. Depending on the server implementation, the channel MAY be included in the message via protocol-defined headers.
 
-#### Protocol {#definitionsProtocol}
+#### <a name="definitionsProtocol"></a>Protocol
 A protocol is the mechanism (wireline protocol OR API) by which [messages](#definitionsMessage) are exchanged between the application and the [channel](#definitionsChannel). Example protocol include, but are not limited to, AMQP, HTTP, JMS, Kafka, MQTT, STOMP, WebSocket.  
 
-## Specification {#specification}
+## <a name="specification"></a>Specification
 
-### Format {#format}
+### <a name="format"></a>Format
 
 The files describing the message-driven API in accordance with the AsyncAPI Specification are represented as JSON objects and conform to the JSON standards.
 YAML, being a superset of JSON, can be used as well to represent a A2S (AsyncAPI Specification) file.
@@ -75,7 +120,7 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 - Tags MUST be limited to those allowed by the [JSON Schema ruleset](http://www.yaml.org/spec/1.2/spec.html#id2803231)
 - Keys used in YAML maps MUST be limited to a scalar string, as defined by the YAML Failsafe schema ruleset
 
-### File Structure {#file-structure}
+### <a name="file-structure"></a>File Structure
 
 The A2S representation of the API is made of a single file.
 However, parts of the definitions can be split into separate files, at the discretion of the user.
@@ -83,9 +128,9 @@ This is applicable for `$ref` fields in the specification as follows from the [J
 
 By convention, the AsyncAPI Specification (A2S) file is named `asyncapi.json` or `asyncapi.yaml`.
 
-### Schema {#schema}
+### <a name="schema"></a>Schema
 
-#### AsyncAPI Object {#A2SObject}
+#### <a name="A2SObject"></a>AsyncAPI Object
 
 This is the root document object for the API specification.
 It combines resource listing and API declaration together into one document.
@@ -106,7 +151,7 @@ Field Name | Type | Description
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
 
-#### AsyncAPI Version String {#A2SVersionString}
+#### <a name="A2SVersionString"></a>AsyncAPI Version String
 
 The version string signifies the version of the AsyncAPI Specification that the document complies to.
 The format for this string _must_ be `major`.`minor`.`patch`.  The `patch` _may_ be suffixed by a hyphen and extra alphanumeric characters.
@@ -116,7 +161,7 @@ The patch version will not be considered by tooling, making no distinction betwe
 
 In subsequent versions of the AsyncAPI Specification, care will be given such that increments of the `minor` version should not interfere with operations of tooling developed to a lower minor version. Thus a hypothetical `1.1.0` specification should be usable with tooling designed for `1.0.0`.
 
-#### Identifier {#A2SIdString}
+#### <a name="A2SIdString"></a>Identifier
 
 This field represents a unique universal identifier of the [application](#definitionsApplication) the AsyncAPI document is defining. It must conform to the URI format, according to [RFC3986](http://tools.ietf.org/html/rfc3986).
 
@@ -144,7 +189,7 @@ id: 'urn:com:smartylighting:streetlights:server'
 id: 'https://github.com/smartylighting/streetlights-server'
 ```
 
-#### Info Object {#infoObject}
+#### <a name="infoObject"></a>Info Object
 
 The object provides metadata about the API.
 The metadata can be used by the clients if needed.
@@ -196,7 +241,7 @@ license:
 version: 1.0.1
 ```
 
-#### Contact Object {#contactObject}
+#### <a name="contactObject"></a>Contact Object
 
 Contact information for the exposed API.
 
@@ -226,7 +271,7 @@ url: http://www.example.com/support
 email: support@example.com
 ```
 
-#### License Object {#licenseObject}
+#### <a name="licenseObject"></a>License Object
 
 License information for the exposed API.
 
@@ -253,7 +298,7 @@ name: Apache 2.0
 url: http://www.apache.org/licenses/LICENSE-2.0.html
 ```
 
-#### Servers Object {#serversObject}
+#### <a name="serversObject"></a>Servers Object
 
 The Servers Object is a map of [Server Objects](#serverObject).
 
@@ -285,7 +330,7 @@ production:
 ```
 
 
-#### Server Object {#serverObject}
+#### <a name="serverObject"></a>Server Object
 
 An object representing a message broker, a server or any other kind of computer program capable of sending and/or receiving data. This object is used to capture details such as URIs, protocols and security configuration. Variable substitution can be used so that some details, for example usernames and passwords, can be injected by code generation tools.
 
@@ -327,46 +372,43 @@ The following shows how multiple servers can be described, for example, at the A
 
 ```json
 {
-  "servers": {
-    "development": {
+  "servers": [
+    {
       "url": "development.gigantic-server.com",
       "description": "Development server",
       "protocol": "amqp",
       "protocolVersion": "0.9.1"
     },
-    "staging": {
+    {
       "url": "staging.gigantic-server.com",
       "description": "Staging server",
       "protocol": "amqp",
       "protocolVersion": "0.9.1"
     },
-    "production": {
+    {
       "url": "api.gigantic-server.com",
       "description": "Production server",
       "protocol": "amqp",
       "protocolVersion": "0.9.1"
     }
-  }
+  ]
 }
 ```
 
 ```yaml
 servers:
-  development:
-    url: development.gigantic-server.com
-    description: Development server
-    protocol: amqp
-    protocolVersion: 0.9.1
-  staging:
-    url: staging.gigantic-server.com
-    description: Staging server
-    protocol: amqp
-    protocolVersion: 0.9.1
-  production:
-    url: api.gigantic-server.com
-    description: Production server
-    protocol: amqp
-    protocolVersion: 0.9.1
+- url: development.gigantic-server.com
+  description: Development server
+  protocol: amqp
+  protocolVersion: 0.9.1
+- url: staging.gigantic-server.com
+  description: Staging server
+  protocol: amqp
+  protocolVersion: 0.9.1
+- url: api.gigantic-server.com
+  description: Production server
+  protocol: amqp
+  protocolVersion: 0.9.1
 ```
 
 The following shows how variables can be used for a server configuration:
@@ -420,7 +462,7 @@ servers:
 ```
 
 
-#### Server Variable Object {#serverVariableObject}
+#### <a name="serverVariableObject"></a>Server Variable Object
 
 An object representing a Server Variable for server URL template substitution.
 
@@ -439,7 +481,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 
 
 
-#### Default Content Type {#defaultContentTypeString}
+#### <a name="defaultContentTypeString"></a>Default Content Type
 
 A string representing the default content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. `application/json`). This value MUST be used by schema parsers when the [contentType](#messageObjectContentType) property is omitted.
 
@@ -462,7 +504,7 @@ defaultContentType: application/json
 
 
 
-#### Channels Object {#channelsObject}
+#### <a name="channelsObject"></a>Channels Object
 
 Holds the relative paths to the individual channel and their operations. Channel paths are relative to servers.
 
@@ -495,7 +537,7 @@ user/signedup:
 
 
 
-#### Channel Item Object {#channelItemObject}
+#### <a name="channelItemObject"></a>Channel Item Object
 
 Describes the operations available on a single channel.
 
@@ -557,11 +599,10 @@ subscribe:
         user:
           $ref: "#/components/schemas/user"
         signup:
-bindings:
-  amqp:
-    is: queue
-    queue:
-      exclusive: true
+amqp:
+  is: queue
+  queue:
+    exclusive: true
 ```
 
 Using `oneOf` to specify multiple messages per operation:
@@ -593,7 +634,7 @@ subscribe:
 
 
 
-#### Operation Object {#operationObject}
+#### <a name="operationObject"></a>Operation Object
 
 Describes a publish or a subscribe operation. This provides a place to document how and why messages are sent and received. For example, an operation might describe a chat application use case where a user sends a text message to a group.
 
@@ -689,7 +730,7 @@ traits:
 
 
 
-#### Operation Trait Object {#operationTraitObject}
+#### <a name="operationTraitObject"></a>Operation Trait Object
 
 Describes a trait that MAY be applied to an [Operation Object](#operationObject). This object MAY contain any property from the [Operation Object](#operationObject), except `message` and `traits`.
 
@@ -729,7 +770,7 @@ bindings:
 
 
 
-#### Parameters Object {#parametersObject}
+#### <a name="parametersObject"></a>Parameters Object
 
 Describes a map of parameters included in a channel name.
 
@@ -776,7 +817,7 @@ user/{userId}/signup:
 
 
 
-#### Parameter Object {#parameterObject}
+#### <a name="parameterObject"></a>Parameter Object
 
 Describes a parameter included in a channel name.
 
@@ -826,7 +867,7 @@ user/{userId}/signup:
 
 
 
-#### Server Bindings Object {#serverBindingsObject}
+#### <a name="serverBindingsObject"></a>Server Bindings Object
 
 Map describing protocol-specific definitions for a server.
 
@@ -835,7 +876,7 @@ Map describing protocol-specific definitions for a server.
 Field Name | Type | Description
 ---|:---:|---
 <a name="serverBindingsObjectHTTP"></a>`http` | [HTTP Server Binding](https://github.com/asyncapi/bindings/blob/master/http#server) | Protocol-specific information for an HTTP server.
-<a name="serverBindingsObjectWebSockets"></a>`ws` | [WebSockets Server Binding](https://github.com/asyncapi/bindings/blob/master/websockets#server) | Protocol-specific information for a WebSockets server.
+<a name="serverBindingsObjectWebSockets"></a>`ws` | [WebSockets Server Binding](https://github.com/asyncapi/bindings/blob/master/ws#server) | Protocol-specific information for a WebSockets server.
 <a name="serverBindingsObjectKafka"></a>`kafka` | [Kafka Server Binding](https://github.com/asyncapi/bindings/blob/master/kafka#server) | Protocol-specific information for a Kafka server.
 <a name="serverBindingsObjectAMQP"></a>`amqp` | [AMQP Server Binding](https://github.com/asyncapi/bindings/blob/master/amqp#server) | Protocol-specific information for an AMQP 0-9-1 server.
 <a name="serverBindingsObjectAMQP1"></a>`amqp1` | [AMQP 1.0 Server Binding](https://github.com/asyncapi/bindings/blob/master/amqp1#server) | Protocol-specific information for an AMQP 1.0 server.
@@ -851,7 +892,7 @@ Field Name | Type | Description
 
 
 
-#### Channel Bindings Object {#channelBindingsObject}
+#### <a name="channelBindingsObject"></a>Channel Bindings Object
 
 Map describing protocol-specific definitions for a channel.
 
@@ -860,7 +901,7 @@ Map describing protocol-specific definitions for a channel.
 Field Name | Type | Description
 ---|:---:|---
 <a name="channelBindingsObjectHTTP"></a>`http` | [HTTP Channel Binding](https://github.com/asyncapi/bindings/blob/master/http/README.md#channel) | Protocol-specific information for an HTTP channel.
-<a name="channelBindingsObjectWebSockets"></a>`ws` | [WebSockets Channel Binding](https://github.com/asyncapi/bindings/blob/master/websockets/README.md#channel) | Protocol-specific information for a WebSockets channel.
+<a name="channelBindingsObjectWebSockets"></a>`ws` | [WebSockets Channel Binding](https://github.com/asyncapi/bindings/blob/master/ws/README.md#channel) | Protocol-specific information for a WebSockets channel.
 <a name="channelBindingsObjectKafka"></a>`kafka` | [Kafka Channel Binding](https://github.com/asyncapi/bindings/blob/master/kafka/README.md#channel) | Protocol-specific information for a Kafka channel.
 <a name="channelBindingsObjectAMQP"></a>`amqp` | [AMQP Channel Binding](https://github.com/asyncapi/bindings/blob/master/amqp/README.md#channel) | Protocol-specific information for an AMQP 0-9-1 channel.
 <a name="channelBindingsObjectAMQP1"></a>`amqp1` | [AMQP 1.0 Channel Binding](https://github.com/asyncapi/bindings/blob/master/amqp1/README.md#channel) | Protocol-specific information for an AMQP 1.0 channel.
@@ -876,7 +917,7 @@ Field Name | Type | Description
 
 
 
-#### Operation Bindings Object {#operationBindingsObject}
+#### <a name="operationBindingsObject"></a>Operation Bindings Object
 
 Map describing protocol-specific definitions for an operation.
 
@@ -885,7 +926,7 @@ Map describing protocol-specific definitions for an operation.
 Field Name | Type | Description
 ---|:---:|---
 <a name="operationBindingsObjectHTTP"></a>`http` | [HTTP Operation Binding](https://github.com/asyncapi/bindings/blob/master/http/README.md#operation) | Protocol-specific information for an HTTP operation.
-<a name="operationBindingsObjectWebSockets"></a>`ws` | [WebSockets Operation Binding](https://github.com/asyncapi/bindings/blob/master/websockets/README.md#operation) | Protocol-specific information for a WebSockets operation.
+<a name="operationBindingsObjectWebSockets"></a>`ws` | [WebSockets Operation Binding](https://github.com/asyncapi/bindings/blob/master/ws/README.md#operation) | Protocol-specific information for a WebSockets operation.
 <a name="operationBindingsObjectKafka"></a>`kafka` | [Kafka Operation Binding](https://github.com/asyncapi/bindings/blob/master/kafka/README.md#operation) | Protocol-specific information for a Kafka operation.
 <a name="operationBindingsObjectAMQP"></a>`amqp` | [AMQP Operation Binding](https://github.com/asyncapi/bindings/blob/master/amqp/README.md#operation) | Protocol-specific information for an AMQP 0-9-1 operation.
 <a name="operationBindingsObjectAMQP1"></a>`amqp1` | [AMQP 1.0 Operation Binding](https://github.com/asyncapi/bindings/blob/master/amqp1/README.md#operation) | Protocol-specific information for an AMQP 1.0 operation.
@@ -903,7 +944,7 @@ Field Name | Type | Description
 
 
 
-#### Message Bindings Object {#messageBindingsObject}
+#### <a name="messageBindingsObject"></a>Message Bindings Object
 
 Map describing protocol-specific definitions for a message.
 
@@ -912,7 +953,7 @@ Map describing protocol-specific definitions for a message.
 Field Name | Type | Description
 ---|:---:|---
 <a name="messageBindingsObjectHTTP"></a>`http` | [HTTP Message Binding](https://github.com/asyncapi/bindings/blob/master/http/README.md#message) | Protocol-specific information for an HTTP message, i.e., a request or a response.
-<a name="messageBindingsObjectWebSockets"></a>`ws` | [WebSockets Message Binding](https://github.com/asyncapi/bindings/blob/master/websockets/README.md#message) | Protocol-specific information for a WebSockets message.
+<a name="messageBindingsObjectWebSockets"></a>`ws` | [WebSockets Message Binding](https://github.com/asyncapi/bindings/blob/master/ws/README.md#message) | Protocol-specific information for a WebSockets message.
 <a name="messageBindingsObjectKafka"></a>`kafka` | [Kafka Message Binding](https://github.com/asyncapi/bindings/blob/master/kafka/README.md#message) | Protocol-specific information for a Kafka message.
 <a name="messageBindingsObjectAMQP"></a>`amqp` | [AMQP Message Binding](https://github.com/asyncapi/bindings/blob/master/amqp/README.md#message) | Protocol-specific information for an AMQP 0-9-1 message.
 <a name="messageBindingsObjectAMQP1"></a>`amqp1` | [AMQP 1.0 Message Binding](https://github.com/asyncapi/bindings/blob/master/amqp1/README.md#message) | Protocol-specific information for an AMQP 1.0 message.
@@ -933,7 +974,7 @@ Field Name | Type | Description
 
 
 
-#### Message Object {#messageObject}
+#### <a name="messageObject"></a>Message Object
 
 Describes a message received on a given channel and operation.
 
@@ -958,7 +999,7 @@ Field Name | Type | Description
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
 
-##### Schema formats table {#messageObjectSchemaFormatTable}
+##### <a name="messageObjectSchemaFormatTable"></a>Schema formats table
 
 The following table contains a set of values that every implementation MUST support.
 
@@ -1091,7 +1132,7 @@ payload:
 
 
 
-#### Message Trait Object {#messageTraitObject}
+#### <a name="messageTraitObject"></a>Message Trait Object
 
 Describes a trait that MAY be applied to a [Message Object](#messageObject). This object MAY contain any property from the [Message Object](#messageObject), except `payload` and `traits`.
 
@@ -1130,11 +1171,11 @@ schemaFormat: 'application/vnd.apache.avro+yaml;version=1.9.0'
 contentType: application/json
 ```
 
-#### Tags Object {#tagsObject}
+#### <a name="tagsObject"></a>Tags Object
 
 A Tags object is a list of Tag Objects.
 
-#### Tag Object {#tagObject}
+#### <a name="tagObject"></a>Tag Object
 
 Allows adding meta data to a single tag.
 
@@ -1167,7 +1208,7 @@ description: User-related messages
 
 
 
-#### External Documentation Object {#externalDocumentationObject}
+#### <a name="externalDocumentationObject"></a>External Documentation Object
 
 Allows referencing an external resource for extended documentation.
 
@@ -1194,7 +1235,7 @@ description: Find more info here
 url: https://example.com
 ```
 
-#### Reference Object {#referenceObject}
+#### <a name="referenceObject"></a>Reference Object
 
 A simple object to allow referencing other components in the specification, internally and externally.
 
@@ -1222,7 +1263,7 @@ This object cannot be extended with additional properties and any properties add
   $ref: '#/components/schemas/Pet'
 ```
 
-#### Components Object {#componentsObject}
+#### <a name="componentsObject"></a>Components Object
 
 Holds a set of reusable objects for different aspects of the AsyncAPI specification.
 All objects defined within the components object will have no effect on the API unless they are explicitly referenced from properties outside the components object.
@@ -1415,7 +1456,7 @@ components:
             maximum: 100
 ```
 
-#### Schema Object {#schemaObject}
+#### <a name="schemaObject"></a>Schema Object
 
 The Schema Object allows the definition of input and output data types.
 These types can be objects, but also primitives and arrays.
@@ -1481,7 +1522,7 @@ Field Name | Type | Description
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
 
-###### Composition and Inheritance (Polymorphism) {#schemaComposition}
+###### <a name="schemaComposition"></a>Composition and Inheritance (Polymorphism)
 
 The AsyncAPI Specification allows combining and extending model definitions using the `allOf` property of JSON Schema, in effect offering model composition.
 `allOf` takes in an array of object definitions that are validated *independently* but together compose a single object.
@@ -1815,7 +1856,7 @@ schemas:
 
 
 
-#### Security Scheme Object {#securitySchemeObject}
+#### <a name="securitySchemeObject"></a>Security Scheme Object
 
 Defines a security scheme that can be used by the operations. Supported schemes are:
 
@@ -1967,7 +2008,7 @@ flows:
       read:pets: read your pets
 ```
 
-#### OAuth Flows Object {#oauthFlowsObject}
+#### <a name="oauthFlowsObject"></a>OAuth Flows Object
 
 Allows configuration of the supported OAuth Flows.
 
@@ -1981,7 +2022,7 @@ Field Name | Type | Description
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
-#### OAuth Flow Object {#oauthFlowObject}
+#### <a name="oauthFlowObject"></a>OAuth Flow Object
 
 Configuration details for a supported OAuth Flow
 
@@ -2036,7 +2077,7 @@ flows:
       read:pets: read your pets
 ```
 
-#### Security Requirement Object {#securityRequirementObject}
+#### <a name="securityRequirementObject"></a>Security Requirement Object
 
 Lists the required security schemes to execute this operation.
 The name used for each property MUST correspond to a security scheme declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject).
@@ -2092,7 +2133,7 @@ petstore_auth:
 - read:pets
 ```
 
-### Correlation ID Object {#correlationIdObject}
+### <a name="correlationIdObject"></a>Correlation ID Object
 
 An object that specifies an identifier at design time that can used for message tracing and correlation. 
 
@@ -2121,7 +2162,7 @@ description: Default Correlation ID
 location: $message.header#/correlationId
 ```
 
-### Runtime Expression {#runtimeExpression}
+### <a name="runtimeExpression"></a>Runtime Expression
 
 A runtime expression allows values to be defined based on information that will be available within the message.
 This mechanism is used by [Correlation ID Object](#correlationIdObject).
@@ -2138,7 +2179,7 @@ The runtime expression is defined by the following [ABNF](https://tools.ietf.org
 
 The table below provides examples of runtime expressions and examples of their use in a value:
 
-##### Examples {#runtimeExpressionExamples}
+##### <a name="runtimeExpressionExamples"></a>Examples
 
 Source Location | Example expression  | Notes
 ---|:---|:---|
@@ -2147,7 +2188,7 @@ Message Payload Property | `$message.payload#/messageId` | Correlation ID is set
 
 Runtime expressions preserve the type of the referenced value.
 
-### Specification Extensions {#specificationExtensions}
+### <a name="specificationExtensions"></a>Specification Extensions
 
 While the AsyncAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.
 
@@ -2159,7 +2200,7 @@ Field Pattern | Type | Description
 
 The extensions may or may not be supported by the available tooling, but those may be extended as well to add requested support (if tools are internal or open-sourced).
 
-### Data Type Formats {#dataTypeFormat}
+### <a name="dataTypeFormat"></a>Data Type Formats
 
 Primitives have an optional modifier property: `format`.
 The AsyncAPI specification uses several known formats to more finely define the data type being used.

--- a/scripts/build-post-list.js
+++ b/scripts/build-post-list.js
@@ -88,8 +88,15 @@ function walkDirectories(directories, result, sectionWeight = 0, sectionTitle) {
 
 function slugifyToC(str) {
   let slug
+  // Try to match heading ids like {# myHeadingId}
   const headingIdMatch = str.match(/[\s]?\{\#([\w\d\-_]+)\}/)
-  if (headingIdMatch && headingIdMatch.length >= 2) slug = headingIdMatch[1]
+  if (headingIdMatch && headingIdMatch.length >= 2) {
+    slug = headingIdMatch[1]
+  } else {
+    // Try to match heading ids like {<a name="myHeadingId"/>}
+    const anchorTagMatch = str.match(/[\s]*<a[\s]+name="([\w\d\s\-_]+)"/)
+    if (anchorTagMatch && anchorTagMatch.length >= 2) slug = anchorTagMatch[1]
+  }
   return slug || slugify(str, { firsth1: true, maxdepth: 6 })
 }
 


### PR DESCRIPTION
**Description**

This PR makes it unnecessary to replace anchor tags like `<a name="definitionsProducer"/>` coming from the specification with something like `{# definitionsProducer}`. Therefore, no need for a preprocessing step when releasing a new version of the spec.

**Related issue(s)**
https://github.com/asyncapi/spec/issues/536