### PR TITLE
feat: remove conference 2021 banner and add 2022 CTA

### DIFF
--- a/components/campaigns/AnnoucementHero.js
+++ b/components/campaigns/AnnoucementHero.js
@@ -1,26 +1,20 @@
-// import { useRouter } from 'next/router'
-// import YouTube from 'react-youtube-embed'
-// import Button from '../buttons/Button'
+import { useRouter } from 'next/router'
+import Button from '../buttons/Button'
 
 export default function AnnouncementHero({ className = '', small = false}) {
-  return null;
 
-  // const { pathname } = useRouter()
+  const { pathname } = useRouter()
 
-  // if (pathname === '/blog/events2021') return null
+  if (pathname === '/blog/events2021') return null
 
-  // return (
-  //   <div className={`bg-gray-50 border border-gray-200 py-6  ${className} ${small ? 'mb-0' : 'mb-12'}`}>
-  //     <h2 className="text-xl md:text-3xl font-bold countdown-text-gradient">AsyncAPI Conference Day 3 is running!</h2>
-  //     <div className='px-4 mt-4 mx-auto max-w-7xl'>
-  //       <YouTube
-  //         id="3EeMHhbwyOQ"
-  //       />
-  //     </div>
-  //     <div className="mt-8 pb-2 space-x-2">
-  //       <Button href="https://www.asyncapi.com/slack-invite" target="_blank" text="Comment and ask questions" />
-  //       <Button bgClassName="bg-none border border-gray-200 text-gray-800 hover:text-gray-700 shadow-none" href="https://conference.asyncapi.com/#schedule" target="_blank" text="Check schedule" />
-  //     </div>
-  //   </div>
-  // )
+  return (
+    <div className={`bg-gray-50 border border-gray-200 py-6  ${className} ${small ? 'mb-0' : 'mb-12'}`}>
+      <h2 className="text-xl md:text-3xl font-bold countdown-text-gradient">AsyncAPI Conference 2022</h2>
+      <h3 className="text-xl md:text-3xl font-bold countdown-text-gradient">Do you prefer flying over or watching online?</h3>
+
+      <div className="mt-8 pb-2 space-x-2">
+        <Button href="https://conference.asyncapi.com/" target="_blank" text="Share your opinion!" />
+      </div>
+    </div>
+  )
 }

--- a/components/campaigns/AnnoucementHero.js
+++ b/components/campaigns/AnnoucementHero.js
@@ -11,10 +11,10 @@ export default function AnnouncementHero({ className = '', small = false}) {
 
   return (
     <div className={`bg-gray-50 border border-gray-200 py-6 rounded ${className} ${small ? 'mb-4' : 'mb-12'}`}>
-      <Heading className="text-xl md:text-3xl font-bold countdown-text-gradient" level="h2" typeStyle="heading-lg countdown-text-gradient">
+      <Heading className="countdown-text-gradient" level="h2" typeStyle="heading-lg">
         AsyncAPI Conference 2022
       </Heading>
-      <Paragraph className="text-xl md:text-3xl font-bold countdown-text-gradient" typeStyle="body-lg countdown-text-gradient">
+      <Paragraph typeStyle="body-lg">
         Help us decide on a date and location by filling out a short survey
       </Paragraph>
       <div className="mt-8 pb-2 space-x-2">

--- a/components/campaigns/AnnoucementHero.js
+++ b/components/campaigns/AnnoucementHero.js
@@ -11,10 +11,10 @@ export default function AnnouncementHero({ className = '', small = false}) {
 
   return (
     <div className={`bg-gray-50 border border-gray-200 py-6 rounded ${className} ${small ? 'mb-4' : 'mb-12'}`}>
-      <Heading level="h2" typeStyle="heading-lg">
+      <Heading className="text-xl md:text-3xl font-bold countdown-text-gradient" level="h2" typeStyle="heading-lg countdown-text-gradient">
         AsyncAPI Conference 2022
       </Heading>
-      <Paragraph typeStyle="body-lg">
+      <Paragraph className="text-xl md:text-3xl font-bold countdown-text-gradient" typeStyle="body-lg countdown-text-gradient">
         Help us decide on a date and location by filling out a short survey
       </Paragraph>
       <div className="mt-8 pb-2 space-x-2">

--- a/components/campaigns/AnnoucementHero.js
+++ b/components/campaigns/AnnoucementHero.js
@@ -1,5 +1,7 @@
 import { useRouter } from 'next/router'
 import Button from '../buttons/Button'
+import Heading from '../typography/Heading';
+import Paragraph from '../typography/Paragraph'
 
 export default function AnnouncementHero({ className = '', small = false}) {
 
@@ -8,10 +10,13 @@ export default function AnnouncementHero({ className = '', small = false}) {
   if (pathname === '/blog/events2021') return null
 
   return (
-    <div className={`bg-gray-50 border border-gray-200 py-6  ${className} ${small ? 'mb-0' : 'mb-12'}`}>
-      <h2 className="text-xl md:text-3xl font-bold countdown-text-gradient">AsyncAPI Conference 2022</h2>
-      <h3 className="text-xl md:text-3xl font-bold countdown-text-gradient">Do you prefer flying over or watching online?</h3>
-
+    <div className={`bg-gray-50 border border-gray-200 py-6 rounded ${className} ${small ? 'mb-4' : 'mb-12'}`}>
+      <Heading level="h2" typeStyle="heading-lg">
+        AsyncAPI Conference 2022
+      </Heading>
+      <Paragraph typeStyle="body-lg">
+        Help us decide on a date and location by filling out a short survey
+      </Paragraph>
       <div className="mt-8 pb-2 space-x-2">
         <Button href="https://conference.asyncapi.com/" target="_blank" text="Share your opinion!" />
       </div>

--- a/components/campaigns/AnnoucementHero.js
+++ b/components/campaigns/AnnoucementHero.js
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router'
 import Button from '../buttons/Button'
-import Heading from '../typography/Heading';
+import Heading from '../typography/Heading'
 import Paragraph from '../typography/Paragraph'
 
 export default function AnnouncementHero({ className = '', small = false}) {

--- a/components/campaigns/Banner.jsx
+++ b/components/campaigns/Banner.jsx
@@ -1,68 +1,70 @@
 import React from "react";
 
 const Banner = () => {
-  return (
-    <div className="bg-gray-100">
-      <div className="mx-auto max-w-screen-xl py-1 px-3 sm:px-6 lg:px-8">
+  return null;
 
-        {/* mobile view */}
-        <div className="flex md:hidden items-center justify-between flex-wrap">
-          <div className="w-0 flex-1 flex items-center text-xs">
-            <p className="font-medium text-gray-700">
-              <span className="md:inline">
-                AsyncAPI Conference 2021 has ended! ⭐️
-              </span>
-            </p>
-          </div>
-          <div className="order-3 flex-shrink-0 sm:order-2 smmd:block">
-            <a
-              href="https://www.youtube.com/playlist?list=PLbi1gRlP7pijq9F5eYsJomWc7Zf6EYVTZ"
-              className="flex items-center justify-center px-4 py-1 border border-transparent rounded-md shadow-sm text-xs font-medium text-indigo-600 focus:text-indigo-600 bg-white hover:bg-indigo-50"
-              target="_blank" rel="noopener noreferrer"
-            >
-              See recordings
-            </a>
-          </div>
-        </div>
+  // return (
+  //   <div className="bg-gray-100">
+  //     <div className="mx-auto max-w-screen-xl py-1 px-3 sm:px-6 lg:px-8">
 
-        <div className="hidden md:flex items-center justify-between flex-wrap">
-          <div className="w-0 flex-1 flex items-center text-xs">
-            <p className="font-medium text-gray-700">
-              <span className="md:inline">
-                AsyncAPI Conference 2021 has ended. Good news: you can still watch the recording! ⭐️
-              </span>
-            </p>
-          </div>
-          <div className="order-3 flex-shrink-0 sm:order-2 smmd:block">
-            <div className="flex">
-              <a
-                href="https://www.youtube.com/watch?v=VpxFpKU2r0U"
-                className="flex items-center justify-center px-4 py-1 border border-transparent rounded-md shadow-sm text-xs font-medium text-indigo-600 focus:text-indigo-600 bg-white hover:bg-indigo-50"
-                target="_blank" rel="noopener noreferrer"
-              >
-                Day 1
-              </a>
-              <a
-                href="https://www.youtube.com/watch?v=mWQtnQIqXTw"
-                className="flex items-center justify-center px-4 py-1 border border-transparent rounded-md shadow-sm text-xs font-medium text-indigo-600 focus:text-indigo-600 bg-white hover:bg-indigo-50 ml-1"
-                target="_blank" rel="noopener noreferrer"
-              >
-                Day 2
-              </a>
-              <a
-                href="https://www.youtube.com/watch?v=3EeMHhbwyOQ"
-                className="flex items-center justify-center px-4 py-1 border border-transparent rounded-md shadow-sm text-xs font-medium text-indigo-600 focus:text-indigo-600 bg-white hover:bg-indigo-50 ml-1"
-                target="_blank" rel="noopener noreferrer"
-              >
-                Day 3
-              </a>
-            </div>
-          </div>
-        </div>
+  //       {/* mobile view */}
+  //       <div className="flex md:hidden items-center justify-between flex-wrap">
+  //         <div className="w-0 flex-1 flex items-center text-xs">
+  //           <p className="font-medium text-gray-700">
+  //             <span className="md:inline">
+  //               AsyncAPI Conference 2021 has ended! ⭐️
+  //             </span>
+  //           </p>
+  //         </div>
+  //         <div className="order-3 flex-shrink-0 sm:order-2 smmd:block">
+  //           <a
+  //             href="https://www.youtube.com/playlist?list=PLbi1gRlP7pijq9F5eYsJomWc7Zf6EYVTZ"
+  //             className="flex items-center justify-center px-4 py-1 border border-transparent rounded-md shadow-sm text-xs font-medium text-indigo-600 focus:text-indigo-600 bg-white hover:bg-indigo-50"
+  //             target="_blank" rel="noopener noreferrer"
+  //           >
+  //             See recordings
+  //           </a>
+  //         </div>
+  //       </div>
 
-      </div>
-    </div>
-  );
+  //       <div className="hidden md:flex items-center justify-between flex-wrap">
+  //         <div className="w-0 flex-1 flex items-center text-xs">
+  //           <p className="font-medium text-gray-700">
+  //             <span className="md:inline">
+  //               AsyncAPI Conference 2021 has ended. Good news: you can still watch the recording! ⭐️
+  //             </span>
+  //           </p>
+  //         </div>
+  //         <div className="order-3 flex-shrink-0 sm:order-2 smmd:block">
+  //           <div className="flex">
+  //             <a
+  //               href="https://www.youtube.com/watch?v=VpxFpKU2r0U"
+  //               className="flex items-center justify-center px-4 py-1 border border-transparent rounded-md shadow-sm text-xs font-medium text-indigo-600 focus:text-indigo-600 bg-white hover:bg-indigo-50"
+  //               target="_blank" rel="noopener noreferrer"
+  //             >
+  //               Day 1
+  //             </a>
+  //             <a
+  //               href="https://www.youtube.com/watch?v=mWQtnQIqXTw"
+  //               className="flex items-center justify-center px-4 py-1 border border-transparent rounded-md shadow-sm text-xs font-medium text-indigo-600 focus:text-indigo-600 bg-white hover:bg-indigo-50 ml-1"
+  //               target="_blank" rel="noopener noreferrer"
+  //             >
+  //               Day 2
+  //             </a>
+  //             <a
+  //               href="https://www.youtube.com/watch?v=3EeMHhbwyOQ"
+  //               className="flex items-center justify-center px-4 py-1 border border-transparent rounded-md shadow-sm text-xs font-medium text-indigo-600 focus:text-indigo-600 bg-white hover:bg-indigo-50 ml-1"
+  //               target="_blank" rel="noopener noreferrer"
+  //             >
+  //               Day 3
+  //             </a>
+  //           </div>
+  //         </div>
+  //       </div>
+
+  //     </div>
+  //   </div>
+  // );
 };
 
 export default Banner;

--- a/components/layout/BlogLayout.js
+++ b/components/layout/BlogLayout.js
@@ -8,7 +8,6 @@ import TOC from '../TOC'
 import NavBar from '../navigation/NavBar'
 import Container from './Container'
 import Footer from '../Footer'
-import AnnouncementHero from '../campaigns/AnnoucementHero'
 import AuthorAvatars from '../AuthorAvatars'
 import StickyNavbar from '../navigation/StickyNavbar'
 
@@ -26,7 +25,6 @@ export default function BlogLayout({ post, children }) {
       <StickyNavbar>
         <NavBar className="max-w-screen-xl block px-4 sm:px-6 lg:px-8 mx-auto" />
       </StickyNavbar>
-      <AnnouncementHero className="text-center m-4" small={true} />
       <Container cssBreakingPoint="lg" flex flexReverse>
         <TOC toc={post.toc} cssBreakingPoint="lg" className="bg-blue-100 mt-4 p-4 sticky top-20 overflow-y-auto max-h-screen lg:bg-transparent lg:mt-2 lg:pt-0 lg:pb-8 lg:top-24 lg:max-h-(screen-16) lg:border-l lg:border-gray-200 lg:min-w-40 lg:max-w-64 lg:-mr-20 xl:min-w-72 xl:-mr-36" />
         <main className="mt-8 px-4 sm:px-6 lg:pr-8 lg:pl-0 lg:flex-1 lg:max-w-172 xl:max-w-172">

--- a/components/layout/DocsLayout.js
+++ b/components/layout/DocsLayout.js
@@ -12,7 +12,6 @@ import NavBar from '../navigation/NavBar'
 import ArrowRight from '../icons/ArrowRight'
 import Feedback from '../Feedback'
 import AnnouncementRemainingDays from '../campaigns/AnnouncementRamainingDays'
-import AnnouncementHero from '../campaigns/AnnoucementHero'
 import Footer from '../Footer'
 import StickyNavbar from '../navigation/StickyNavbar'
 import Heading from '../typography/Heading'
@@ -73,7 +72,6 @@ export default function DocsLayout({ post, navItems = {}, children }) {
         </div>
         <div className="flex flex-col w-0 flex-1 max-w-full lg:max-w-(screen-16)">
           <main className="relative z-0 pt-2 pb-6 focus:outline-none md:py-6" tabIndex="0">
-            <AnnouncementHero className="text-center mx-4" small={true} />
             {!showMenu && (
               <div className="lg:hidden">
                 <button onClick={() => setShowMenu(true)} className="flex text-gray-500 px-4 sm:px-6 md:px-8 hover:text-gray-900 focus:outline-none" aria-label="Open sidebar">


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- remove old panel about conference 2021
- add announcement of 2022 and CTA

Desktop

<img width="2154" alt="Screenshot 2022-06-08 at 19 00 29" src="https://user-images.githubusercontent.com/6995927/172674897-af8ed510-bdfb-454a-bf69-8fbdbd2efa80.png">




Mobile

<img width="356" alt="Screenshot 2022-06-08 at 19 00 53" src="https://user-images.githubusercontent.com/6995927/172674822-7c7c44e7-ed51-41a7-afde-4103c2151430.png">



