### PR TITLE
chore(jobs): fix link to article on event driven arch

### DIFF
--- a/pages/docs/getting-started/servers.md
+++ b/pages/docs/getting-started/servers.md
@@ -38,7 +38,7 @@ You might have noticed that the example mentions `amqp`. This protocol is very c
 
 The `servers` section defines where your application should connect to start sending and receiving messages. 
 
-1. If you are using a <a href="https://fmvilas.com/event-driven-architectures-asyncapi/" target="_blank" className="text-teal-600 font-medium hover:underline">broker-centric architecture</a> such as Kafka or RabbitMQ, usually you specify the URL of the broker. 
+1. If you are using a <a href="https://dev.to/fmvilas/event-driven-architectures--asyncapi-db7" target="_blank" className="text-teal-600 font-medium hover:underline">broker-centric architecture</a> such as Kafka or RabbitMQ, usually you specify the URL of the broker. 
 2. If you have the classic client-server model such as for REST APIs, then your `server` should be the URL of the server.
 
 </Remember>


### PR DESCRIPTION
I've update a link in the doc that was not working