### PR TITLE
fix: added margin in calendar button

### DIFF
--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -54,7 +54,7 @@ export default function Calendar({ className = '' }) {
       {getEvents().map((event, index) => (
         <a
           href={event.url}
-          className="flex-grow md:pl-8 pl-6 flex sm:items-center items-start flex-col sm:flex-row mb-1"
+          className="flex-grow flex sm:items-center items-start flex-col sm:flex-row mb-1"
           key={index}
         >
           <div className="inline-flex flex-row h-12 min-w-12 rounded-full bg-pink-500 text-white font-bold">
@@ -75,7 +75,7 @@ export default function Calendar({ className = '' }) {
       ))}
       {eventsExist && (
         <Button
-          className="block md:inline-block md:text-center float-right mt-4"
+          className="block md:inline-block md:text-center float-left mt-4"
           text="Go to Calendar"
           href={CALENDAR_URL}
           target="_blank"

--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -75,7 +75,7 @@ export default function Calendar({ className = '' }) {
       ))}
       {eventsExist && (
         <Button
-          className="block md:inline-block md:text-center float-right"
+          className="block md:inline-block md:text-center float-right mt-4"
           text="Go to Calendar"
           href={CALENDAR_URL}
           target="_blank"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This PR includes a minor change to the website adding a proper margin to the `Calendar` button, so that it doesn't mixed up with content in the card.

**Preview**
![Screenshot from 2022-01-12 17-52-20](https://user-images.githubusercontent.com/76521428/149140071-97670b1d-288b-4612-a9c4-3229ccca5a13.png)


**Related issue(s)**
Resolves #541 
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->