### PR TITLE
fix: refactor generator/docs links to match PR #793 refactor

### DIFF
--- a/pages/blog/february-2021-at-asyncapi.md
+++ b/pages/blog/february-2021-at-asyncapi.md
@@ -168,8 +168,8 @@ We are very noisy :sweat_smile:
 - [Maciej Urbanczyk](https://www.linkedin.com/in/maciej-urba%C5%84czyk-909547164/) and [I](https://twitter.com/derberq) (I mean me :smiley:) pushed some features to the AsyncAPI Generator:
   - It supports the latest Node.js 15 and npm 7
   - You can now install generator templates globally. For more details, read [this](https://github.com/asyncapi/generator/#global-templates-installed-with-yarn-or-npm) new section in the readme.
-  - It is now much easier to generate multiple files using the new React render engine. For more details, read [this](https://github.com/asyncapi/generator/blob/master/docs/authoring.md#react) or have a look at it [here](https://github.com/asyncapi/template-for-generator-templates/blob/master/template/schemas/schema.js#L10)
-  - Some parts of templates can be written in TypeScript. For more details, read [this](https://github.com/asyncapi/generator/blob/master/docs/authoring.md#typescript-support). We still cannot use TS in main template code. For more details read [this](https://github.com/asyncapi/generator-react-sdk/issues/3).
+  - It is now much easier to generate multiple files using the new React render engine. For more details, read [this](https://github.com/asyncapi/generator/blob/master/docs/react-render-engine.md) or have a look at it [here](https://github.com/asyncapi/template-for-generator-templates/blob/master/template/schemas/schema.js#L10)
+  - Some parts of templates can be written in TypeScript. For more details, read [this](https://github.com/asyncapi/generator/blob/master/docs/typescript-support.md). We still cannot use TS in main template code. For more details read [this](https://github.com/asyncapi/generator-react-sdk/issues/3).
 
 Check out all the [releases](https://github.com/asyncapi/generator/releases)
 

--- a/pages/blog/january-2021-at-asyncapi.md
+++ b/pages/blog/january-2021-at-asyncapi.md
@@ -91,7 +91,7 @@ Spoiler alert -> number of developers using AsyncAPI in production tripled in 20
 
 ## TypeScript NATS template
 
-We have a [new template](https://github.com/asyncapi/ts-nats-template) available. You can use this template to generate [NATS](https://nats.io/) client based on the AsyncAPI document for Node.js. Interesting fact: it is already using the new [React render engine](https://github.com/asyncapi/generator/blob/master/docs/authoring.md#react) from the AsyncAPI Generator.
+We have a [new template](https://github.com/asyncapi/ts-nats-template) available. You can use this template to generate [NATS](https://nats.io/) client based on the AsyncAPI document for Node.js. Interesting fact: it is already using the new [React render engine](https://github.com/asyncapi/generator/blob/master/docs/react-render-engine.md) from the AsyncAPI Generator.
 
 ## Next major feature is data model generation
 

--- a/pages/blog/react-as-generator-engine.md
+++ b/pages/blog/react-as-generator-engine.md
@@ -54,7 +54,7 @@ The [Generator](https://github.com/asyncapi/generator) doesn't use React rendere
 }
 ```
 
-You can find more information about the Generator configuration [here](https://github.com/asyncapi/generator/blob/master/docs/authoring.md#configuration-file).	 
+You can find more information about the Generator configuration [here](https://github.com/asyncapi/generator/blob/master/docs/configuration-file.md).	 
 
 ## How it works
 
@@ -146,7 +146,7 @@ Looking at both examples we see that in Nujucks we operate on string literals, i
 
 ### Using third party packages
 
-Using helper functions from third-party packages, in Nunjucks you must apply them as [filters](https://github.com/asyncapi/generator/blob/master/docs/authoring.md#filters). For example, you want to use one function from [Underscore.string](https://github.com/esamattis/underscore.string) library like **cleanDiacritics**, which replaces diacritic characters with closest ASCII equivalents. To do this, you must create a function inside **filters** folder to convert the function to Nunjucks's filter:
+Using helper functions from third-party packages, in Nunjucks you must apply them as [filters](https://github.com/asyncapi/generator/blob/master/docs/nunjucks-render-engine.md#filters). For example, you want to use one function from [Underscore.string](https://github.com/esamattis/underscore.string) library like **cleanDiacritics**, which replaces diacritic characters with closest ASCII equivalents. To do this, you must create a function inside **filters** folder to convert the function to Nunjucks's filter:
 
 ```js
 // filters/cleanDiacritics.js

--- a/pages/blog/using-nunjucks-with-asyncapi.md
+++ b/pages/blog/using-nunjucks-with-asyncapi.md
@@ -13,7 +13,7 @@ authors:
 ---
 
 > **Edit 14.04.2021**
-In this post, I explain how you can use Nunjucks to template information extracted from an AsyncAPI file. I also write how you can make it even easier using Nunjucks inside the AsyncAPI Generator. Now, we also have a [React-based](https://github.com/asyncapi/generator/blob/master/docs/authoring.md#react) render engine inside the generator, and it is far more developer-friendly. I encourage you to try it out. 
+In this post, I explain how you can use Nunjucks to template information extracted from an AsyncAPI file. I also write how you can make it even easier using Nunjucks inside the AsyncAPI Generator. Now, we also have a [React-based](https://github.com/asyncapi/generator/blob/master/docs/react-render-engine.md) render engine inside the generator, and it is far more developer-friendly. I encourage you to try it out. 
 
 
 Specifications exist for a reason. Among other things, they help to bring quality, consistency, and standardize a given area. They are a great use case for templating engines. You can prepare a template that generates something from any document that follows a particular specification. You can generate whatever you want, docs, code, and diagrams. The sky is the limit. 


### PR DESCRIPTION
**Description**
- Updated the filter and configuration-file links to match the new structure of the generator docs

**Related issue(s)**
See [#793](https://github.com/asyncapi/generator/pull/793) 
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->