### PR TITLE
feat: serve JSON Schema definitions

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,11 +14,6 @@
   to = "https://github.com/asyncapi/spec-json-schemas/tree/master/schemas"
   status = 200
 
-[[redirects]]
-  from = "/definitions/*"
-  to = "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/master/schemas/:splat"
-  status = 200
-
 [[edge_functions]]
 function = "serve-definitions"
 path = "/definitions/*"
@@ -27,11 +22,6 @@ path = "/definitions/*"
 [[redirects]]
   from = "/schema-store"
   to = "https://github.com/asyncapi/spec-json-schemas/tree/master/schemas"
-  status = 200
-
-[[redirects]]
-  from = "/schema-store/*"
-  to = "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/master/schemas/:splat"
   status = 200
 
 [[edge_functions]]


### PR DESCRIPTION
**Description**

This PR adds the feature of serving all definitions (partials) from https://github.com/asyncapi/spec-json-schemas/tree/master/definitions as well. Previously, we were only serving the schemas from https://github.com/asyncapi/spec-json-schemas/tree/master/schemas.

This is especially useful since our `$id` values on schemas are pointing to our website and those are not being served yet (it will after this PR is merged), e.g. http://asyncapi.com/definitions/2.4.0/asyncapi.json

I removed the rewrites from the `netlify.toml` and instead, we handle it now from inside the handler since we need to check where the file should be served from based on the URL. For example:

- `/schema-store/2.4.0.json` -> https://raw.githubusercontent.com/asyncapi/spec-json-schemas/master/schemas/2.4.0.json
- `/definitions/2.4.0/asyncapi.json` -> https://raw.githubusercontent.com/asyncapi/spec-json-schemas/master/definitions/2.4.0/asyncapi.json