### PR TITLE
docs: replace existing interactive tutorial with new

### DIFF
--- a/pages/docs/tutorials/streetlights-interactive.md
+++ b/pages/docs/tutorials/streetlights-interactive.md
@@ -5,17 +5,13 @@ weight: 20
 ---
 
 >tl;dr
-Please try out [this](https://www.katacoda.com/asyncapi/scenarios/streetlight-tut) interactive tutorial and let us know what you think, as we plan to have all the docs written this way.<!--more-->
+Please try out [this](https://killercoda.com/asyncapi/scenario/streetlight-tut) interactive tutorial and let us know what you think, as we plan to have all the docs written this way.<!--more-->
 
-One of the most critical roadmap items for the AsyncAPI Initiative in 2020 was **Make it super easy for people to get started with AsyncAPI**. One of the crucial things here is to put a lot of love into the documentation.
-
-Before we start writing more docs and improve their structure, we first need to know how you want you to interact with docs. We need to see if you prefer static HTML pages, or interactive docs where you can play with the content.
-
-We created an interactive tutorial using [Katacoda](https://www.katacoda.com/). It is another version of the [Streetlights](./streetlights) tutorial that will always work for you no matter what operating system you have.
+We created an interactive tutorial using [KillerCoda](https://killercoda.com). It is another version of the [Streetlights](./streetlights) tutorial that will always work for you no matter what operating system you have.
 
 Please become our alpha testers of the tutorial:
 
-1. Go through the tutorial [here](https://www.katacoda.com/asyncapi/scenarios/streetlight-tut)
+1. Go through the tutorial [here](https://killercoda.com/asyncapi/scenario/streetlight-tut)
 2. Let us know what you think using the channel that works for you the best:
     - [Slack](https://www.asyncapi.com/slack-invite/)
     - [Twitter](https://twitter.com/AsyncAPISpec)


### PR DESCRIPTION
As @TomasEkeli informed us in https://github.com/asyncapi/website/issues/125#issuecomment-1137196500 Katacoda service will be unavailable soon. Also @akshatnema worried about it in https://github.com/asyncapi/community/discussions/379#discussioncomment-2824575

Luckily, there is a replacement that I could migrate to quickly, and it has even better UI than Katacoda.

New service is KillerCoda and it works pretty well -> https://killercoda.com/asyncapi/scenario/streetlight-tut

See also https://github.com/asyncapi/website/issues/125
