### PR TITLE
feat: homepage features styling

### DIFF
--- a/components/DemoAnimation.js
+++ b/components/DemoAnimation.js
@@ -214,8 +214,8 @@ export default function DemoAnimation({ className = '' }) {
             { (showDisplayName || showDisplayNameDescription) && renderEmail(() => setShowEmail(true)) }
           </MacWindow>
         </div>
-        <div className={`relative md:flex-1 md:ml-1 md:mb-0 transition-all duration-500 ease-in-out z-10`}>
-          <div className={`md:text-left text-center mt-8 lg:mt-0 lg:absolute lg:left-0 lg:top-0 lg:right-0 lg:ml-48 lg:mr-8 ${showControls ? 'block' : 'hidden'}`}>
+        <div className={`relative md:flex-1 md:ml-6 md:mb-0 transition-all duration-500 ease-in-out z-10`}>
+          <div className={`md:text-left text-center mt-8 md:mt-0 lg:absolute lg:left-0 lg:top-0 lg:right-0 lg:ml-48 lg:mr-8 ${showControls ? 'block' : 'hidden'}`}>
             <h3 className="text-primary-800 text-2xl font-bold md:text-2xl mb-4">
               Play with it!
             </h3>

--- a/components/DemoAnimation.js
+++ b/components/DemoAnimation.js
@@ -215,7 +215,7 @@ export default function DemoAnimation({ className = '' }) {
           </MacWindow>
         </div>
         <div className={`relative md:flex-1 md:ml-1 md:mb-0 transition-all duration-500 ease-in-out z-10`}>
-          <div className={`text-center mt-8 lg:mt-0 lg:absolute lg:left-0 lg:top-0 lg:right-0 lg:ml-48 lg:mr-8 ${showControls ? 'block' : 'hidden'}`}>
+          <div className={`md:text-left text-center mt-8 lg:mt-0 lg:absolute lg:left-0 lg:top-0 lg:right-0 lg:ml-48 lg:mr-8 ${showControls ? 'block' : 'hidden'}`}>
             <h3 className="text-primary-800 text-2xl font-bold md:text-2xl mb-4">
               Play with it!
             </h3>

--- a/components/Hero.js
+++ b/components/Hero.js
@@ -23,7 +23,7 @@ export default function Hero({ className = '' }) {
           <strong>industry standard</strong> for defining asynchronous APIs.
         </h2>
         <Button className="block md:inline-block" text="Read the docs" href="/docs/getting-started" icon={<ArrowRight className="-mb-1 h-5 w-5" />} />
-        <OpenInStudioButton text='Open Studio' />
+        <OpenInStudioButton text='Open Studio' className="md:ml-2" />
         <p className="mt-4 text-xs text-gray-500">
           Proud to be part of the {" "}
           <a className="underline" href="https://www.linuxfoundation.org/">

--- a/components/buttons/OpenInStudioButton.js
+++ b/components/buttons/OpenInStudioButton.js
@@ -1,11 +1,11 @@
 import Button from './Button'
 import IconRocket from '../icons/Rocket'
 
-export default function OpenInStudioButton({ text = 'Open in Studio' }) {
+export default function OpenInStudioButton({ text = 'Open in Studio', className = '' }) {
   const sampleSpec = encodeURI('https://raw.githubusercontent.com/asyncapi/asyncapi/v2.2.0/examples/simple.yml')
   return (
     <Button
-      className="block mt-2 md:mt-0 md:inline-block md:ml-2"
+      className={`text-center block mt-2 md:mt-0 md:inline-block ${className}`}
       bgClassName="bg-green-500"
       text={text}
       href={`https://studio.asyncapi.com?url=${sampleSpec}`}

--- a/components/features/index.jsx
+++ b/components/features/index.jsx
@@ -62,7 +62,7 @@ export default function Features() {
         <div className="mt-12 text-left">
           <div className="grid  grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
             {features.map((feature) => (
-              <div key={feature.name} className="flex flex-col justify-between border border-gray-200 shadow-lg rounded-lg px-6 pb-8">
+              <div key={feature.name} className="flex flex-col justify-between border border-gray-200 shadow-md hover:shadow-lg transition-all duration-300 ease-in-out rounded-lg px-6 pb-8">
                 <div>
                   <h3 className="mt-8 text-lg font-medium text-gray-900 tracking-tight">
                     {feature.name}

--- a/components/features/index.jsx
+++ b/components/features/index.jsx
@@ -60,7 +60,7 @@ export default function Features() {
           Improving the current state of Event-Driven Architectures (EDA)
         </p>
         <div className="mt-12 text-left">
-          <div className="grid  grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid  grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
             {features.map((feature) => (
               <div key={feature.name} className="flex flex-col justify-between border border-gray-200 shadow-lg rounded-lg px-6 pb-8">
                 <div>

--- a/components/features/index.jsx
+++ b/components/features/index.jsx
@@ -62,7 +62,7 @@ export default function Features() {
         <div className="mt-12 text-left">
           <div className="grid  grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
             {features.map((feature) => (
-              <div key={feature.name} className="flex flex-col justify-between shadow-lg rounded-lg px-6 pb-8">
+              <div key={feature.name} className="flex flex-col justify-between border border-gray-200 shadow-lg rounded-lg px-6 pb-8">
                 <div>
                   <h3 className="mt-8 text-lg font-medium text-gray-900 tracking-tight">
                     {feature.name}

--- a/components/navigation/BlogPostItem.js
+++ b/components/navigation/BlogPostItem.js
@@ -21,7 +21,7 @@ export default function BlogPostItem({ post, className = '' }) {
   }
 
   return (
-    <div className={`flex flex-col rounded-lg shadow-lg overflow-hidden ${className}`}>
+    <div className={`flex flex-col border border-gray-200 rounded-lg shadow-md divide-y divide-gray-200 transition-all duration-300 ease-in-out hover:shadow-lg overflow-hidden ${className}`}>
       <a href={post.slug} className="flex-shrink-0">
         <img className="h-48 w-full object-cover" src={post.cover} alt="" />
       </a>


### PR DESCRIPTION
I am proposing a few quick styling tweaks as follows:

**1. Left-align block of text next to home page animation**
Seems silly, but I think this section looks a little more polished with the text left-aligned. On mobile, the text goes back to being centered.

Before:
![Screen Shot 2021-12-30 at 2 06 31 PM](https://user-images.githubusercontent.com/60163079/147781210-a775fb82-bd92-43db-9fab-45ff3548a686.png)

After:
![Screen Shot 2021-12-30 at 2 06 22 PM](https://user-images.githubusercontent.com/60163079/147781218-09947529-9dfd-4b45-a0a8-e60b72e7d03b.png)

<hr>

**2. Add a thin gray border around the cards in the Features section**
Also a very minor visual tweak, but I thought that these cards should visually compare to the [next chapter links in the docs](https://www.asyncapi.com/docs/getting-started). It also just sets the white cards a bit more from the background, whereas right now they look like they are blending in with the white background towards the top.

Before:
![Screen Shot 2021-12-30 at 2 11 50 PM](https://user-images.githubusercontent.com/60163079/147781448-05e6ebab-d511-41e2-a9e7-a0eb7c077dcb.png)

After:
![Screen Shot 2021-12-30 at 2 12 05 PM](https://user-images.githubusercontent.com/60163079/147781457-19576022-f989-4fec-9b87-54ae9ad858d0.png)

<hr>

**3. Adding a thin gray border around the blog cards on the home page as well as hover states**
Again, just matching the card style on the docs pages for consistency.

Before:
![Screen Shot 2021-12-30 at 2 14 10 PM](https://user-images.githubusercontent.com/60163079/147781597-0b2e8f60-2157-4b45-868a-1ae699c51791.png)

After:
![Screen Shot 2021-12-30 at 2 14 50 PM](https://user-images.githubusercontent.com/60163079/147781644-d081b55f-a715-4ca5-b497-377690a23e38.png)

<hr>

P.S. This is also just me trying to get a feel for how styles are applied to the website and I just found some easy things to improve on along the way 😄 
