### PR TITLE
ci: update script to grab meetings from the time it runs and not +1day

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -20,7 +20,7 @@ jobs:
         id: netlify
         with:
           site_name: asyncapi-website
-          max_timeout: 300
+          max_timeout: 600
 
       - name: Lighthouse Audit
         id: lighthouse_audit

--- a/scripts/build-meetings.js
+++ b/scripts/build-meetings.js
@@ -15,17 +15,15 @@ async function buildMeetings() {
   try {
 
       //cron job runs this always on midnight
-      //so every day we get refreshed list of meetings for comming 7 days
+      //so every day we get refreshed list of meetings for comming 14 days
       const currentTime = new Date(Date.now()).toISOString();
-      //we check moday
-      const timeTomorrow = new Date(Date.parse(currentTime) + 1 * 24 * 60 * 60 * 1000).toISOString();
-      //7 days front
-      const timeIn8Days = new Date(Date.parse(currentTime) + 8 * 24 * 60 * 60 * 1000).toISOString();
+      //14 days front
+      const timeIn15Days = new Date(Date.parse(currentTime) + 8 * 24 * 60 * 60 * 1000).toISOString();
 
       const eventsList = await calendar.events.list({
           calendarId: process.env.CALENDAR_ID,
-          timeMax: timeIn8Days,
-          timeMin: timeTomorrow
+          timeMax: timeIn15Days,
+          timeMin: currentTime
       })
 
       eventsItems = eventsList.data.items.map((e) => {


### PR DESCRIPTION
now script fetch from (today + 1) which is a problem as workflow to refresh meetings can be also triggered manually, and might be, like today that we have a meeting today, but since meetings.json was refreshed with meetings (today+1) so today's meeting was removed from the list