### PR TITLE
feat: add two new hiring positions and enable jobs board rss

### DIFF
--- a/components/Head.js
+++ b/components/Head.js
@@ -8,6 +8,8 @@ export default function HeadComponent({
   title,
   description = 'Open source tools to easily build and maintain your event-driven architecture. All powered by the AsyncAPI specification, the industry standard for defining asynchronous APIs.',
   image = '/img/social/card.png',
+  rssTitle = 'RSS Feed for AsyncAPI Initiative Blog',
+  rssLink = '/rss.xml'
 }) {
   const url = process.env.DEPLOY_PRIME_URL || process.env.DEPLOY_URL
   const { path = '' } = useContext(AppContext)
@@ -31,7 +33,7 @@ export default function HeadComponent({
       <meta httpEquiv="x-ua-compatible" content="ie=edge" />
       <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
       <meta name="description" content={description} />
-      <link rel="alternate" type="application/rss+xml" title="RSS Feed for AsyncAPI Initiative Blog" href="/rss.xml" />
+      <link rel="alternate" type="application/rss+xml" title={rssTitle} href={rssLink} />
 
       {/* Icons */}
       <link rel="icon" href="/favicon.ico" />

--- a/components/buttons/ApplyJob.js
+++ b/components/buttons/ApplyJob.js
@@ -1,9 +1,21 @@
 import Button from './Button'
 
 export default function ApplyJobButton({ job,  className = '' }) {
+
+  const getHref = (contact) => {
+
+    try {
+      new URL(contact);
+    } catch (_) {
+      return `mailto:${contact}`;  
+    }
+
+    return contact;
+  }
+
   return (
     <Button
-      href={`mailto:info@asyncapi.io?subject=Applying for the ${job.title} position`}
+      href={getHref(job.contact)}
       target="_blank"
       text="Apply for this job"
       className={className}

--- a/pages/jobs/apiture-api-architect.md
+++ b/pages/jobs/apiture-api-architect.md
@@ -1,7 +1,7 @@
 ---
 title: 'API Architect'
 date: 06/22/2021
-category: job category
+category: Architect
 closingOn: 08/22/2021
 company: 
   name: 'Apiture'

--- a/pages/jobs/apiture-api-architect.md
+++ b/pages/jobs/apiture-api-architect.md
@@ -3,6 +3,7 @@ title: 'API Architect'
 date: 06/22/2021
 category: Architect
 closingOn: 08/22/2021
+contact: https://apiture.com/careers/?gh_jid=5303104002
 company: 
   name: 'Apiture'
   logoUrl: /img/logos/companies/apiture.png

--- a/pages/jobs/dev-rel-postman.md
+++ b/pages/jobs/dev-rel-postman.md
@@ -1,0 +1,40 @@
+---
+title: 'Developer Advocate'
+date: 2021-07-01T06:00:00+01:00
+category: Education
+closingOn: 10/01/2021
+company: 
+  name: 'Postman'
+  logoUrl: /img/logos/companies/postman.svg
+---
+
+## About the team
+
+Postman is the world’s leading API collaboration platform used by more than 15 million developers and 500,000 organizations worldwide. Postman was founded on a straightforward premise: to simplify each step of building an API so developers could create better APIs—faster.
+
+Postman’s Open Technologies function was created to establish Postman as a leader in the API sector by investing in Open Specifications, Standards, Tooling, Data, and Policies as well as building strong relationships with thought leaders and organizations in the domain.
+
+Through our collaboration with the AsyncAPI Initiative, we are looking for a Developer Advocate to work closely with the AsyncAPI team within our Open Technologies function to help shape and build the future of API tooling. Everything is open-source and, therefore, much of your work will be open-source too.
+
+We believe that building a strong community and investing in their success is essential to our own success as a company. You will engage with open source communities on Github while collaborating within the AsyncAPI team to drive API better practices throughout the broader API ecosystem. In addition to advocacy, you will also have shared responsibilities for user education and community engagement.
+
+## Responsibilities
+
+- Engage with various kinds of AsyncAPI users (including developers, testers, architects, and more) to understand their perspectives, workflows, and use cases.
+- Drive API better practices by creating blog and video content, developing code samples and open source tools, and/or speaking at events
+- Collaborate closely with technical writers to ensure docs and learning materials align with community needs which includes assisting with AsyncAPI documentation, tutorials, and other education efforts within Open Technologies
+- Assist with AsyncAPI communication channels, events, and other community engagement 
+- Dogfood AsyncAPI technology, and interpret user data and community feedback, to drive insights and assist product development
+- Represent the company online and at events
+
+
+## About You
+- Strong familiarity and knowledge of open source development and communities. Nice to have proven experience within the field
+- Strong written, verbal, and interpersonal skills with the proven ability to communicate effectively at all levels internally and externally and across diverse geographies and leveraging remote teaming technologies
+- Demonstrated experience working with developer communities and APIs on GitHub, blog posts, and/or videos. This is a critical aspect of the role. 
+- Two years of programming experience, or a willingness and aptitude for learning technology
+- Experience making data-driven decisions.
+
+## What Else? (Remote Benefits)
+
+We offer competitive salary and benefits, and a flexible schedule working with a fun, collaborative team. Enjoy full medical coverage, unlimited PTO, and a monthly lunch stipend. (Yes, seriously. We want you to eat well wherever you’re at.) Plus, our wellness program will help you stay healthy from your location with fitness-related reimbursements. Our frequent and fascinating virtual team-building events will keep you connected, while our donation-matching program can support the causes you care about. We’re building a long-term company with an inclusive culture where everyone can be the best version of themselves, and we want you to be part of it. Join us, why dontcha?

--- a/pages/jobs/dev-rel-postman.md
+++ b/pages/jobs/dev-rel-postman.md
@@ -3,6 +3,7 @@ title: 'Developer Advocate'
 date: 2021-07-01T06:00:00+01:00
 category: Education
 closingOn: 10/01/2021
+contact: https://www.postman.com/company/careers/developer-advocate-open-technologies-4360218003/
 company: 
   name: 'Postman'
   logoUrl: /img/logos/companies/postman.svg

--- a/pages/jobs/index.js
+++ b/pages/jobs/index.js
@@ -30,6 +30,7 @@ title: 'Job Title'
 date: MM/DD/YYYY (current date)
 category: job category
 closingOn: MM/DD/YYYY
+contact: provide link to oryginal job posting or a contact email address
 company: 
   name: 'YourCompanyName'
   logoUrl: /img/logos/companies/YourCompanyName.png

--- a/pages/jobs/index.js
+++ b/pages/jobs/index.js
@@ -61,7 +61,7 @@ const jobPostUrl = encodeURIComponent(body);
 const hasPosts = Object.keys(posts).length;
   return (
     <div>
-      <Head title="Jobs" />
+      <Head title="Jobs" rssTitle="RSS Feed for AsyncAPI Initiative Jobs Board" rssLink = "/jobs/rss.xml" />
       <Container>
         <NavBar />
       </Container>
@@ -83,6 +83,9 @@ const hasPosts = Object.keys(posts).length;
             </p>
             <p className="max-w-2xl mx-auto text-md leading-7 text-gray-400"> Do you want to discuss your job offer first?
             <a className="ml-1 text-primary-500 hover:text-primary-400" href="https://github.com/asyncapi/website/issues/new" target="_blank">Get started here.</a>
+            </p>
+            <p className="max-w-2xl mx-auto text-md leading-7 text-gray-400">
+              We have an <img className="ml-1 text-primary-500 hover:text-primary-400" style={{ display: 'inline' }} src="/img/logos/rss.svg" height="18px" width="18px" /> <a className="ml-1 text-primary-500 hover:text-primary-400" href="jobs/rss.xml">RSS Feed</a> too!
             </p>
           </div>
           <div className="text-center">

--- a/pages/jobs/tech-writer-postman.md
+++ b/pages/jobs/tech-writer-postman.md
@@ -3,6 +3,7 @@ title: 'Technical Writer'
 date: 2021-07-01T06:00:00+01:00
 category: Education
 closingOn: 10/01/2021
+contact: https://www.postman.com/company/careers/technical-writer-open-technologies-4360221003/
 company: 
   name: 'Postman'
   logoUrl: /img/logos/companies/postman.svg

--- a/pages/jobs/tech-writer-postman.md
+++ b/pages/jobs/tech-writer-postman.md
@@ -1,0 +1,42 @@
+---
+title: 'Technical Writer'
+date: 2021-07-01T06:00:00+01:00
+category: Education
+closingOn: 10/01/2021
+company: 
+  name: 'Postman'
+  logoUrl: /img/logos/companies/postman.svg
+---
+
+## About the team
+
+Postman is the world’s leading API collaboration platform used by more than 15 million developers and 500,000 organizations worldwide. Postman was founded on a straightforward premise: to simplify each step of building an API so developers could create better APIs—faster. 
+
+Postman’s Open Technologies function was created to establish Postman as a leader in the API sector by investing in Open Specifications, Standards, Tooling, Data, and Policies as well as building strong relationships with thought leaders and organizations in the domain. 
+
+Through our collaboration with the AsyncAPI Initiative, we are looking for a Technical Writer to work closely with the AsyncAPI team within our Open Technologies function to help shape and build the future of API tooling. This Technical Writer will work to improve and organize documentation around open source tools so developers can easily build and maintain event-driven architecture powered by the AsyncAPI specification - the industry standard for defining asynchronous APIs. 
+
+As the Open Technologies Technical Writer, you will help create a foundation of learning material that will scale up for a rapidly growing AsyncAPI user base. Everything is open-source and, therefore, much of your work will be open-source too. If supporting open source learners sounds like the kind of challenge you’d like to tackle, apply to join us! 
+
+## Responsibilities
+
+- Own the docs for the AsyncAPI feature set—you’ll be responsible for documenting this specific area of our Open Technologies function and will drive all docs efforts around it
+- Plan documentation in conjunction with community feedback—you’ll work with open source communities to learn about a feature from specifications, user research, and most importantly through your own hands-on experimentation with the product
+- Collaborate closely with developer relations to ensure docs and learning materials align with community needs which includes assisting with AsyncAPI documentation, tutorials, and other education efforts within Open Technologies
+- Carry out editorial reviews on your docs teammates’ drafts—you’ll be providing constructive feedback that helps your colleagues to grow, as well as receiving it
+- Deliver high-quality, accurate documentation that acts as an effective learning resource, aligns with content strategy guidelines, and represents the AsyncAPI specification to community and customers
+- Liaise with stakeholders across the AsyncAPI Initiative to establish and address docs needs
+- Open to learning how to write the occasional code sample to include within documentation
+
+## About You
+- At least 1 year of experience with the Docs as Code/Docs like Code approach to documentation, writing Markdown-based content, working in an Agile environment, and using open source tooling
+- Self-starter—you can pick up tech skills with minimal support and guidance and have a curiosity about learning development workflows and practices
+- Problem solver—you take a broad view of the role your docs work plays within the organization and are comfortable with shifting priorities
+- User empathy—maybe you’ve been involved in tech support, in a community or customer facing role, you’ve helped people learn tech skills, or you’ve sought user feedback on docs in the past
+- Strong communicator—you’ve written technical material before, whether official documentation or just your own tutorials on tech skills you wanted to share, and your communication skills carry over into the way you engage with teammates
+- Distributed team member—you’re comfortable working within a diverse global team in multiple time zones
+- Nice to have developer knowledge—ideally you’ve worked with APIs and/or open source tooling in some form, maybe you’ve worked as a developer, or you’ve written a little bit of code here and there, but whatever your skill level you’re happy to have a go at developer tasks where they support the documentation effort 
+
+## What Else? (Remote Benefits)
+
+We offer competitive salary and benefits, and a flexible schedule working with a fun, collaborative team. Enjoy full medical coverage, unlimited PTO, and a monthly lunch stipend. (Yes, seriously. We want you to eat well wherever you’re at.) Plus, our wellness program will help you stay healthy from your location with fitness-related reimbursements. Our frequent and fascinating virtual team-building events will keep you connected, while our donation-matching program can support the causes you care about. We’re building a long-term company with an inclusive culture where everyone can be the best version of themselves, and we want you to be part of it. Join us, why dontcha?

--- a/pages/jobs/ui-ux-dx-designer.md
+++ b/pages/jobs/ui-ux-dx-designer.md
@@ -8,7 +8,7 @@ company:
   logoUrl: /img/logos/companies/postman.svg
 ---
 
-We're a tiny team working on the AsyncAPI Initiative. We're hiring a UI/UX/DX designer to help us design more awesome UI and CLI tools for developers.
+We are a tiny team working on the AsyncAPI Initiative. We are hiring a UI/UX/DX designer to help us design more awesome UI and CLI tools for developers.
 
 ## TL;DR
 

--- a/pages/jobs/ui-ux-dx-designer.md
+++ b/pages/jobs/ui-ux-dx-designer.md
@@ -3,6 +3,7 @@ title: 'UI/UX/DX Designer'
 date: 2020-12-02T16:56:52+01:00
 category: Design
 closingOn: 10/01/2021
+contact: https://www.postman.com/company/careers/product-designer-open-technologies-4359182003/
 company: 
   name: 'Postman'
   logoUrl: /img/logos/companies/postman.svg

--- a/public/jobs/.gitignore
+++ b/public/jobs/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/scripts/build-rss.js
+++ b/scripts/build-rss.js
@@ -15,9 +15,9 @@ function clean(s) {
   return s
 }
 
-function rssFeed() {
+function rssFeed(type, title, desc, outputPath) {
   const posts = getAllPosts()
-    .filter(p => p.slug.startsWith('/blog/'))
+    .filter(p => p.slug.startsWith(`/${type}/`))
     .sort((i1, i2) => {
       const i1Date = new Date(i1.date)
       const i2Date = new Date(i2.date)
@@ -35,13 +35,13 @@ function rssFeed() {
   rss['@version'] = '2.0'
   rss["@xmlns:atom"] = 'http://www.w3.org/2005/Atom'
   rss.channel = {}
-  rss.channel.title = 'AsyncAPI Initiative Blog RSS Feed'
-  rss.channel.link = base+'/rss.xml'
+  rss.channel.title = title
+  rss.channel.link = `${base}/${outputPath}`
   rss.channel["atom:link"] = {}
   rss.channel["atom:link"]["@rel"] = 'self'
   rss.channel["atom:link"]["@href"] = rss.channel.link
   rss.channel["atom:link"]["@type"] = 'application/rss+xml'
-  rss.channel.description = 'AsyncAPI Initiative Blog'
+  rss.channel.description = desc
   rss.channel.language = 'en-gb';
   rss.channel.copyright = 'Made with :love: by the AsyncAPI Initiative.';
   rss.channel.webMaster = 'info@asyncapi.io (AsyncAPI Initiative)'
@@ -51,7 +51,7 @@ function rssFeed() {
 
   for (let post of posts) {
     const link = `${base}${post.slug}${tracking}`;
-    const item = { title: post.title, description: clean(post.excerpt), link, category: 'blog', guid: { '@isPermaLink': true, '': link }, pubDate: new Date(post.date).toUTCString() }
+    const item = { title: post.title, description: clean(post.excerpt), link, category: type, guid: { '@isPermaLink': true, '': link }, pubDate: new Date(post.date).toUTCString() }
     if (post.cover) {
       const enclosure = {};
       enclosure["@url"] = base+post.cover;
@@ -71,7 +71,8 @@ function rssFeed() {
   feed.rss = rss
 
   const xml = json2xml.getXml(feed,'@','',2)
-  fs.writeFileSync('./public/rss.xml',xml,'utf8')
+  fs.writeFileSync(`./public/${outputPath}`, xml, 'utf8')
 }
 
-rssFeed()
+rssFeed('blog', 'AsyncAPI Initiative Blog RSS Feed', 'AsyncAPI Initiative Blog', 'rss.xml')
+rssFeed('jobs', 'AsyncAPI Initiative Jobs RSS Feed', 'AsyncAPI Initiative Jobs Board', 'jobs/rss.xml')


### PR DESCRIPTION
- new positions from postman
- we still promote rss to blog on all asyncapi pages, except of jobs
- generation of rss dedicated to jobs so people can set up alerts and get info about new jobs. Something to consider for the `jobs` channel on slack
- modify apply button