### PR TITLE
feat: hide job posts from Postman as we already hired

### DIFF
--- a/pages/jobs/index.js
+++ b/pages/jobs/index.js
@@ -10,11 +10,9 @@ import AnnouncementHero from "../../components/campaigns/AnnoucementHero";
 import Empty from "../../components/illustrations/empty";
 
 export default function JobsIndexPage() {
-  const { navItems } = useContext(JobsContext);
-  navItems.map((job, index) => {
-    if (new Date().getTime() > new Date(job.closingOn).getTime()) {
-      navItems.splice(index, 1);
-    }
+  let { navItems } = useContext(JobsContext);
+  navItems = navItems.filter((job) => {
+    return new Date() <= new Date(job.closingOn)
   });
   const [posts, setPosts] = useState(
     navItems.sort((i1, i2) => {

--- a/pages/jobs/ui-ux-dx-designer.md
+++ b/pages/jobs/ui-ux-dx-designer.md
@@ -1,8 +1,8 @@
 ---
 title: 'UI/UX/DX Designer'
-date: 2020-12-02T16:56:52+01:00
+date: 2021-07-01T06:00:00+01:00
 category: Design
-closingOn: 10/01/2021
+closingOn: 09/15/2021
 contact: https://www.postman.com/company/careers/product-designer-open-technologies-4582365003/
 company: 
   name: 'Postman'


### PR DESCRIPTION
I'm removing all the Postman open positions as we already hired for them.

I'm now wondering if we should keep them as "Closed" or "Hired" to show others this is actually working. What do you think?