### PR TITLE
fix: correct previous SIG meeting recordings URL

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -89,7 +89,7 @@ function HomePage() {
                   <div className="mt-5 md:flex">
                     <Button className="block md:inline-block md:flex-1 md:text-center" text="Add to Google Calendar" href="https://calendar.google.com/calendar?cid=dGJyYmZxNGRlNWJjbmd0OG9rdmV2NGxzdGtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ" target="_blank" />
                     <Button className="mt-2 md:mt-0 md:ml-2 block md:inline-block md:flex-1 md:text-center" bgClassName="bg-indigo-500 hover:bg-indigo-400" text="Join mailing list to get invite" href="https://groups.google.com/forum/#!forum/asyncapi-users" target="_blank" />
-                    <Button className="mt-2 md:mt-0 md:ml-2 block md:inline-block md:flex-1 md:text-center" bgClassName="bg-red-500 hover:bg-red-400" text="Watch previous recordings" href="https://groups.google.com/forum/#!forum/asyncapi-users" target="_blank" />
+                    <Button className="mt-2 md:mt-0 md:ml-2 block md:inline-block md:flex-1 md:text-center" bgClassName="bg-red-500 hover:bg-red-400" text="Watch previous recordings" href="https://www.youtube.com/playlist?list=PLbi1gRlP7pijUwZJErzyYf_Rc-PWu4lXS" target="_blank" />
                   </div>
                 </div>
               </div>
@@ -97,7 +97,7 @@ function HomePage() {
           </Container>
         </div>
       </Container>
-      
+
       <Container className="text-center pb-12" wide>
         <h3 className="text-primary-800 text-3xl font-bold md:text-4xl mb-4">Adopted by the world leading brands</h3>
         <p className="mt-2 mb-20 text-base leading-6 text-gray-500 md:w-1/2 md:mx-auto">
@@ -121,7 +121,7 @@ function HomePage() {
           </div>
         </div>
       </Container>
-      
+
       <Container className="text-center pb-12" wide>
         <section>
           <div className="max-w-screen-xl mx-auto md:grid md:grid-cols-2 md:px-6 lg:px-8">


### PR DESCRIPTION
Fixes #428 
![Screenshot (266)](https://user-images.githubusercontent.com/74204086/137030309-ec29ed4c-4b26-4945-abd2-7c83fd2c5eab.png)
Solved issue #428 
I changed link of Watch previous recordings from https://groups.google.com/forum/#!forum/asyncapi-users to https://www.youtube.com/playlist?list=PLbi1gRlP7pijUwZJErzyYf_Rc-PWu4lXS as mentioned by a member.


