### PR TITLE
chore: removing the link for accepting speakers

### DIFF
--- a/components/campaigns/AnnoucementHero.js
+++ b/components/campaigns/AnnoucementHero.js
@@ -19,7 +19,6 @@ export default function AnnouncementHero({ className = '', small = false }) {
         <Button href="https://zoom.us/webinar/register/8316333610674/WN_pv8NDGIoSg2CnF9qsoptWw" target="_blank" text="Register" />
         <Button bgClassName="bg-none border border-gray-200 text-gray-800 hover:text-gray-700 shadow-none" href="https://conference.asyncapi.com/" target="_blank" text="Learn more" />
       </div>
-      <p className="text-gray-700 mt-8 hidden md:block">We are still accepting speakers. <a href="https://linuxfoundation.smapply.io/prog/asyncapi_conference_2021/" target="_blank" rel="noreferrer" className="font-semibold underline">Submit your talk</a></p>
     </div>
   )
 }


### PR DESCRIPTION
**Description**

The call for papers ended yesterday (17th October 2021) this simple PR removes the call for papers link on the landing page.

![image](https://user-images.githubusercontent.com/3268013/137680228-173f83dc-f455-4c3c-9142-fff25c6fd099.png)

`We are still accepting speakers. Submit your talk` no longer there.