### PR TITLE
fix: prevent jumping of blog page layout

### DIFF
--- a/components/navigation/Filter.js
+++ b/components/navigation/Filter.js
@@ -49,7 +49,7 @@ export default function Filter({ data, onFilter, checks, className }) {
           });
         }}
         selected={selected}
-        className={`${className} my-1 md:mr-4`}
+        className={`${className} md:mr-4`}
       />
     );
   });

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -14,6 +14,7 @@ import Heading from "../../components/typography/Heading";
 import StickyNavbar from "../../components/navigation/StickyNavbar"
 import Paragraph from "../../components/typography/Paragraph";
 import TextLink from "../../components/typography/TextLink";
+import Button from "../../components/buttons/Button";
 
 export default function BlogIndexPage() {
   const router = useRouter();
@@ -42,6 +43,11 @@ export default function BlogIndexPage() {
       name: "tags",
     },
   ];
+  const clearFilters = () => {
+    router.push(`${router.pathname}`, undefined, {
+      shallow: true,
+    });
+  };
   const showClearFilters = Object.keys(router.query).length > 0;
   return (
     <div>
@@ -94,9 +100,11 @@ export default function BlogIndexPage() {
               checks={toFilter}
             />
             {showClearFilters && (
-              <span className="text-sm leading-10">
-                <Link href="/blog" passHref><a> Clear filters </a></Link>
-              </span>
+              <Button
+                  bgClassName="bg-none border border-gray-200 text-gray-800 hover:text-gray-700 shadow-none mt-1 pb-2 pt-2 md:mt-0"
+                  text="Clear filters"
+                  onClick={clearFilters}
+              />
             )}
           </div>
           <div>

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -96,15 +96,17 @@ export default function BlogIndexPage() {
             <Filter
               data={navItems}
               onFilter={onFilter}
-              className="w-full mx-px md:mt-0 md:w-1/5 md: md:text-sm"
+              className="w-full mx-px md:mt-0 mt-1 md:w-1/5 md: md:text-sm"
               checks={toFilter}
             />
             {showClearFilters && (
-              <Button
-                  bgClassName="bg-none border border-gray-200 text-gray-800 hover:text-gray-700 shadow-none mt-1 pb-2 pt-2 md:mt-0"
-                  text="Clear filters"
-                  onClick={clearFilters}
-              />
+              <button 
+                type="button" 
+                className="bg-none border border-gray-200 text-gray-800 hover:text-gray-700 shadow-none py- text-white transition-all duration-500 ease-in-out rounded-md px-4 text-md font-semibold tracking-heading text-white md:mt-0 mt-1 md:py-0 py-2"
+                onClick={clearFilters}
+              >
+                <span className="inline-block">Clear filters</span>
+              </button>
             )}
           </div>
           <div>


### PR DESCRIPTION
Prevent blog page from jumping to the top of the page when filters are cleared.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fixes: #815 