### PR TITLE
feat: adding GSoD and GSoC pages

### DIFF
--- a/components/layout/Layout.js
+++ b/components/layout/Layout.js
@@ -18,6 +18,15 @@ export default function Layout({ children }) {
         {children}
       </DocsLayout>
     )
+  } else if (pathname.startsWith('/community/mentorship')) {
+    const posts = getAllPosts()
+    const post = getPostBySlug(pathname);
+    console.log(pathname, post);
+    return (
+      <DocsLayout post={post} navItems={posts.filter(p => p.slug.startsWith('/community/mentorship'))}>
+        {children}
+      </DocsLayout>
+    )
   } else if (pathname.startsWith('/blog/')) {
     const posts = getAllPosts()
     const post = getPostBySlug(pathname)

--- a/components/navigation/communityItems.js
+++ b/components/navigation/communityItems.js
@@ -12,6 +12,5 @@ export default [
   { icon: IconContributing, title: 'Contributing', href: 'https://github.com/asyncapi?type=source#-contribute-to-asyncapi', target: '_blank', description: `We are always welcoming and looking for contributions. If you are interested check out our contribution guide.` },
   { icon: IconTSC, title: 'Technical Steering Committee', href: '/community/tsc', description: 'Get to know what is a TSC member, how you can become one, and meet our current TSC members.' },
   { icon: IconMeetings, title: 'Meetings', href: '/community/meetings', description: 'See what meetings are organized under AsyncAPI umbrella and join one of them.' },
-  { icon: IconMeetings, title: 'Google Season of Docs (GSoD)', href: '/community/gsod', description: 'All technical writers are welcome to participate, regardless of tech background or years of experience!' },
-  { icon: IconMeetings, title: 'Google Summer of Code (GSoC)', href: '/community/gsoc', description: 'All information needed about how AsyncAPI participates in Google Summer of Code (GSoC).' }
+  { icon: IconMeetings, title: 'Mentorship', href: '/community/mentorship', description: 'All technical writers are welcome to participate, regardless of tech background or years of experience!' },
 ]

--- a/components/navigation/communityItems.js
+++ b/components/navigation/communityItems.js
@@ -5,12 +5,13 @@ import IconContributing from '../icons/Contributing'
 import IconTSC from '../icons/TSC'
 import IconMeetings from '../icons/Meetings'
 
-
 export default [
   { icon: IconTools, title: 'Tools & Services', href: '/docs/community/tooling', description: 'Explore the tools and services our awesome community has created.' },
   { icon: IconGithubOrganization, title: 'Github Organization', href: 'https://github.com/asyncapi', target: '_blank', description: 'Want to sneak in the code? Everything we do is open-sourced in our Github organization.' },
   { icon: IconSlack, title: 'Slack Workspace', href: 'https://asyncapi.com/slack-invite', target: '_blank', description: `Need help? Want to share something? Join our Slack workspace. We're nice people :)` },
   { icon: IconContributing, title: 'Contributing', href: 'https://github.com/asyncapi?type=source#-contribute-to-asyncapi', target: '_blank', description: `We are always welcoming and looking for contributions. If you are interested check out our contribution guide.` },
   { icon: IconTSC, title: 'Technical Steering Committee', href: '/community/tsc', description: 'Get to know what is a TSC member, how you can become one, and meet our current TSC members.' },
-  { icon: IconMeetings, title: 'Meetings', href: '/community/meetings', description: 'See what meetings are organized under AsyncAPI umbrella and join one of them.' }
+  { icon: IconMeetings, title: 'Meetings', href: '/community/meetings', description: 'See what meetings are organized under AsyncAPI umbrella and join one of them.' },
+  { icon: IconMeetings, title: 'Google Season of Docs (GSoD)', href: '/community/gsod', description: 'All technical writers are welcome to participate, regardless of tech background or years of experience!' },
+  { icon: IconMeetings, title: 'Google Summer of Code (GSoC)', href: '/community/gsoc', description: 'All information needed about how AsyncAPI participates in Google Summer of Code (GSoC).' }
 ]

--- a/pages/community/gsoc.js
+++ b/pages/community/gsoc.js
@@ -1,0 +1,100 @@
+import GenericLayout from '../../components/layout/GenericLayout'
+import Heading from '../../components/typography/Heading'
+import Paragraph from '../../components/typography/Paragraph'
+
+export default function GSoCPage() {
+
+  return (
+      <div className="py-12 overflow-hidden">
+        <div className="relative max-w-xl mx-auto px-4 sm:px-6 lg:px-8 lg:max-w-screen-xl">
+          <div className="relative">
+            <Heading level="h1" typeStyle="heading-lg">
+              Google Summer of Code at AsyncAPI 
+            </Heading>
+            <Paragraph>
+            The intention of this page is to list all information that explains how AsyncAPI Initiative participates in Google Summer of Code (GSoC) in 2022.
+            </Paragraph>
+          </div>
+
+          <div className="relative mb-8 lg:mt-8">
+              <Heading level="h2" typeStyle="heading-md-semibold">
+              A bit of history
+              </Heading> 
+              <Paragraph className="mt-4 lg:pr-4">
+              AsyncAPI already participated in GSoC in 2021. We were not accepted as organization, but it was also a time when we were not yet part of the Linux Foundation. Therefore some of AsyncAPI maintainers pushed their ideas through Postman (that was accepted for GSoC) because they were Postman employees working on AsyncAPI. So far so good?
+              <br></br>
+              We mentored 5 mentees. All of them successfully completed GSoC. As a result, all of them became members of our Technical Steering Committee and also presented their solutions at AsyncAPI Conference 2021:
+            
+              <ul>
+                <li>GSoC: Writing the spec document without knowing the specification - Elegbede Azeez W., Individual C.</li>
+                <li>GSoC: Visualise your defined EDA using Cupid - Arjun Garg, Individual Contributor</li>
+                <li>GSoC: Make your AsyncAPI document shorter with Optimizer - Khuda Dad Nomani, Individual Contributor</li>
+                <li>GSoC: Generating diffs using AsyncAPI Diff - Aayush Sahu, Individual Contributor</li>
+                <li>Nektarios that created https://github.com/asyncapi/simulator could not, unfortunately, join the conference</li>
+              </ul>
+        
+              We want to repeat history on an even larger scale in 2022.  
+              </Paragraph>
+          </div>
+
+          <div className="relative mb-8 lg:mt-8">
+              <Heading level="h2" typeStyle="heading-md-semibold">
+              What about 2022?
+              </Heading> 
+              <Paragraph className="mt-4 lg:pr-4">
+              We already shared some of the details in our live stream dedicated to contributors. We already counted about 8 mentors (AsyncAPI maintainers) that want to join in this GSoC edition and help. The number will grow for sure.
+              </Paragraph>
+          </div>
+
+          <div className="relative mb-8 lg:mt-8">
+              <Heading level="h3" typeStyle="heading-md-semibold">
+              How we work on proposals
+              </Heading> 
+              <Heading level="h4" typeStyle="heading-md-semibold">
+              All on GitHub
+              </Heading> 
+              <Paragraph className="mt-4 lg:pr-4">
+              AsyncAPI Initiative is a community-driven organization that puts radical transparency at the core of its values.
+              <br></br>
+              This means all the work on proposals should take place in GitHub and be fully transparent.
+              <br></br>
+              Another good reason for this approach is that it is easy to identify duplicates and proposals that have more than one candidate. We do not want to reject candidates just because there are too many for one proposal. Let us discover it sooner and make sure we can enable as many people as possible.
+              </Paragraph>
+          </div>
+
+          <div className="relative mb-8 lg:mt-8">
+              <Heading level="h4" typeStyle="heading-md-semibold">
+              Processing Proposals 
+              </Heading> 
+              <Paragraph className="mt-4 lg:pr-4">
+              Proposals can be submitted either as GitHub Discussion or GitHub Issue in AsyncAPI GitHub organization.
+              <br></br>
+              We label proposals with gsoc label in order to make them easy to discover in the following dashboard: GitHub GSoC Issues. In case you do not have a GitHub account and cannot access the list, try here.
+              <br></br>
+              Proposal suggestions can be created by anyone. There is no specific template to follow, only common sense. Describe in a detailed way what is it about, what are the requirements and desired outcome. If the proposal suggestion misses some details - do not worry, we will follow up with request for more clarification.
+              <br></br>
+              We will make sure there are mentors for each proposal.
+              </Paragraph>
+          </div>
+
+          <div className="relative mb-8 lg:mt-8">
+              <Heading level="h3" typeStyle="heading-md-semibold">
+              How to connect with us
+              </Heading> 
+              <Paragraph className="mt-4 lg:pr-4">
+                <lu>
+                  <li>Join our Slack workspace. Just make sure to follow our Slack etiquette and the code of conduct.</li>
+                  <li>Join the dedicated GSoC channel #temp-gsoc-2022 that we will use to coordinate the application process until coding starts. All mentees and mentors are there.</li>
+                </lu>
+
+                Happy coding ☮️!
+              </Paragraph>
+          </div>
+
+
+
+        </div>    
+      </div>
+        
+  )
+}

--- a/pages/community/gsod.js
+++ b/pages/community/gsod.js
@@ -1,0 +1,144 @@
+import GenericLayout from '../../components/layout/GenericLayout'
+import Heading from '../../components/typography/Heading'
+import Paragraph from '../../components/typography/Paragraph'
+
+export default function GSoDPage() {
+
+  return (
+      <div className="py-12 overflow-hidden">
+        <div className="relative max-w-xl mx-auto px-4 sm:px-6 lg:px-8 lg:max-w-screen-xl">
+          <div className="relative">
+            <Heading level="h1" typeStyle="heading-lg">
+              📑 Google Season of Docs at AsyncAPI 
+            </Heading>
+            <Paragraph>
+            All technical writers are welcome to participate with AsyncAPI for GSoD 2022 season, regardless of tech background or years of experience! At AsynAPI, we love mentoring folks who want to get involved in OSS, tech, and Docs.
+            </Paragraph>
+          </div>
+          <br></br>
+          <div className="relative">
+            <Paragraph>
+            Below is the project proposal we've submitted to GSoD 2022 and then we close with a reminder of how to get started as an AsyncAPI Docs contributor:            
+            </Paragraph>
+          </div>
+
+          <div className="relative mt-12">
+            <div className="relative mb-8 lg:mt-8">
+              <Heading level="h2" typeStyle="heading-md-semibold">
+                🙌🏾 Update Docs Information Architecture - AsyncAPI Initiative
+              </Heading>
+              <Heading level="h3" typeStyle="heading-md-semibold">
+              ❤️ About AsyncAPI
+              </Heading> 
+              <Paragraph className="mt-4 lg:pr-4">
+              AsyncAPI (currently version 2.3.0, first released in 2016) is an Apache License 2.0 library under the Linux Foundation that seeks to improve the current state of Event-Driven Architectures (EDA). The AsyncAPI Initiative is a specification and growing set of open-source tools to help developers define asynchronous APIs, and build and maintain event-driven architectures. Developers familiar with OpenAPI (aka Swagger) for RESTful APIs will see strong similarities when using AsyncAPI. One common use case is generating documentation (HTML or Markdown) of an asynchronous API. The specification is both platform and language agnostic. Current tooling includes support for common message brokers such as Apache Kafka and RabbitMQ, and languages including Python, Java, and Nodejs. Our long-term goal is to make working with EDAs as easy as working with REST APIs. That goes from documentation to code generation, from discovery to event management, and beyond. Our 150+ Open-Source (OSS) contributors are EDA enthusiasts from all around the world.
+              </Paragraph>
+            </div>
+
+            <div className="relative mb-8 lg:mt-8">
+            <Heading level="h3" typeStyle="heading-md-semibold">
+             📑 About our Docs project
+            </Heading> 
+            <Paragraph className="mt-4 lg:pr-4">
+            Our current Docs and their Information Architecture (IA) needs a major makeover. The current content buckets are far from ideal and much basic content is missing to help onboard new contributors. Users new to our API spec need /Conceptual docs that explain our spec terminology in more detail with engineering diagrams: people often learn visually! We also have to move our CLI docs under the Docs upcoming new Reference content bucket; currently, we have a README version of CLI docs only. Similarly, we're adding a new and broader /Tools section of documentation for our tools in individual tools' GitHub repositories, under a /docs directory. Those should still remain there and continue to be maintained, but they also need to be documented in our Docs in a less informal way than what you see in a README. In time, we also need to add many more tutorials (i.e. Websocket, Kafka, etc) and Use Cases and Troubleshooting Guides, under a new How-To section. 
+            <br></br>
+            We also need to re-structure the Generator tool docs. Because this is one of our main tools, it's big enough to be it's own independent project for 2022 GSoD. Currently, our Generator docs need a major update, to better explain every single functionality of the Generator.
+            </Paragraph>
+            </div>
+
+            <div className="relative mb-8 lg:mt-8">
+            <Heading level="h3" typeStyle="heading-md-semibold">
+            🎯 Our Docs project's scope
+            </Heading> 
+            <Paragraph className="mt-4 lg:pr-4">
+            We're already invested in utilizing the Diátaxis methodology for determining our content buckets (Concepts, Tutorials, Tools, How-To Guides, Reference). Along with this change, it makes sense to add new landing pages that introduce each content bucket. Each content bucket landing page could include cards featuring requested content from the community that still needs contributions. Then each card will read, "Contributors Needed."
+            <br></br>
+            AsyncAPI has several CLI and Tools markdown README documentation in miscellaneous GitHub repositories that we plan to migrate over to the main Docs site. This task is part of our goal for finalizing our 2022 AsyncAPI Docs Information Architecture makeover. We explain this in more detail in our previous OSS blog post titled "Change is coming to our AsyncAPI Developer Documentation". It's also extensively documented in our AsyncAPI Docs GitHub Project Board.
+            <br></br>
+            In addition, we want to also target improving the Generator tool docs that are only READMEs in a repo right now. The Docs for this one tool are a big enough job to merit being our 2nd proposed project for 2022 GSoD.
+            <br></br>
+            We're also writing voluntary OSS bi-weekly updates via GitHub Gists to speak about the latest updates made in the AsyncAPI Docs Ecosystem. Due to our commitment to investing time in gaining interest in our community and getting Google excited about us, we've made sure to maintain updates about our Google Season of Docs 2022 application too! In fact, you can take a look at the latest three where we made said mentions here in AsyncAPI Docs update (31 Jan - 11 Feb 2022), AsyncAPI Docs update (14 Feb - 25 Feb 2022), and AsyncAPI Docs update (28 Feb - 11 March 2022).
+            </Paragraph>
+            </div>
+
+            <div className="relative mb-8 lg:mt-8">
+            <Heading level="h3" typeStyle="heading-md-semibold">
+            📏 Measuring our Docs project's success
+            </Heading> 
+            <Paragraph className="mt-4 lg:pr-4">
+            We will partially measure success in the Docs project by capturing specific feedback about the IA changes via our soon-to-come new Docs Feedback card. We need this specific and granular feedback to make sure we listen and make changes according to what the community requests from Docs. In previous AsyncAPI Docs Gist updates, we've mentioned that Design contributors were teaming with Docs on /websiteissue #453 for the ideation and development of our new feedback card that will be added at the bottom of each Docs page. What the community decided over the last 2 weeks was that the Submit feedback button in the card will publish the feedback anonymously via the AsyncAPI bot and create a new GitHub Discussion with said feedback:
+            <br></br>
+            The other way we would consider the project successful is the number of our contributors and Docs PRs increased from 3 to 6 community members. Currently, a majority of our OSS contributor community focuses only on contributing code, but we would like to instill a greater interest in contributing to documentation that provides value for everyone.
+            </Paragraph>
+            </div>
+
+            <div className="relative mb-8 lg:mt-8">
+            <Heading level="h3" typeStyle="heading-md-semibold">
+            ⌛ Timeline
+            </Heading> 
+            <Paragraph className="mt-4 lg:pr-4">
+            The project itself will take approximately 4-6 months to complete, depending on the different levels of knowledge from diverse technical writers (TW) that might get involved. (At AsyncAPI, we want to work with any TW, regardless of their years of experience. We have a passion for mentorship, and we do not wish to have a bar that would prevent any TW from contributing to our OSS Initiative. In fact, we look forward to potentially mentoring TW(s) who are completely new to tech and making them feel welcome!)
+            <br></br>
+            For our 2 projects, we would like to request a minimum of 2 TWs, so that we can work on both the CLI/Tools and Generator Docs.
+            <br></br>
+            The timeline would look as following:
+            </Paragraph>
+            <ul>
+              <li>May: Orientation on how to contribute to AsyncAPI Inititiave, how Docs issues are organized, detail how we're migrating our CLI and Tools Docs, and assign good first-time-tickets to get each new TW contributor started.</li>
+              <li>June - August: Each TW goes through designated issues marked for both first time contributors and work set aside for GSoD 2022. Each TW starts creating documentation for their individual issues assigned/selected.</li>
+              <li>September - October: We determine if we're going to be able to complete both CLI and Tools Docs plus the Generator Docs, depending on how many TWs are in our group and how much they've been able to complete so far. We re-align priorities as needed and asses what is missing to reach our 2022 IA change goals for AsyncAPI Docs.</li>
+              <li>November: Project completion and all contributors receive some swag!</li>
+            </ul>
+            </div>
+
+            <div className="relative mb-8 lg:mt-8">
+            <Heading level="h3" typeStyle="heading-md-semibold">
+            💸 Project budget 
+            </Heading> 
+            <Paragraph className="mt-4 lg:pr-4">
+            We have set aside 2 mentors for now, for our 2 projects: improving our IA and re-structuring our Generator Docs. Should we be selected, AsyncAPI would like to request from Google a US $5000 budget for each project. For both projects, the request then totals for a $10,000 budget.
+            </Paragraph>
+
+            <table>
+              <thead>
+                <tr>
+                  <th>Budget item</th>
+                  <th>Total Amount</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Technical writer updates, reviews, edits, and publishing new documentation for the IA improvements. </td>
+                  <td>$5000</td>
+                </tr>
+                <tr>
+                  <td>Technical writer updates, reviews, migration, and publishing improved Generator tool documentation.</td>
+                  <td>$5000</td>
+                </tr>
+              </tbody>
+              </table>
+            </div>
+
+            <div className="relative mb-8 lg:mt-8">
+            <Heading level="h3" typeStyle="heading-md-semibold">
+            👉🏽 Get started contributing to AsyncAPI Docs Today
+            </Heading> 
+            <Paragraph className="mt-4 lg:pr-4">
+            Last but not least, don't forget that code isn't the only way to contribute to OSS; Dev Docs are a huge help that benefit the entire OSS ecosystem. At AsyncAPI, we value Doc contributions as much as every other type of contribution.
+            <br></br>
+            To get started as a Docs contributor:
+            <br></br>
+            <ul>
+              <li>Familiarize yourself with our project's Contribution Guide and our Code of Conduct.</li>
+              <li>Head over to our Docs GH Board here.</li>
+              <li>Pick an issue you would like to contribute to and leave a comment introducing yourself. This is also the perfect place to leave any questions you may have on how to get started.</li>
+              <li>If there is no work done in that Docs issue yet, feel free to open a PR and get started!</li>
+            </ul>       
+            </Paragraph>
+            </div>
+
+          </div>
+        </div>
+      </div>
+  )
+}

--- a/pages/community/mentorship/_section.md
+++ b/pages/community/mentorship/_section.md
@@ -1,0 +1,4 @@
+---
+title: Mentorship
+weight: 0
+---

--- a/pages/community/mentorship/gsoc/_section.md
+++ b/pages/community/mentorship/gsoc/_section.md
@@ -1,0 +1,4 @@
+---
+title: Google Summer Of Code
+weight: 1
+---

--- a/pages/community/mentorship/gsoc/index.md
+++ b/pages/community/mentorship/gsoc/index.md
@@ -1,0 +1,12 @@
+---
+title: Google Summer Of Code
+weight: 0
+---
+
+## Welcome to AsyncAPI Mentorship! 
+
+AsyncAPI is an open source initiative that seeks to improve the current state of Event-Driven Architectures (EDA). Our long-term goal is to make working with EDAs as easy as working with REST APIs. That goes from documentation to code generation, from discovery to event management, and beyond.
+
+## Explore the Docs
+
+lorem ipsum

--- a/pages/community/mentorship/gsod/_section.md
+++ b/pages/community/mentorship/gsod/_section.md
@@ -1,0 +1,4 @@
+---
+title: Google Summer Of Docs
+weight: 2
+---

--- a/pages/community/mentorship/gsod/index.md
+++ b/pages/community/mentorship/gsod/index.md
@@ -3,10 +3,96 @@ title: Google Summer Of Docs
 weight: 2
 ---
 
-## Welcome to AsyncAPI Mentorship! 
+![Google Season of Docs Logo ](https://user-images.githubusercontent.com/19964402/160034755-3eee923e-68a0-426f-9033-bf2b96e5cda0.png)
 
-AsyncAPI is an open source initiative that seeks to improve the current state of Event-Driven Architectures (EDA). Our long-term goal is to make working with EDAs as easy as working with REST APIs. That goes from documentation to code generation, from discovery to event management, and beyond.
+## Hola
 
-## Explore the Docs
+¡Hola, AsyncAPI community! 😄
 
-lorem ipsum
+For today's latest announcement around AsyncAPI Docs 📑, I wanted to share with all technical writers about our organization’s plan for participation in `Google Season of Docs 2022 (GSoD)`. Any and all technical writers are welcome to come and participate with us for GSoD 2022 season, regardless of tech background or years of experience! At AsynAPI, we love mentoring folks who want to get involved in OSS, tech, and Docs. ❤️
+
+As some of you may remember from my [Gist Docs update for 31 Jan - 11 Feb 2022](https://gist.github.com/alequetzalli/94ca1ffb5d123b450501e40a4a3b56e2), I noted that GSoD 2022 was coming up and that AsyncAPI wanted to participate in the application process once it opened on February 23, 2022. 
+
+In anticipation of this, I also created a new AsyncAPI Slack channel named `#temp-gsod-2022` that anyone can join! First, [join our Slack workspace](https://www.asyncapi.com/slack-invite) ☎️ and please respect [our slack etiquette](https://github.com/asyncapi/.github/blob/master/slack-etiquette.md).🙂 Then join the `temp-gsod-2022` channel, our temporary channel to coordinate GSoC 2022 setup. I'll publish regular updates on where we are in the application process, so stay tuned as the process continues. 🙂
+
+Join the `#temp-gsod-2022` slack channel for:
+- mentees identification
+- mentors identification
+- ideas identification
+- mentees and ideas and mentors matching
+
+Below is the **project proposal** we've submitted to `GSoD 2022` and then we close with a reminder of how to get started as an AsyncAPI Docs contributor:
+
+# Update Docs Information Architecture - AsyncAPI Initiative 
+
+## About AsyncAPI
+
+AsyncAPI (currently version 2.3.0, first released in 2016) is an Apache License 2.0 library [under the Linux Foundation](https://www.linuxfoundation.org/press-release/linux-foundation-will-host-asyncapi-to-support-growth-and-collaboration-for-industrys-fastest-growing-api-spec/) that seeks to improve the current state of Event-Driven Architectures (EDA). The AsyncAPI Initiative is a specification and growing set of open-source tools to help developers define asynchronous APIs, and build and maintain event-driven architectures. Developers familiar with OpenAPI (aka Swagger) for RESTful APIs will see strong similarities when using AsyncAPI. One common use case is generating documentation (HTML or Markdown) of an asynchronous API. The specification is both platform and language agnostic. Current tooling includes support for common message brokers such as Apache Kafka and RabbitMQ, and languages including Python, Java, and Nodejs. Our long-term goal is to make working with EDAs as easy as working with REST APIs. That goes from documentation to code generation, from discovery to event management, and beyond. Our 150+ Open-Source (OSS) contributors are EDA enthusiasts from all around the world. 
+
+## About our Docs project
+
+### Our current Docs problem
+
+Our current Docs and their Information Architecture (IA) needs a major makeover. The current content buckets are far from ideal and much basic content is missing to help onboard new contributors. Users new to our API spec need `/Conceptual` docs that explain our spec terminology in more detail with engineering diagrams: people often learn visually! We also have to move our CLI docs under the Docs upcoming new `Reference` content bucket; currently, we have a README version of CLI docs only. Similarly, we're adding a new and broader `/Tools` section of documentation for our tools in individual tools' GitHub repositories, under a `/docs` directory. Those should still remain there and continue to be maintained, but they also need to be documented in our Docs in a less informal way than what you see in a README. In time, we also need to add many more tutorials (i.e. Websocket, Kafka, etc) and Use Cases and Troubleshooting Guides, under a new `How-To` section.
+
+We also need to re-structure the [Generator tool](https://github.com/asyncapi/template-for-generator-templates) docs. Because this is one of our main tools, it's big enough to be it's own independent project for 2022 GSoD. Currently, our Generator docs need a major update, to better explain every single functionality of the Generator. 
+
+### Our Docs project’s scope
+
+We're already invested in utilizing the [Diátaxis methodology](https://diataxis.fr/) for determining our **content buckets** _(Concepts, Tutorials, Tools, How-To Guides, Reference)_. Along with this change, it makes sense to add new landing pages that introduce each content bucket. Each content bucket landing page could include cards featuring requested content from the community that still needs contributions. Then each card will read, "Contributors Needed." 
+
+AsyncAPI has several CLI and Tools markdown README documentation in miscellaneous GitHub repositories that we plan to migrate over to the main Docs site. This task is part of our goal for finalizing our 2022 AsyncAPI Docs Information Architecture makeover. We explain this in more detail in our previous OSS blog post titled ["Change is coming to our AsyncAPI Developer Documentation"](https://www.asyncapi.com/blog/changes-coming-docs). It's also extensively documented in our [AsyncAPI Docs GitHub Project Board](https://github.com/orgs/asyncapi/projects/8). 
+
+In addition, we want to also target improving the [Generator tool](https://github.com/asyncapi/template-for-generator-templates) docs that are only READMEs in a repo right now. The Docs for this one tool are a big enough job to merit being our 2nd proposed project for 2022 GSoD.
+
+We're also writing voluntary OSS bi-weekly updates via GitHub Gists to speak about the latest updates made in the AsyncAPI Docs Ecosystem. Due to our commitment to investing time in gaining interest in our community and getting Google excited about us, we've made sure to maintain updates about our `Google Season of Docs 2022` application too! In fact, you can take a look at the latest three where we made said mentions here in [AsyncAPI Docs update (31 Jan - 11 Feb 2022)](https://gist.github.com/alequetzalli/94ca1ffb5d123b450501e40a4a3b56e2), [AsyncAPI Docs update (14 Feb - 25 Feb 2022)](https://gist.github.com/alequetzalli/d34e3aececa49d10d0ddb2dc9938b477), and [AsyncAPI Docs update (28 Feb - 11 March 2022)](https://gist.github.com/alequetzalli/8f449f731b919193f4101098a69da14d).
+
+### Measuring our Docs project’s success
+
+We will partially measure success in the Docs project by capturing specific feedback about the IA changes via our soon-to-come new [Docs Feedback card](https://github.com/asyncapi/website/issues/453). We need this specific and granular feedback to make sure we listen and make changes according to what the community requests from Docs. In previous AsyncAPI Docs Gist updates, we've mentioned that Design contributors were teaming with Docs on `/website`issue [#453](https://github.com/asyncapi/website/issues/453) for the ideation and development of our new **feedback card** that will be added at the bottom of each Docs page. What the community decided over the last 2 weeks was that the `Submit feedback` button in the card will publish the feedback anonymously via the AsyncAPI bot and create a new **GitHub Discussion** with said feedback:
+
+![A screenshot displaying the design of our new feedback card for receiving feedback on AsyncAPI Docs](https://user-images.githubusercontent.com/19964402/160034876-2fff83b8-b2ae-46ce-849a-9ce735b23d6e.png "A screenshot displaying the design of our new feedback card for receiving feedback on AsyncAPI Docs")
+
+![A screenshot of AsyncAPI GitHub Discussions for the Docs category](https://user-images.githubusercontent.com/19964402/160034880-89a37fbc-c86c-4921-930e-9eaa766b8e21.png "A screenshot of AsyncAPI GitHub Discussions for the Docs category")
+
+The other way we would consider the project successful is the number of our contributors and Docs PRs increased from 3 to 6 community members. Currently, a majority of our OSS contributor community focuses only on contributing code, but we would like to instill a greater interest in contributing to documentation that provides value for everyone.
+
+### Timeline
+
+The project itself will take approximately 4-6 months to complete, depending on the different levels of knowledge from diverse technical writers (TW) that might get involved. (At AsyncAPI, we want to work with any TW, regardless of their years of experience. We have a passion for mentorship, and we do not wish to have a bar that would prevent any TW from contributing to our OSS Initiative. In fact, we look forward to potentially mentoring TW(s) who are completely new to tech and making them feel welcome!)
+
+For our 2 projects, we would like to request a minimum of 2 TWs, so that we can work on both the CLI/Tools and Generator Docs. 
+
+The timeline would look as following:
+- **May:** Orientation on how to contribute to AsyncAPI Inititiave, how Docs issues are organized, detail how we're migrating our CLI and Tools Docs, and assign good `first-time-tickets` to get each new TW contributor started. 
+- **June - August:**\tEach TW goes through designated issues marked for both first time contributors and work set aside for `GSoD 2022`. Each TW starts creating documentation for their individual issues assigned/selected. 
+- **September - October:** We determine if we're going to be able to complete both CLI and Tools Docs plus the Generator Docs, depending on how many TWs are in our group and how much they've been able to complete so far. We re-align priorities as needed and asses what is missing to reach our 2022 IA change goals for AsyncAPI Docs.
+- **November:**\tProject completion and all contributors receive some swag! 
+
+### Project budget
+
+We have set aside 2 mentors for now, for our 2 projects: improving our IA and re-structuring our Generator Docs. Should we be selected, AsyncAPI would like to request from Google a US $5000 budget for each project. For both projects, the request then totals for a $10,000 budget. 
+
+| **Budget item** | **Total Amount** |
+|------------------------------------------------------------------------------------------------------|------------------|
+| Technical writer updates, reviews, edits, and publishing new documentation for the IA improvements. | $5000 |
+| Technical writer updates, reviews, migration, and publishing improved Generator tool documentation. | $5000 |
+| **TOTAL** | $10,000 |
+
+## Get started contributing to AsyncAPI Docs Today
+
+Last but not least, don't forget that code isn't the only way to contribute to OSS; Dev Docs are a **huge** help that benefit the entire OSS ecosystem. At AsyncAPI, we value Doc contributions as much as every other type of contribution. ❤️
+
+To get started as a Docs contributor:
+1. Familiarize yourself with our [project's Contribution Guide](https://github.com/asyncapi/community/blob/master/CONTRIBUTING.md) and our [Code of Conduct](https://github.com/asyncapi/.github/blob/master/CODE_OF_CONDUCT.md).
+2. Head over to our Docs GH Board [here](https://github.com/orgs/asyncapi/projects/8).
+3. Pick an issue you would like to contribute to and leave a comment introducing yourself. This is also the perfect place to leave any questions you may have on how to get started. 
+4. If there is no work done in that Docs issue yet, feel free to open a PR and get started!
+
+### Tag me in your AsyncAPI Doc PRs
+
+Do you have a documentation contributor question and you're wondering how to tag me into a GitHub discussion or PR? Never fear!
+
+Tag me in your AsyncAPI Doc PRs or [GitHub Discussions](https://github.com/asyncapi/community/discussions/categories/docs) via my GitHub handle, [`alequetzalli`](https://github.com/alequetzalli) 🐙.
+
+*-A.Q. 👩🏻‍💻 and Canela 🐕‍🦺*"

--- a/pages/community/mentorship/gsod/index.md
+++ b/pages/community/mentorship/gsod/index.md
@@ -1,0 +1,12 @@
+---
+title: Google Summer Of Docs
+weight: 2
+---
+
+## Welcome to AsyncAPI Mentorship! 
+
+AsyncAPI is an open source initiative that seeks to improve the current state of Event-Driven Architectures (EDA). Our long-term goal is to make working with EDAs as easy as working with REST APIs. That goes from documentation to code generation, from discovery to event management, and beyond.
+
+## Explore the Docs
+
+lorem ipsum

--- a/pages/community/mentorship/index.md
+++ b/pages/community/mentorship/index.md
@@ -1,0 +1,12 @@
+---
+title: Welcome
+weight: 0
+---
+
+## Welcome to AsyncAPI Mentorship! 
+
+AsyncAPI is an open source initiative that seeks to improve the current state of Event-Driven Architectures (EDA). Our long-term goal is to make working with EDAs as easy as working with REST APIs. That goes from documentation to code generation, from discovery to event management, and beyond.
+
+## Explore the Docs
+
+lorem ipsum

--- a/scripts/build-post-list.js
+++ b/scripts/build-post-list.js
@@ -12,6 +12,7 @@ const result = []
 const basePath = 'pages'
 const postDirectories = [
   [`${basePath}/docs`, '/docs'],
+  [`${basePath}/community/mentorship`, '/community/mentorship'],
   [`${basePath}/blog`, '/blog'],
   [`${basePath}/about`, '/about'],
   [`${basePath}/jobs`, '/jobs'],


### PR DESCRIPTION
## Contribution Description
The purpose of this PR is to create 2 NEW pages on our website for `/GSoD` (Google Season of Docs) and `/GSoC`(Google Summer of Code). In addition to adding those 2 pages to our website, I'm also proposing adding nav links to these pages under the **Community** nav group.

<img width="500" alt="Screen Shot 2022-03-30 at 3 51 33 PM" src="https://user-images.githubusercontent.com/19964402/160948246-6c6d5e8c-3cd4-434e-bc23-a8283f4080aa.png">

I truly love the idea of having them under `Community` because they are (potentially) a huge group event to do with the whole community. It just seemed to fit under that section best. But I know (as you can see too) that the sub-nav `<li>`s look like a long list now, so I will understand if you folks are wondering about that. Perhaps the styling should change to make the dropdown be a wider rectangle horizontally vs the current vertical grid?

## Page sources 
- The [`/GSoC`(Google Summer of Code) page gets its details from here](https://github.com/asyncapi/community/discussions/261).
- The [`/GSoD` (Google Season of Docs) page gets its details from here](https://github.com/asyncapi/community/discussions/303).

