### PR TITLE
feat: add button in the modelina page with scroll into playground section functionality

### DIFF
--- a/components/buttons/Button.js
+++ b/components/buttons/Button.js
@@ -8,12 +8,13 @@ export default function Button({
   className,
   bgClassName = 'bg-primary-500 hover:bg-primary-400',
   textClassName = 'text-white hover:text-white',
+  ...props
 }) {
   const classNames = `${bgClassName} ${textClassName} shadow-md hover:shadow-lg transition-all duration-500 ease-in-out rounded px-4 py-3 text-white ${className || ''}`
   
   if (!href) {
     return (
-      <button type={type} className={classNames}>
+      <button {...props} type={type} className={classNames}>
         {
           icon && iconPosition === 'left' && (
             <span className="inline-block mr-2">{icon}</span>
@@ -30,7 +31,7 @@ export default function Button({
   }
 
   return (
-    <a href={href} target={target} className={classNames}>
+    <a {...props} href={href} target={target} className={classNames}>
       {
         icon && iconPosition === 'left' && (
           <span className="inline-block mr-2">{icon}</span>

--- a/pages/modelina.js
+++ b/pages/modelina.js
@@ -1,11 +1,12 @@
-import GenericWideLayout from '../components/layout/GenericWideLayout'
 import GenericLayout from '../components/layout/GenericLayout'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import Select from '../components/form/Select'
 import CodeBlock from '../components/editor/CodeBlock'
 import Tabs from '../components/tabs/Tabs'
 import modelinaLanguageOptions from '../config/modelina-language-options.json'
 import GithubButton from '../components/buttons/GithubButton'
+import Button from '../components/buttons/Button'
+import IconRocket from '../components/icons/Rocket'
 import MonacoEditorWrapper from '../components/editor/MonacoEditorWrapper'
 import {parse} from '@asyncapi/parser'
 import TypeScriptOptions from '../components/modelina/TypeScriptGenerator'
@@ -182,6 +183,7 @@ const models = await generator.generate(input)`
 
 export default function ModelinaPlaygroundPage() {
   const [error, setError] = useState();
+  const tryItOutRef = useRef(null);
 
   const description = 'Sometimes you just want to generate data models for your payload.';
   const image = '/img/social/modelina.png';
@@ -251,8 +253,17 @@ export default function ModelinaPlaygroundPage() {
               <CodeBlock language="bash" showLineNumbers={false} className="mt-8">npm install @asyncapi/modelina</CodeBlock>
               <div className="mt-8">
                 <GithubButton
-                  className="w-full sm:w-auto mt-8"
+                  className="block mt-2 md:mt-0 md:inline-block w-full sm:w-auto mt-8"
                   href="https://www.github.com/asyncapi/modelina"
+                />
+                <Button 
+                  className="hidden mt-2 md:mt-0 lg:inline-block md:ml-2" 
+                  text="Try it now"
+                  icon={<IconRocket className="inline-block -mt-1 w-6 h-6" />}
+                  onClick={() => {
+                    const element = tryItOutRef.current;
+                    element && typeof element.scrollIntoView === 'function' && element.scrollIntoView({ behavior: 'smooth' });
+                  }}
                 />
               </div>
             </div>
@@ -262,7 +273,9 @@ export default function ModelinaPlaygroundPage() {
           </div>
         </div>
 
-        {playground}
+        <div ref={tryItOutRef}>
+          {playground}
+        </div>
 
         {error && (
           <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-2 rounded relative" role="alert">


### PR DESCRIPTION
As in title:

Add `Try it now` button (next to the Github button) in the modelina page with scroll into playground section functionality.

Slask discussion:

![image](https://user-images.githubusercontent.com/20404945/132236303-2627aa7b-cd13-4169-833b-f996ad088452.png)

Example:

https://user-images.githubusercontent.com/20404945/132236139-b4e396cd-7d37-4e58-8b7a-c3ff6eb83da7.mov

