### PR TITLE
feat: add robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /definitions/
+Disallow: /schema-store/


### PR DESCRIPTION
**Description**

This PR adds a `robots.txt` file. For now, just disabling crawlers to crawl `/definitions` and `/schema-store` as we don't really need them, avoiding friendly bots traffic to pollute our metrics in New Relic (and consuming requests from GH, etc).

cc @derberg 