### PR TITLE
fix: remove extra variable

### DIFF
--- a/components/layout/Container.js
+++ b/components/layout/Container.js
@@ -10,7 +10,7 @@ export default function Container ({
   const commonClassNames = `${flex ? `${cssBreakingPoint}:flex` : 'block'} ${flexReverse ? `${cssBreakingPoint}:flex-row-reverse` : ''} ${className} px-4 sm:px-6 lg:px-8`
   const wideClassNames = `max-w-screen-xl ${commonClassNames}`
   const regularClassNames = `max-w-4xl ${commonClassNames}`
-  const normalClassNames = `${wide ? wideClassNames : regularClassNames} mx-auto ${commonClassNames}`
+  const normalClassNames = `${wide ? wideClassNames : regularClassNames} mx-auto`
   const fluidClassNames = `${commonClassNames}`
   return (
     <div className={fluid ? fluidClassNames : normalClassNames}>


### PR DESCRIPTION
Removes extra variable in `Container` component where classes are rendering twice.

**Related issue(s)**
Resolves #521 