### PR TITLE
chore: update slack redirect to self invite

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -30,7 +30,7 @@ https://www.asyncapi.io/* https://www.asyncapi.com/:splat 301!
 /asyncapi-react https://asyncapi.github.io/asyncapi-react 301!
 
 # Slack
-/slack-invite https://join.slack.com/t/asyncapi/shared_invite/enQtNDY3MzI0NjU5OTQyLTM5NTlkYzFmZDQyMGVkNzVkOTRhMGU2N2VmMWRlOTdkNWE0YzdjMGQ2NzRlOWU1NGJkYjUyZDEzMzM3ZGYzYzM 302!
+/slack-invite https://join.slack.com/t/asyncapi/shared_invite/zt-153ifujzl-fD4W~~LxiRroF8E5bx80qA 302!
 
 # Central Maven repository verification
 /OSSRH-63280 https://github.com/asyncapi/java-asyncapi


### PR DESCRIPTION
current link expired