### PR TITLE
fix: removed repeated line in the docs

### DIFF
--- a/pages/docs/getting-started/event-driven-architectures.md
+++ b/pages/docs/getting-started/event-driven-architectures.md
@@ -58,7 +58,7 @@ A channel is usually assigned a name or identifier (e.g., `user_signed_up`) and 
 
 You will find both used interchangeably, although they are not exactly the same. You will even find _"message-based"_ and _"event-based"_. In practice, chances are they all refer to the same thing.
 
-Theoretically, _"message-driven"_ is the most generic term -meaning you may use events and commands- while _event-driven_ means that it's purely about events. However, that's not always the case, as Martin Fowler explains in his talk _"the many meanings of Event-Driven Architecture"_:
+Theoretically, _"message-driven"_ is the most generic term -meaning you may use events and commands- while _event-driven_ means that it's purely about events.
 
 However, that's not always the case, as Martin Fowler explains in his
 talk ["the many meanings of Event-Driven Architecture"](https://www.youtube.com/watch?v=STKCRSUsyP0).


### PR DESCRIPTION
Removed the repeated line:

>  However, that's not always the case, as Martin Fowler explains in his talk "the many meanings of Event-Driven Architecture":

 in the `getting-started/event-driven-architectures` page.

Thank you😀

(Note: I have already submitted a PR but by mistake, I pushed commits of another PR to this one. Sorry for the inconvenience😔)