### PR TITLE
ci: fixed the cron syntax error in the workflow

### DIFF
--- a/.github/workflows/regenerate-meetings.yml
+++ b/.github/workflows/regenerate-meetings.yml
@@ -8,24 +8,25 @@ on:
 
 jobs:
   meetings:
-    env:
-      CALENDAR_ID: ${{ secrets.CALENDAR_ID }}
-      CALENDAR_SERVICE_ACCOUNT: ${{ secrets.CALENDAR_SERVICE_ACCOUNT }}
-    name: Regenerate meetings.json
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Install dependencies
-        run: npm install
-      - name: Regenerate
-        run: npm run generate:meetings
-      - name: Create Pull Request with new meetings.json version
-        uses: peter-evans/create-pull-request@v3
-        with:
-          token: ${{ secrets.GH_TOKEN }}
-          commit-message: 'chore: update meetings.json'
-          committer: asyncapi-bot <info@asyncapi.io>
-          author: asyncapi-bot <info@asyncapi.io>
-          title: 'chore: update meetings.json'
-          branch: update-meetings/${{ github.job }} 
+    if: (github.repository == 'asyncapi/website')
+      env:
+        CALENDAR_ID: ${{ secrets.CALENDAR_ID }}
+        CALENDAR_SERVICE_ACCOUNT: ${{ secrets.CALENDAR_SERVICE_ACCOUNT }}
+      name: Regenerate meetings.json
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v2
+        - name: Install dependencies
+          run: npm install
+        - name: Regenerate
+          run: npm run generate:meetings
+        - name: Create Pull Request with new meetings.json version
+          uses: peter-evans/create-pull-request@v3
+          with:
+            token: ${{ secrets.GH_TOKEN }}
+            commit-message: 'chore: update meetings.json'
+            committer: asyncapi-bot <info@asyncapi.io>
+            author: asyncapi-bot <info@asyncapi.io>
+            title: 'chore: update meetings.json'
+            branch: update-meetings/${{ github.job }} 

--- a/.github/workflows/regenerate-meetings.yml
+++ b/.github/workflows/regenerate-meetings.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
   #every day at midnight
-  - cron: "0 0 * * *"
+  - cron: "10 0 * *"
 
 jobs:
   meetings:

--- a/.github/workflows/regenerate-meetings.yml
+++ b/.github/workflows/regenerate-meetings.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
   #every day at midnight
-  - cron: "10 0 * *"
+  - cron: "10 0 * * *"
 
 jobs:
   meetings:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
This is regarding the `regenerate-meetings.yaml` workflow which got failed today's morning due to the cron's error in it. With an extra `*` added on to correct it, the workflow has been tested properly in my forked repository and it is well and good now. See the test run on the forked repository [here](https://github.com/akshatnema/website/actions/runs/2317807626).

**Related issue(s)**
Fixes #759 in continuation of #760 
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->