### PR TITLE
fix: broken blog post image on previous hacktoberfest post

### DIFF
--- a/pages/blog/hacktoberfest-summary-2020.md
+++ b/pages/blog/hacktoberfest-summary-2020.md
@@ -4,7 +4,7 @@ date: 2020-11-05T06:00:00+01:00
 type: Community
 tags:
   - Hacktoberfest
-cover: /img/pots/hacktoberfest-summary-2020/cover.webp
+cover: /img/posts/hacktoberfest-summary-2020/cover.webp
 authors:
   - name: Lukasz Gornicki
     photo: /img/avatars/lpgornicki.webp


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
Fixes https://github.com/asyncapi/website/issues/417 - There was a broken image on a previous blog post - it was a simple one liner as the path to the image had a typo in it.
