### PR TITLE
docs: removed period from headline

### DIFF
--- a/components/Hero.js
+++ b/components/Hero.js
@@ -14,7 +14,7 @@ export default function Hero({ className = '' }) {
           Building the future of {` `}
           <span className="text-primary-400 block md:-mt-4">
             {" "}
-            Event-Driven Architectures (EDA).
+            Event-Driven Architectures (EDA)
           </span>
         </h1>
         <h2 className="text-gray-500 text-lg font-normal mb-16 max-w-3xl mx-auto">

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -49,12 +49,12 @@ export default function BlogIndexPage() {
         </div>
         <div className="relative max-w-7xl mx-auto">
           <div className="text-center">
-            <h2 className="text-3xl my-4 leading-9 tracking-tight font-extrabold text-gray-900 sm:text-4xl sm:leading-10">
+            <h2 className="text-3xl leading-9 tracking-tight font-extrabold text-gray-900 sm:text-4xl sm:leading-10">
               Welcome to our blog!
             </h2>
-            {/* <p className="mt-3 max-w-2xl mx-auto text-xl leading-7 text-gray-500 sm:mt-4">
-              Find the latest and greatest stories from our community.
-            </p> */}
+            <p className="mt-3 max-w-2xl mx-auto text-xl leading-7 text-gray-500 sm:mt-4">
+              Find the latest and greatest stories from our community
+            </p>
             <p className="max-w-2xl mx-auto text-md leading-7 text-gray-400">
               Want to publish a blog post? We love community stories.
               <a

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -49,12 +49,12 @@ export default function BlogIndexPage() {
         </div>
         <div className="relative max-w-7xl mx-auto">
           <div className="text-center">
-            <h2 className="text-3xl leading-9 tracking-tight font-extrabold text-gray-900 sm:text-4xl sm:leading-10">
+            <h2 className="text-3xl my-4 leading-9 tracking-tight font-extrabold text-gray-900 sm:text-4xl sm:leading-10">
               Welcome to our blog!
             </h2>
-            <p className="mt-3 max-w-2xl mx-auto text-xl leading-7 text-gray-500 sm:mt-4">
+            {/* <p className="mt-3 max-w-2xl mx-auto text-xl leading-7 text-gray-500 sm:mt-4">
               Find the latest and greatest stories from our community.
-            </p>
+            </p> */}
             <p className="max-w-2xl mx-auto text-md leading-7 text-gray-400">
               Want to publish a blog post? We love community stories.
               <a


### PR DESCRIPTION
**Description**

- As already discussed, removed the period from headline.
- Removed a second level heading from `blogs` index.
- Added a bit of margin to the heading as it wasn't looking very spacious after eliminating the subheading.
- This is what it looks like now: 

![image](https://user-images.githubusercontent.com/76242518/144481596-232eda96-7469-4b63-b123-bda414adf100.png)


Fixes #471 
