### PR TITLE
feat: enable link to AsyncAPI Studio

### DIFF
--- a/components/DemoAnimation.js
+++ b/components/DemoAnimation.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import Typing from 'react-typing-animation'
 import MacWindow from './MacWindow'
 import ArrowRight from './icons/ArrowRight'
-import OpenInPlaygroundButton from './buttons/OpenInPlaygroundButton'
+import OpenInStudioButton from './buttons/OpenInStudioButton'
 
 export default function DemoAnimation({ className = '' }) {
   const [started, setStarted] = useState(true)
@@ -220,9 +220,9 @@ export default function DemoAnimation({ className = '' }) {
               Play with it!
             </h3>
             <p className="text-gray-500 text-lg font-normal mb-6 max-w-3xl mx-auto mb-8">
-              Open this example on AsyncAPI Playground to get a better taste of the specification. No signup is required!
+              Open this example on AsyncAPI Studio to get a better taste of the specification. No signup is required!
             </p>
-            <OpenInPlaygroundButton />
+            <OpenInStudioButton />
           </div>
           <MacWindow
             className={`bg-gray-50 border-gray-200 border shadow-lg min-h-full transition-all duration-500 ease-in-out ${showControls ? 'transform -translate-x-full h-0 opacity-0 lg:h-auto lg:opacity-100 lg:-translate-x-3/4' : ''}`}

--- a/components/Hero.js
+++ b/components/Hero.js
@@ -18,7 +18,7 @@ export default function Hero ({ className = '' }) {
           All powered by the AsyncAPI specification, the <strong>industry standard</strong> for defining asynchronous APIs.
         </h2>
         <Button className="block md:inline-block" text="Read the docs" href="/docs/getting-started" icon={<ArrowRight className="-mb-1 h-5 w-5" />} />
-        <OpenInStudioButton />
+        <OpenInStudioButton text='Open Studio' />
       </div>
       <div className="mt-8 md:mt-16">
         <DemoAnimation />

--- a/components/Hero.js
+++ b/components/Hero.js
@@ -1,6 +1,6 @@
 import Button from './buttons/Button'
 import ArrowRight from './icons/ArrowRight'
-import OpenInPlaygroundButton from './buttons/OpenInPlaygroundButton'
+import OpenInStudioButton from './buttons/OpenInStudioButton'
 import DemoAnimation from './DemoAnimation'
 import AnnouncementHero from './campaigns/AnnoucementHero'
 
@@ -18,7 +18,7 @@ export default function Hero ({ className = '' }) {
           All powered by the AsyncAPI specification, the <strong>industry standard</strong> for defining asynchronous APIs.
         </h2>
         <Button className="block md:inline-block" text="Read the docs" href="/docs/getting-started" icon={<ArrowRight className="-mb-1 h-5 w-5" />} />
-        <OpenInPlaygroundButton />
+        <OpenInStudioButton />
       </div>
       <div className="mt-8 md:mt-16">
         <DemoAnimation />

--- a/components/buttons/OpenInStudioButton.js
+++ b/components/buttons/OpenInStudioButton.js
@@ -1,13 +1,13 @@
 import Button from './Button'
 import IconRocket from '../icons/Rocket'
 
-export default function OpenInStudioButton() {
+export default function OpenInStudioButton({ text = 'Open in Studio' }) {
   const sampleSpec = encodeURI('https://raw.githubusercontent.com/asyncapi/asyncapi/v2.2.0/examples/simple.yml')
   return (
     <Button
       className="block mt-2 md:mt-0 md:inline-block md:ml-2"
       bgClassName="bg-green-500"
-      text="Open in Studio"
+      text={text}
       href={`https://studio.asyncapi.com?url=${sampleSpec}`}
       target="_blank"
       icon={<IconRocket className="w-5 h-5 -mb-1 ml-1" />}

--- a/components/buttons/OpenInStudioButton.js
+++ b/components/buttons/OpenInStudioButton.js
@@ -1,0 +1,16 @@
+import Button from './Button'
+import IconRocket from '../icons/Rocket'
+
+export default function OpenInStudioButton() {
+  const sampleSpec = encodeURI('https://raw.githubusercontent.com/asyncapi/asyncapi/v2.2.0/examples/simple.yml')
+  return (
+    <Button
+      className="block mt-2 md:mt-0 md:inline-block md:ml-2"
+      bgClassName="bg-green-500"
+      text="Open Studio"
+      href={`https://studio.asyncapi.com?url=${sampleSpec}`}
+      target="_blank"
+      icon={<IconRocket className="w-5 h-5 -mb-1 ml-1" />}
+    />
+  )
+}

--- a/components/buttons/OpenInStudioButton.js
+++ b/components/buttons/OpenInStudioButton.js
@@ -7,7 +7,7 @@ export default function OpenInStudioButton() {
     <Button
       className="block mt-2 md:mt-0 md:inline-block md:ml-2"
       bgClassName="bg-green-500"
-      text="Open Studio"
+      text="Open in Studio"
       href={`https://studio.asyncapi.com?url=${sampleSpec}`}
       target="_blank"
       icon={<IconRocket className="w-5 h-5 -mb-1 ml-1" />}

--- a/components/navigation/Label.js
+++ b/components/navigation/Label.js
@@ -11,7 +11,7 @@ export default function Label ({ text, color = 'gray' }) {
   }
 
   return (
-    <span className={`text-xs uppercase py-0.5 px-1 ml-2 rounded ${colorClasses}`}>
+    <span className={`inline-block text-xs uppercase py-0 px-1 ml-2 rounded transform -translate-y-0.5 ${colorClasses}`}>
       {text}
     </span>
   )

--- a/components/navigation/MenuBlocks.js
+++ b/components/navigation/MenuBlocks.js
@@ -6,21 +6,30 @@ export default function MenuBlocks ({
   return (
     <>
       {
-        items.map((item, index) => (
-          <a href={item.comingSoon ? null : item.href} key={index} className="-m-3 p-3 flex items-start space-x-4 rounded-lg hover:bg-gray-50 transition ease-in-out duration-150">
-            <div className={`flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-md bg-primary-500 text-white sm:h-12 sm:w-12 ${item.comingSoon && 'opacity-50'}`}>
-              <item.icon className="h-6 w-6" />
-            </div>
-            <div className="space-y-1">
-              <p className="text-base leading-6 font-medium text-gray-900">
-                <span className={item.comingSoon && 'opacity-50'}>{ item.title }</span> { item.comingSoon && <Label text="Coming soon" /> }
-              </p>
-              <p className={`text-sm leading-5 text-gray-500 ${item.comingSoon && 'opacity-50'}`}>
-                { item.description }
-              </p>
-            </div>
-          </a>
-        ))
+        items.map((item, index) => {
+          const isExternalHref = item.href && item.href.startsWith('http');
+          return (
+            <a 
+              href={item.comingSoon ? null : item.href} 
+              key={index} 
+              className="-m-3 p-3 flex items-start space-x-4 rounded-lg hover:bg-gray-50 transition ease-in-out duration-150" 
+              target={isExternalHref ? "_blank" : undefined} 
+              rel={isExternalHref ? "noopener noreferrer" : undefined}
+            >
+              <div className={`flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-md bg-primary-500 text-white sm:h-12 sm:w-12 ${item.comingSoon && 'opacity-50'}`}>
+                <item.icon className="h-6 w-6" />
+              </div>
+              <div className="space-y-1">
+                <p className="text-base leading-6 font-medium text-gray-900">
+                  <span className={item.comingSoon && 'opacity-50'}>{ item.title }</span> { item.comingSoon && <Label text="Coming soon" /> } { item.beta && <Label text="Beta" /> }
+                </p>
+                <p className={`text-sm leading-5 text-gray-500 ${item.comingSoon && 'opacity-50'}`}>
+                  { item.description }
+                </p>
+              </div>
+            </a>
+          )
+        })
       }
     </>
   )

--- a/components/navigation/toolingItems.js
+++ b/components/navigation/toolingItems.js
@@ -7,7 +7,7 @@ import IconParser from '../icons/Parser'
 // import IconPlugins from '../icons/Plugins'
 
 export default [
-  { href: '/tools/studio', icon: IconHub, title: 'Studio', description: 'Visually design your AsyncAPI files and event-driven architecture.', comingSoon: true },
+  { href: 'https://studio.asyncapi.com/', icon: IconHub, title: 'Studio', description: 'Visually design your AsyncAPI files and event-driven architecture.', beta: true },
   { href: '/tools/generator', icon: IconGenerator, title: 'Generator', description: 'Use your AsyncAPI files to generate documentation, code, anything!' },
   { href: '/tools/modelina', icon: IconModelina, title: 'Modelina', description: 'Sometimes you just want to generate data models from your payload.' },
   // { href: '/react', icon: IconReact, title: 'React Component', description: 'Embed your AsyncAPI documentation in your React application.' },


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Enable studio in navigation
- Change buttons for Playground to for Studio

@boyney123 I know that we have such an issue https://github.com/asyncapi/studio/issues/129 but maybe we should go atm with this direction and If we find the time and have the documentation we will create a separate path `/tools/studio`?