### PR TITLE
feat: updating visuals for conference and hackaton on main page

### DIFF
--- a/components/Hero.js
+++ b/components/Hero.js
@@ -6,21 +6,20 @@ import AnnouncementHero from './campaigns/AnnoucementHero'
 
 export default function Hero ({ className = '' }) {
   return (
-    <div className={`px-2 mt-12 ${className}`}>
+    <div className={`px-2 mt-6 ${className}`}>
       <div className="text-center">
         <AnnouncementHero />
-
-        <h1 className="text-primary-800 text-3xl font-bold md:text-4xl mb-4">
-          Building the future of event-driven architecture.
+        <h1 className="text-primary-800 text-2xl font-bold md:text-6xl mb-4 leading-snug">
+          Building the future of {` `}
+          <span className="text-primary-400 block"> event-driven architecture.</span>
         </h1>
-        <h2 className="text-gray-500 text-xl font-normal mb-6 max-w-3xl mx-auto">
+        <h2 className="text-gray-500 text-lg font-normal mb-16 max-w-3xl mx-auto">
           Open source tools to easily build and maintain your event-driven architecture.
           All powered by the AsyncAPI specification, the <strong>industry standard</strong> for defining asynchronous APIs.
         </h2>
         <Button className="block md:inline-block" text="Read the docs" href="/docs/getting-started" icon={<ArrowRight className="-mb-1 h-5 w-5" />} />
         <OpenInPlaygroundButton />
       </div>
-
       <div className="mt-8 md:mt-16">
         <DemoAnimation />
       </div>

--- a/components/Hero.js
+++ b/components/Hero.js
@@ -14,7 +14,7 @@ export default function Hero ({ className = '' }) {
           <span className="text-primary-400 block"> event-driven architecture.</span>
         </h1>
         <h2 className="text-gray-500 text-lg font-normal mb-16 max-w-3xl mx-auto">
-          Open source tools to easily build and maintain your event-driven architecture.
+          Open Source tools to easily build and maintain your event-driven architecture.
           All powered by the AsyncAPI specification, the <strong>industry standard</strong> for defining asynchronous APIs.
         </h2>
         <Button className="block md:inline-block" text="Read the docs" href="/docs/getting-started" icon={<ArrowRight className="-mb-1 h-5 w-5" />} />

--- a/components/campaigns/AnnoucementHero.js
+++ b/components/campaigns/AnnoucementHero.js
@@ -12,7 +12,7 @@ export default function AnnouncementHero({ className = '', small = false }) {
       {!small && 
         <>
           <p className=" text-gray-700 md:hidden text-xs  my-2 text-center">Connect and innovate with the AsyncAPI Community.</p>
-          <p className=" text-gray-700 hidden md:block max-w-3xl mx-auto  my-2 text-center">First day of the conference is dedicated entirely to folks that want to contribute to AsyncAPI Initiative. Next two days of the conference are a pure learning experience, community for the community.</p>
+          <p className=" text-gray-700 hidden md:block max-w-3xl mx-auto  my-2 text-center">The first day of the conference is dedicated entirely for folks that want to contribute to AsyncAPI Initiative. The next two days of the conference are a pure learning experience, community for the community.</p>
         </>
       }
       <div className="mt-8 pb-2 space-x-2">

--- a/components/campaigns/AnnoucementHero.js
+++ b/components/campaigns/AnnoucementHero.js
@@ -8,7 +8,7 @@ export default function AnnouncementHero({ className = '', small = false }) {
 
   return (
     <div className={`bg-gray-50 border border-gray-200 py-6  ${className} ${small ? 'mb-0' : 'mb-12'}`}>
-      <h2 className="text-xl md:text-3xl">AsyncAPI Conference (Nov 16-18)</h2>
+      <h2 className="text-xl md:text-3xl font-bold countdown-text-gradient">AsyncAPI Conference (Nov 16-18)</h2>
       {!small && 
         <>
           <p className=" text-gray-700 md:hidden text-xs  my-2 text-center">Connect and innovate with the AsyncAPI Community.</p>

--- a/components/campaigns/AnnoucementHero.js
+++ b/components/campaigns/AnnoucementHero.js
@@ -1,31 +1,25 @@
 import { useRouter } from 'next/router'
-import AnnouncementRemainingDays from './AnnouncementRamainingDays'
 import Button from '../buttons/Button'
 
 export default function AnnouncementHero({ className = '', small = false }) {
   const { pathname } = useRouter()
-  const hackathonStartDateTime = '2021-10-01T06:00:00Z'
-  const conferenceStartDateTime = '2021-11-16T06:00:00Z'
-  const hackathonDeadlineDateTime = '2021-10-31T16:00:00Z'
-  const conferenceDeadlineDateTime = '2021-11-18T16:00:00Z'
-  const isHackathonOver = new Date(hackathonDeadlineDateTime) < new Date()
-  const isConferenceOver = new Date(conferenceDeadlineDateTime) < new Date()
 
   if (pathname === '/blog/events2021') return null
-  if (isHackathonOver && isConferenceOver) return null
 
   return (
-    <div className={`mb-12 px-4 ${small ? 'sm:py-6' : 'sm:py-12'} ${className}`}>
-      <h1 className={`text-4xl sm:text-4xl md:text-5xl`}>
-        { !isHackathonOver && <AnnouncementRemainingDays dateTime={hackathonStartDateTime} eventName="Hackathon" /> }
-        { !isConferenceOver && <AnnouncementRemainingDays dateTime={conferenceStartDateTime} eventName="Conference" /> }
-      </h1>
-      <div className="my-2 text-xl text-gray-500">
-        <p className="font-bold text-gray-700">Connect and innovate with the AsyncAPI Community.</p>
+    <div className={`bg-gray-50 border border-gray-200 py-6  ${className} ${small ? 'mb-0' : 'mb-12'}`}>
+      <h2 className="text-xl md:text-3xl">AsyncAPI Conference (Nov 16-18)</h2>
+      {!small && 
+        <>
+          <p className=" text-gray-700 md:hidden text-xs  my-2 text-center">Connect and innovate with the AsyncAPI Community.</p>
+          <p className=" text-gray-700 hidden md:block max-w-3xl mx-auto  my-2 text-center">First day of the conference is dedicated entirely to folks that want to contribute to AsyncAPI Initiative. Next two days of the conference are a pure learning experience, community for the community.</p>
+        </>
+      }
+      <div className="mt-8 pb-2 space-x-2">
+        <Button href="https://zoom.us/webinar/register/9416323899487/WN_pv8NDGIoSg2CnF9qsoptWw" target="_blank" text="Register" />
+        <Button bgClassName="bg-none border border-gray-200 text-gray-800 hover:text-gray-700 shadow-none" href="https://conference.asyncapi.com/" target="_blank" text="Learn more" />
       </div>
-      <div className="mt-8">
-        <Button href="https://conference.asyncapi.com/" target="_blank" text="Learn more" />
-      </div>
+      <p className="text-gray-700 mt-8 hidden md:block">We are still accepting speakers. <a href="https://linuxfoundation.smapply.io/prog/asyncapi_conference_2021/" target="_blank" rel="noreferrer" className="font-semibold underline">Submit your talk</a></p>
     </div>
   )
 }

--- a/components/campaigns/AnnoucementHero.js
+++ b/components/campaigns/AnnoucementHero.js
@@ -16,7 +16,7 @@ export default function AnnouncementHero({ className = '', small = false }) {
         </>
       }
       <div className="mt-8 pb-2 space-x-2">
-        <Button href="https://zoom.us/webinar/register/9416323899487/WN_pv8NDGIoSg2CnF9qsoptWw" target="_blank" text="Register" />
+        <Button href="https://zoom.us/webinar/register/8316333610674/WN_pv8NDGIoSg2CnF9qsoptWw" target="_blank" text="Register" />
         <Button bgClassName="bg-none border border-gray-200 text-gray-800 hover:text-gray-700 shadow-none" href="https://conference.asyncapi.com/" target="_blank" text="Learn more" />
       </div>
       <p className="text-gray-700 mt-8 hidden md:block">We are still accepting speakers. <a href="https://linuxfoundation.smapply.io/prog/asyncapi_conference_2021/" target="_blank" rel="noreferrer" className="font-semibold underline">Submit your talk</a></p>

--- a/components/campaigns/Banner.jsx
+++ b/components/campaigns/Banner.jsx
@@ -3,27 +3,13 @@ import React from "react";
 const Banner = () => {
   return (
     <div className="bg-primary-600 ">
-      <div className="mx-auto max-w-screen-xl py-3 px-3 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-screen-xl py-1 px-3 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between flex-wrap">
-          <div className="w-0 flex-1 flex items-center">
-            <span className="flex p-2 rounded-lg bg-primary-800">
-              <svg
-                className="h-6 w-6 text-white"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z"
-                />
-              </svg>
+          <div className="w-0 flex-1 flex items-center text-xs">
+            <span className="flex px-2 py-1 rounded-lg bg-primary-100 text-primary-600 text-xs uppercase font-bold">
+              Hackathon
             </span>
-            <p className="ml-3 font-medium text-white truncate">
+            <p className="ml-3 font-medium  text-white truncate">
               <span className="md:hidden">Our Global Hackathon is on! <a className="underline" href="/blog/hackathon-faq" target="_blank" rel="noreferrer">Join us &rarr;</a></span>
               <span className="hidden md:inline">
                 Our Global Hackathon has begun! Prizes to be won ⭐️
@@ -33,7 +19,7 @@ const Banner = () => {
           <div className="order-3 mt-2 flex-shrink-0 w-full sm:order-2 sm:mt-0 sm:w-auto hidden md:block">
             <a
               href="/blog/hackathon-faq"
-              className="flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-indigo-600 bg-white hover:bg-indigo-50"
+              className="flex items-center justify-center px-4 py-1 border border-transparent rounded-md shadow-sm text-xs font-medium text-indigo-600 bg-white hover:bg-indigo-50"
             >
               Learn more
             </a>

--- a/components/campaigns/Banner.jsx
+++ b/components/campaigns/Banner.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+const Banner = () => {
+  return (
+    <div className="bg-primary-600 ">
+      <div className="mx-auto max-w-screen-xl py-3 px-3 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between flex-wrap">
+          <div className="w-0 flex-1 flex items-center">
+            <span className="flex p-2 rounded-lg bg-primary-800">
+              <svg
+                className="h-6 w-6 text-white"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z"
+                />
+              </svg>
+            </span>
+            <p className="ml-3 font-medium text-white truncate">
+              <span className="md:hidden">Global Hackathon now on! <a className="underline" href="/blog/hackathon-faq" target="_blank" rel="noreferrer">Join us &rarr;</a></span>
+              <span className="hidden md:inline">
+                Our Global Hackathon is now taking place! Prizes to be won ⭐️
+              </span>
+            </p>
+          </div>
+          <div className="order-3 mt-2 flex-shrink-0 w-full sm:order-2 sm:mt-0 sm:w-auto hidden md:block">
+            <a
+              href="/blog/hackathon-faq"
+              className="flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-indigo-600 bg-white hover:bg-indigo-50"
+            >
+              Learn more
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Banner;

--- a/components/campaigns/Banner.jsx
+++ b/components/campaigns/Banner.jsx
@@ -24,7 +24,7 @@ const Banner = () => {
               </svg>
             </span>
             <p className="ml-3 font-medium text-white truncate">
-              <span className="md:hidden">Global Hackathon now on! <a className="underline" href="/blog/hackathon-faq" target="_blank" rel="noreferrer">Join us &rarr;</a></span>
+              <span className="md:hidden">Our Global Hackathon is on! <a className="underline" href="/blog/hackathon-faq" target="_blank" rel="noreferrer">Join us &rarr;</a></span>
               <span className="hidden md:inline">
                 Our Global Hackathon is now taking place! Prizes to be won ⭐️
               </span>

--- a/components/campaigns/Banner.jsx
+++ b/components/campaigns/Banner.jsx
@@ -26,7 +26,7 @@ const Banner = () => {
             <p className="ml-3 font-medium text-white truncate">
               <span className="md:hidden">Our Global Hackathon is on! <a className="underline" href="/blog/hackathon-faq" target="_blank" rel="noreferrer">Join us &rarr;</a></span>
               <span className="hidden md:inline">
-                Our Global Hackathon is now taking place! Prizes to be won ⭐️
+                Our Global Hackathon has begun! Prizes to be won ⭐️
               </span>
             </p>
           </div>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -14,6 +14,7 @@ import Column from '../components/layout/Column'
 import Figure from '../components/Figure'
 import GeneratorInstallation from '../components/GeneratorInstallation'
 import NewsletterSubscribe from '../components/NewsletterSubscribe'
+import HeaderCampaign from '../components/campaigns/Banner'
 import AppContext from '../context/AppContext'
 import '../css/styles.css'
 
@@ -23,6 +24,7 @@ export default function MyApp({ Component, pageProps, router }) {
     <AppContext.Provider value={{ path: router.asPath }}>
       <MDXProvider components={getMDXComponents()}>
         <Layout>
+          <HeaderCampaign />
           <Component {...pageProps} />
         </Layout>
       </MDXProvider>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -22,9 +22,9 @@ export default function MyApp({ Component, pageProps, router }) {
 
   return (
     <AppContext.Provider value={{ path: router.asPath }}>
+      <HeaderCampaign />
       <MDXProvider components={getMDXComponents()}>
         <Layout>
-          <HeaderCampaign />
           <Component {...pageProps} />
         </Layout>
       </MDXProvider>

--- a/pages/index.js
+++ b/pages/index.js
@@ -16,6 +16,7 @@ import SalesforceLogo from '../components/logos/Salesforce'
 import SapLogo from '../components/logos/SAP'
 import Testimonial from '../components/Testimonial'
 import BlogPostItem from '../components/navigation/BlogPostItem'
+import HeaderCampaign from '../components/campaigns/Banner'
 
 function HomePage() {
   const posts = getAllPosts()
@@ -32,6 +33,7 @@ function HomePage() {
 
   return (
     <>
+      <HeaderCampaign />
       <Container wide>
         <Head />
         <NavBar className="z-50" />

--- a/pages/index.js
+++ b/pages/index.js
@@ -16,7 +16,6 @@ import SalesforceLogo from '../components/logos/Salesforce'
 import SapLogo from '../components/logos/SAP'
 import Testimonial from '../components/Testimonial'
 import BlogPostItem from '../components/navigation/BlogPostItem'
-import HeaderCampaign from '../components/campaigns/Banner'
 
 function HomePage() {
   const posts = getAllPosts()
@@ -33,7 +32,6 @@ function HomePage() {
 
   return (
     <>
-      <HeaderCampaign />
       <Container wide>
         <Head />
         <NavBar className="z-50" />

--- a/pages/roadmap.js
+++ b/pages/roadmap.js
@@ -28,7 +28,7 @@ export default function RoadmapPage() {
       image={image}
       wide
     >
-      <div className="py-16 overflow-hidden lg:py-24">
+      <div className="py-12 overflow-hidden">
         <div className="relative max-w-xl mx-auto px-4 sm:px-6 lg:px-8 lg:max-w-screen-xl">
           <div className="relative">
             <div className="lg:w-2/3 lg:mx-auto lg:text-center">

--- a/pages/tools/generator.js
+++ b/pages/tools/generator.js
@@ -34,7 +34,7 @@ export default function GeneratorPage() {
       image={image}
       wide
     >
-      <div className="py-16 overflow-hidden lg:py-24">
+      <div className="py-12 overflow-hidden">
         <div className="relative max-w-xl mx-auto px-4 sm:px-6 lg:px-8 lg:max-w-screen-xl">
           <div className="relative">
             <h3 className="text-center text-3xl leading-8 font-normal tracking-tight text-gray-900 sm:text-4xl sm:leading-10">

--- a/pages/tools/github-actions.js
+++ b/pages/tools/github-actions.js
@@ -31,7 +31,7 @@ export default function GithubActionsPage() {
       image={image}
       wide
     >
-      <div className="py-16 overflow-hidden lg:py-24">
+      <div className="py-12 overflow-hidden">
         <div className="relative max-w-xl mx-auto px-4 sm:px-6 lg:px-8 lg:max-w-screen-xl">
           <div className="relative">
             <h3 className="text-center text-3xl leading-8 font-normal tracking-tight text-gray-900 sm:text-4xl sm:leading-10">

--- a/pages/tools/parsers.js
+++ b/pages/tools/parsers.js
@@ -31,7 +31,7 @@ export default function ParsersPage() {
       image={image}
       wide
     >
-      <div className="py-16 overflow-hidden lg:py-24">
+      <div className="py-12 overflow-hidden">
         <div className="relative max-w-xl mx-auto px-4 sm:px-6 lg:px-8 lg:max-w-screen-xl">
           <div className="relative">
             <h3 className="text-center text-3xl leading-8 font-normal tracking-tight text-gray-900 sm:text-4xl sm:leading-10">


### PR DESCRIPTION
**Description**

Here are some minor updates to update:

- The call to actions on the main page
- Introduced a Banner at the top (dedicated to Hackathon for now), which is only shown on homepage
- Added box for Conference on all pages 
- Also small changes to the title on the main page


## Screen shots

![image](https://user-images.githubusercontent.com/3268013/135598907-31204324-8da7-4fbc-a340-dd2d2c728330.png)


### Notes

Also fixed an issue we have at the moment on the website, don't think that timer thing for hackaton is working since we hit the date. This PR will fix that.

![image](https://user-images.githubusercontent.com/3268013/135598978-95cb7b46-f1ab-4b78-b1d9-f7528720c6fc.png)
