### PR TITLE
chore: add bot as codeowner for markdown too

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,4 +8,4 @@
 * @fmvilas @derberg @magicmatatjahu @github-actions[bot]
 
 # All .md files
-*.md @alequetzalli 
+*.md @alequetzalli @github-actions[bot]


### PR DESCRIPTION
Some changes in markdown files are done through automation and we need bot to also be responsible for these changes otherwise PRs like https://github.com/asyncapi/website/pull/526 are blocked