### PR TITLE
feat: add new newsletter view

### DIFF
--- a/components/NewsletterSubscribe.js
+++ b/components/NewsletterSubscribe.js
@@ -11,17 +11,20 @@ export default function NewsletterSubscribe ({
 }) {
   if (!formName) throw new Error('Parameter formName is required for the NewsletterSubscribe component.')
 
+  const headTextColor = dark ? 'text-white' : ''
+  const paragraphTextColor = dark ? 'text-gray-300' : ''
+
   return (
     <div className={className}>
       <Heading 
         level="h3"
-        textColor="text-white"
+        textColor={headTextColor}
         typeStyle="heading-lg"
         className="mb-4"
       >
         {title}
       </Heading>
-      <Paragraph className="mb-8" textColor="text-gray-300">
+      <Paragraph className="mb-8" textColor={paragraphTextColor}>
         We respect your inbox. No spam, promise ✌️
       </Paragraph>
       <form className="md:flex" data-netlify="true">

--- a/components/layout/BlogLayout.js
+++ b/components/layout/BlogLayout.js
@@ -86,7 +86,6 @@ export default function BlogLayout({ post, children }) {
           </article>
         </main>
       </Container>
-      <Footer />
     </BlogContext.Provider>
   )
 }

--- a/components/layout/DocsLayout.js
+++ b/components/layout/DocsLayout.js
@@ -114,7 +114,6 @@ export default function DocsLayout({ post, navItems = {}, children }) {
         </div>
         </div>
       </div>
-      <Footer/>
     </DocsContext.Provider>
   )
 }

--- a/components/layout/DocsLayout.js
+++ b/components/layout/DocsLayout.js
@@ -24,7 +24,6 @@ function generateEditLink(post) {
 }
 
 export default function DocsLayout({ post, navItems = {}, children }) {
-  
   if (!post) return <ErrorPage statusCode={404} />
   if (post.title === undefined) throw new Error('Post title is required')
 
@@ -49,7 +48,7 @@ export default function DocsLayout({ post, navItems = {}, children }) {
       <StickyNavbar>
             <NavBar className="max-w-screen-xl block px-4 sm:px-6 lg:px-8 mx-auto" />
         </StickyNavbar>
-      <div className="bg-white px-4 sm:px-6 lg:px-8 xl:max-w-7xl xl:mx-auto">
+      <div className="bg-white px-4 sm:px-6 lg:px-8 w-full xl:max-w-7xl xl:mx-auto">
         { showMenu && (
           <DocsMobileMenu onClickClose={() => setShowMenu(false)} post={post} navigation={navigation} />
         ) }

--- a/components/layout/GenericLayout.js
+++ b/components/layout/GenericLayout.js
@@ -28,7 +28,6 @@ export default function GenericLayout({
         <AnnouncementHero className="text-center m-4" small={true} />
         {children}
       </Container>
-      <Footer />
     </>
   )
 }

--- a/components/layout/GenericPostLayout.js
+++ b/components/layout/GenericPostLayout.js
@@ -38,7 +38,6 @@ export default function GenericPostLayout({ post, children }) {
           </article>
         </main>
       </Container>
-      <Footer />
     </GenericPostContext.Provider>
   )
 }

--- a/components/layout/GenericWideLayout.js
+++ b/components/layout/GenericWideLayout.js
@@ -28,7 +28,6 @@ export default function GenericWideLayout({
         <AnnouncementHero className="text-center m-4" small={true} />
         {children}
       </Row>
-      <Footer />
     </>
   )
 }

--- a/components/layout/JobsLayout.js
+++ b/components/layout/JobsLayout.js
@@ -42,7 +42,6 @@ export default function JobsLayout({ post, children }) {
           </div>
         </main>
       </Container>
-      <Footer />
     </JobsContext.Provider>
   )
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -19,6 +19,7 @@ import Banner from '../components/campaigns/Banner'
 import Link from 'next/link'
 import DocsButton from '../components/buttons/DocsButton';
 import AppContext from '../context/AppContext'
+import Footer from "../components/Footer";
 import '../css/styles.css'
 
 export default function MyApp({ Component, pageProps, router }) {
@@ -28,11 +29,16 @@ export default function MyApp({ Component, pageProps, router }) {
       <Head>
           <script async defer src="https://buttons.github.io/buttons.js"></script>
       </Head>
-      <Banner />
       <MDXProvider components={getMDXComponents()}>
-        <Layout>
-          <Component {...pageProps} />
-        </Layout>
+        <div className="flex flex-col h-screen">
+          <Banner />
+          <Layout>
+            <Component {...pageProps} />
+          </Layout>
+          <div className="mt-auto">
+            <Footer />
+          </div>
+        </div>
       </MDXProvider>
     </AppContext.Provider>
   )

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -30,7 +30,7 @@ export default function MyApp({ Component, pageProps, router }) {
           <script async defer src="https://buttons.github.io/buttons.js"></script>
       </Head>
       <MDXProvider components={getMDXComponents()}>
-        <div className="flex flex-col h-screen">
+        <div className="flex flex-col min-h-screen">
           <Banner />
           <Layout>
             <Component {...pageProps} />

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -111,7 +111,6 @@ export default function BlogIndexPage() {
           </div>
         </div>
       </div>
-      <Footer />
     </div>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -256,7 +256,6 @@ function HomePage() {
           <Button bgClassName="bg-none border border-gray-200 text-gray-800 hover:text-gray-700 shadow-none" href="/blog" text="View more blog posts" />
         </div>
       </Container>
-      <Footer />
     </>
   )
 }

--- a/pages/jobs/index.js
+++ b/pages/jobs/index.js
@@ -171,7 +171,6 @@ Join us!
           </div>
         </div>
       </div>
-      <Footer />
     </div>
   );
 }

--- a/pages/newsletter/index.js
+++ b/pages/newsletter/index.js
@@ -1,0 +1,24 @@
+import NavBar from "../../components/navigation/NavBar";
+import Footer from "../../components/Footer";
+import Head from "../../components/Head";
+import Container from '../../components/layout/Container'
+import StickyNavbar from "../../components/navigation/StickyNavbar"
+import NewsletterSubscribe from '../../components/NewsletterSubscribe'
+
+export default function NewsletterIndexPage() {
+
+  return (
+    <div>
+      <Head title="Newsletter"/>
+      <StickyNavbar>
+       <NavBar className="max-w-screen-xl block px-4 sm:px-6 lg:px-8 mx-auto" />
+      </StickyNavbar>
+      <div className="bg-gray-900 py-12 mt-12">
+        <Container wide>
+          <NewsletterSubscribe formName="form 1" dark />
+        </Container>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/pages/newsletter/index.js
+++ b/pages/newsletter/index.js
@@ -1,24 +1,21 @@
 import NavBar from "../../components/navigation/NavBar";
-import Footer from "../../components/Footer";
 import Head from "../../components/Head";
 import Container from '../../components/layout/Container'
 import StickyNavbar from "../../components/navigation/StickyNavbar"
 import NewsletterSubscribe from '../../components/NewsletterSubscribe'
 
 export default function NewsletterIndexPage() {
-
   return (
     <div>
       <Head title="Newsletter"/>
       <StickyNavbar>
-       <NavBar className="max-w-screen-xl block px-4 sm:px-6 lg:px-8 mx-auto" />
+        <NavBar className="max-w-screen-xl block px-4 sm:px-6 lg:px-8 mx-auto" />
       </StickyNavbar>
-      <div className="py-12 mt-12 h-full-screen">
+      <div className="py-12 mt-12">
         <Container wide>
           <NewsletterSubscribe formName="form 1" />
         </Container>
       </div>
-      <Footer />
     </div>
   );
 }

--- a/pages/newsletter/index.js
+++ b/pages/newsletter/index.js
@@ -13,9 +13,9 @@ export default function NewsletterIndexPage() {
       <StickyNavbar>
        <NavBar className="max-w-screen-xl block px-4 sm:px-6 lg:px-8 mx-auto" />
       </StickyNavbar>
-      <div className="bg-gray-900 py-12 mt-12">
+      <div className="py-12 mt-12 h-full-screen">
         <Container wide>
-          <NewsletterSubscribe formName="form 1" dark />
+          <NewsletterSubscribe formName="form 1" />
         </Container>
       </div>
       <Footer />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -140,7 +140,6 @@ module.exports = {
         '116': '29rem',
         '120': '30rem',
         'half-screen': '50vh',
-        'full-screen': '80vh',
       },
       maxWidth: {
         '(screen-16)': 'calc(100vw - 16rem)',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -140,6 +140,7 @@ module.exports = {
         '116': '29rem',
         '120': '30rem',
         'half-screen': '50vh',
+        'full-screen': '80vh',
       },
       maxWidth: {
         '(screen-16)': 'calc(100vw - 16rem)',


### PR DESCRIPTION
This PR introduces asyncapi.com/newsletter page to make it easy to link to a location where people can subscribe to Newsletter.

We had [this page in the past](https://github.com/asyncapi/website/pull/52) but it was lost during change from Hugo to Next.js

**Related issue(s)**
See also[ #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->](https://github.com/asyncapi/community/pull/308)