### PR TITLE
fix: node-fetch version issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "moment": "^2.26.0",
     "monaco-editor": "^0.20.0",
     "next": "^11.1.3",
-    "node-fetch": "2.6.7",
+    "node-fetch": "^2.6.7",
     "postcss-import": "^12.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "moment": "^2.26.0",
     "monaco-editor": "^0.20.0",
     "next": "^11.1.3",
-    "node-fetch": "^3.1.1",
+    "node-fetch": "2.6.7",
     "postcss-import": "^12.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

-  Fixing the node-fetch version to `^2.6.7` as upgraded version `^3.1.1` made it mandatory to use` ES module` (those using import instead of require)  so, when it found `import` inside node-fetch code, it failed. 