### PR TITLE
fix: disable fs module on browser rendering

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -21,4 +21,13 @@ const withMDX = require('@next/mdx')({
 })
 module.exports = withMDX({
   pageExtensions: ['js', 'md'],
+  webpack(config, { isServer }) {
+    // Fixes npm packages that depend on `fs` module
+    if (!isServer) {
+      config.node = {
+        fs: 'empty'
+      }
+    }
+    return config
+  },
 })


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Disable `fs` module in the browser rendering: In some PRs error stating that the fs module is not defined for Modelina:

```
./node_modules/@asyncapi/modelina/lib/esm/helpers/FileHelpers.js
Module not found: Can't resolve 'fs' in '/Users/XXX/Documents/AsyncAPI/website/node_modules/@asyncapi/modelina/lib/esm/helpers'
``` 

PR fixes it with disabling `fs` module on browser rendering.

TBH: I don't know why Webpack cannot tree shaking the fs module on browser side and we have to make it manually...