### PR TITLE
chore(blog): cleanup featured articles

### DIFF
--- a/pages/blog/2021-summary.md
+++ b/pages/blog/2021-summary.md
@@ -11,6 +11,7 @@ authors:
     link: https://twitter.com/derberq
     byline: AsyncAPI Maintainer and Dev Comm Keeper
 excerpt: 'AsyncAPI Initiative growth presented in different metrics from different channels in 2021.'
+featured: true
 ---
 
 This article is a continuation of a tradition where once a year, we summarize all the metrics that we can collect from our different tools to see how we are growing as a community.

--- a/pages/blog/asyncapi-discovery-intro.md
+++ b/pages/blog/asyncapi-discovery-intro.md
@@ -1,6 +1,5 @@
 ---
 type: Engineering
-featured: true
 cover: /img/posts/asyncapi-discovery-intro/asyncapi-discovery-tool-header.webp
 title: "Align Production Reality and Event Documentation with the AsyncAPI Discovery Tool"
 date: 2021-12-07T06:00:00+01:00

--- a/pages/blog/socketio-part1.md
+++ b/pages/blog/socketio-part1.md
@@ -2,7 +2,6 @@
 type: Engineering
 title: "The journey of documenting a Socket.IO API (Pt 1)"
 date: 2021-09-23T10:00:00+01:00
-featured: true
 cover: /img/posts/socketio-part1/cover.webp
 tags:
    - Specification

--- a/pages/blog/socketio-part2.md
+++ b/pages/blog/socketio-part2.md
@@ -2,7 +2,6 @@
 type: Engineering
 title: "The journey of documenting a Socket.IO API (Pt 2)"
 date: 2021-11-04T10:00:00+01:00
-featured: true
 cover: /img/posts/socketio-part2/cover.webp
 tags:
    - Specification

--- a/pages/blog/the-reference-rabbit-hole.md
+++ b/pages/blog/the-reference-rabbit-hole.md
@@ -1,7 +1,6 @@
 ---
 title: "The Reference Rabbit Hole"
 date: 2021-11-30T12:00:00+01:00
-featured: true
 type: Engineering
 tags:
   - Specification


### PR DESCRIPTION
- new article about 2021 was not featured and is lost on the list
- remove `featured` flag from very old articles prior december