### PR TITLE
docs: update getting-started with the strongest version to date

### DIFF
--- a/components/DemoAnimation.js
+++ b/components/DemoAnimation.js
@@ -43,7 +43,7 @@ export default function DemoAnimation({ className = '' }) {
     const common = (
       <>
         <div>
-          <span className="text-teal-400">asyncapi:</span> 2.0.0
+          <span className="text-teal-400">asyncapi:</span> 2.1.0
         </div>
         <div>
           <span className="text-teal-400">info:</span>

--- a/components/buttons/OpenInPlaygroundButton.js
+++ b/components/buttons/OpenInPlaygroundButton.js
@@ -2,7 +2,7 @@ import Button from './Button'
 import IconRocket from '../icons/Rocket'
 
 export default function OpenInPlaygroundButton() {
-  const playgroundLoadUrl = encodeURI('https://raw.githubusercontent.com/asyncapi/asyncapi/master/examples/2.0.0/simple.yml')
+  const playgroundLoadUrl = encodeURI('https://raw.githubusercontent.com/asyncapi/asyncapi/v2.1.0/examples/simple.yml')
   return (
     <Button
       className="block mt-2 md:mt-0 md:inline-block md:ml-2"
@@ -14,4 +14,3 @@ export default function OpenInPlaygroundButton() {
     />
   )
 }
-

--- a/pages/docs/getting-started/asyncapi-documents.md
+++ b/pages/docs/getting-started/asyncapi-documents.md
@@ -12,7 +12,7 @@ An AsyncAPI document is a file that defines and annotates the different componen
 The format of the file must be JSON or YAML, however, only the subset of YAML that matches the JSON capabilities is allowed.
 
 <CodeBlock>
-{`asyncapi: 2.0.0
+{`asyncapi: 2.1.0
 info:
   title: Example
   version: 0.1.0

--- a/pages/docs/getting-started/coming-from-openapi.md
+++ b/pages/docs/getting-started/coming-from-openapi.md
@@ -19,8 +19,8 @@ Aside from structural differences you must know that:
 
 1. AsyncAPI is compatible with OpenAPI schemas.
 1. Message payload in AsyncAPI can be any value, not just an AsyncAPI/OpenAPI schema. For instance, it could be an Avro schema.
-1. [AsyncAPI server object](/docs/specifications/2.0.0/#serverObject) is almost identical to its OpenAPI counterpart with the exception that `scheme` has been renamed to `protocol` and AsyncAPI introduces a new property called `protocolVersion`.
-1. OpenAPI path parameters and [AsyncAPI channel parameters](/docs/specifications/2.0.0/#parameterObject) are a bit different since AsyncAPI doesn't have the notion of "query" and "cookie", and header parameters can be defined in the [message object](/docs/specifications/2.0.0/#messageObject). Therefore, AsyncAPI channel parameters are the equivalent of OpenAPI path parameters.
+1. [AsyncAPI server object](/docs/specifications/2.1.0/#serverObject) is almost identical to its OpenAPI counterpart with the exception that `scheme` has been renamed to `protocol` and AsyncAPI introduces a new property called `protocolVersion`.
+1. OpenAPI path parameters and [AsyncAPI channel parameters](/docs/specifications/2.1.0/#parameterObject) are a bit different since AsyncAPI doesn't have the notion of "query" and "cookie", and header parameters can be defined in the [message object](/docs/specifications/2.1.0/#messageObject). Therefore, AsyncAPI channel parameters are the equivalent of OpenAPI path parameters.
 
 ## Conclusion
 

--- a/pages/docs/getting-started/hello-world.md
+++ b/pages/docs/getting-started/hello-world.md
@@ -10,7 +10,7 @@ weight: 30
 Let's define an application that's capable of receiving a "hello {name}" message.
 
 <CodeBlock>
-{`asyncapi: 2.0.0
+{`asyncapi: 2.1.0
 info:
   title: Hello world application
   version: '0.1.0'
@@ -26,7 +26,7 @@ channels:
 Let's get into the details of the sample specification:
 
 <CodeBlock highlightedLines={[1]}>
-{`asyncapi: 2.0.0
+{`asyncapi: 2.1.0
 info:
   title: Hello world application
   version: '0.1.0'
@@ -39,10 +39,10 @@ channels:
           pattern: '^hello .+$'`}
 </CodeBlock>
 
-The first line of the specification starts with the document type, `asyncapi`, and the version (2.0.0). This line doesn't have to be the first one but it's a recommended practice.
+The first line of the specification starts with the document type, `asyncapi`, and the version (2.1.0). This line doesn't have to be the first one but it's a recommended practice.
 
 <CodeBlock highlightedLines={[2,3,4]}>
-{`asyncapi: 2.0.0
+{`asyncapi: 2.1.0
 info:
   title: Hello world application
   version: '0.1.0'
@@ -58,7 +58,7 @@ channels:
 The `info` object contains the minimum required information about the application. It contains the `title`, which is a memorable name for the API, and the `version`. While it's not mandatory, it is strongly recommended to change the version whenever you make changes to the API.
 
 <CodeBlock highlightedLines={[5,6,7,8,9,10,11]}>
-{`asyncapi: 2.0.0
+{`asyncapi: 2.1.0
 info:
   title: Hello world application
   version: '0.1.0'
@@ -76,7 +76,7 @@ The `channels` section of the specification houses all of the mediums where mess
 In this example, you only have one channel called `hello`. The sample app subscribes to this channel to receive `hello {name}` messages.
 
 <CodeBlock highlightedLines={[6,7,8,9]}>
-{`asyncapi: 2.0.0
+{`asyncapi: 2.1.0
 info:
   title: Hello world application
   version: '0.1.0'
@@ -93,7 +93,7 @@ You can read the highlighted lines as:
 > This is the `payload` of the `message` that `Hello world application` is subscribed to. You can `publish` the `message` to `hello` channel and `Hello world application` app will receive it.
 
 <CodeBlock highlightedLines={[9,10,11]}>
-{`asyncapi: 2.0.0
+{`asyncapi: 2.1.0
 info:
   title: Hello world application
   version: '0.1.0'

--- a/pages/docs/getting-started/index.md
+++ b/pages/docs/getting-started/index.md
@@ -13,7 +13,7 @@ AsyncAPI is an open source initiative that seeks to improve the current state of
 
 To make this happen, the first step has been to create a specification that allows **developers, architects, and product managers** to define the interfaces of an async API. Much like [OpenAPI (fka Swagger)](https://github.com/OAI/OpenAPI-Specification) does for REST APIs.
 
-**The AsyncAPI specification settles the base for a greater and better tooling ecosystem for EDA's**. We recently launched AsyncAPI specification 2.0.0 —the strongest version to date— that will sustain the event-driven architectures of tomorrow.
+**The AsyncAPI specification settles the base for a greater and better tooling ecosystem for EDA's**. We recently launched AsyncAPI specification 2.1.0 —the strongest version to date— that will sustain the event-driven architectures of tomorrow.
 
 If you are looking for a solution to automate and formalize the documentation or code generation of your event-driven (micro)services, you are in the right place. Likewise, if you are aiming to establish solid standards for your events and improve the governance of your asynchronous APIs, welcome to your new home.
 

--- a/pages/docs/getting-started/security.md
+++ b/pages/docs/getting-started/security.md
@@ -19,7 +19,7 @@ If you're using AsyncAPI to define an API that connects to a message broker, you
 Continuing with the `hello world` application example, let's learn how to define a simple security scheme (mechanism) for it.
 
 <CodeBlock highlightedLines={[10,11,42,43,44]}>
-{`asyncapi: '2.0.0'
+{`asyncapi: '2.1.0'
 info:
   title: Hello world application
   version: '0.1.0'
@@ -72,7 +72,7 @@ The example above shows how to specify that your server (the Kafka broker) requi
 
 <Remember title="Hint">
 
-There are many more security schemes. Learn more about them <a href="/docs/specifications/2.0.0/#securitySchemeObject" className="text-teal-600 font-medium hover:underline">here</a>.
+There are many more security schemes. Learn more about them <a href="/docs/specifications/2.1.0/#securitySchemeObject" className="text-teal-600 font-medium hover:underline">here</a>.
 
 </Remember>
 

--- a/pages/docs/getting-started/servers.md
+++ b/pages/docs/getting-started/servers.md
@@ -12,7 +12,7 @@ In the previous lesson, you learned how to create the definition of a simple [He
 In this article, you learn how to add `servers` to your AsyncAPI document. Adding and defining servers is useful because it specifies where and how to connect. The connection facilitates where to send and receive messages.
 
 <CodeBlock highlightedLines={[5,6,7,8,9]}>
-{`asyncapi: 2.0.0
+{`asyncapi: 2.1.0
 info:
   title: Hello world application
   version: '0.1.0'

--- a/pages/docs/tutorials/streetlights.md
+++ b/pages/docs/tutorials/streetlights.md
@@ -23,7 +23,7 @@ You'll use Node.js to code APIs and Mosquitto as the message broker. Selected te
 Let's start by creating an AsyncAPI file to describe your API. It will help you generate the code and the documentation later.
 
 <CodeBlock>
-{`asyncapi: '2.0.0'
+{`asyncapi: '2.1.0'
 info:
   title: Streetlights API
   version: '1.0.0'
@@ -64,7 +64,7 @@ channels:
 Let's break it down into pieces:
 
 <CodeBlock>
-{`asyncapi: '2.0.0'
+{`asyncapi: '2.1.0'
 info:
   title: Streetlights API
   version: '1.0.0'
@@ -132,7 +132,7 @@ To generate your code you'll use the [AsyncAPI Generator](https://github.com/asy
 ### 3. Create a file with the AsyncAPI machine-readable description you defined before. On Windows use `type` instead of `cat`:
 <CodeBlock language="yaml">
 {`cat <<EOT >> asyncapi.yaml
-asyncapi: '2.0.0'
+asyncapi: '2.1.0'
 info:
   title: Streetlights API
   version: '1.0.0'


### PR DESCRIPTION
The getting-started page includes a sentence about the “strongest”
version to date. Since the recent release of 2.1.0 of AsyncAPI spec,
let's update the number here too 🙂