### PR TITLE
feat: add 'version' field to metrics sent to NR

### DIFF
--- a/netlify/edge-functions/serve-definitions.ts
+++ b/netlify/edge-functions/serve-definitions.ts
@@ -128,14 +128,16 @@ function newNRMetricCount(name: string, request: Request, attributes: any = {}):
 
   const splitPath = new URL(request.url).pathname.split("/");
   // Examples: 
-  //   /definitions/2.4.0/info.json => file = 2.4.0/info.json
+  //   /definitions/2.4.0/info.json => file = info.json
   //   /definitions/2.4.0.json      => file = 2.4.0.json
-  let file = splitPath.slice(2, splitPath.length).join("/");
+  const file = splitPath.slice(-1).pop();
+  const version = splitPath[2].replace(".json", "");
 
   metric.attributes = {
     "source": splitPath[1],
     "file": file,
     "url": request.url,
+    "version": version,
     ...attributes,
   };
 


### PR DESCRIPTION
**Description**

This PR adds a new field called `version` to the metrics sent to NR when downloading JSON Schema files. with this change, we don't need to report the whole filepath on the `file` field but just the simple filename. 
Thanks to NR facets, we will be able to make queries via NRQL and group by both `version` and `file` independently or combined. 
