### PR TITLE
docs: add Kotlin AsyncAPI to community tools list

### DIFF
--- a/pages/docs/tools/index.md
+++ b/pages/docs/tools/index.md
@@ -28,7 +28,7 @@ ___
 
 ## AsyncAPI Tools List
 
-Would you like to add your tool to this list? [Let us know!](https://github.com/asyncapi/asyncapi/issues/new)
+Would you like to add your tool to this list? [Let us know!](https://github.com/asyncapi/website/issues/new)
 <!--more-->
 
 > Please, before you decide to create a new tool, consider contributing to the existing ones. Thanks!
@@ -42,6 +42,7 @@ The following is a list of tools that generate AsyncAPI documents from your code
 | [Go AsyncAPI](https://github.com/swaggest/go-asyncapi) | It uses reflection to translate Go structures in JSON Schema definitions and arrange them in AsyncAPI schema. Thanks to [@vearutop](https://github.com/vearutop). | Go
 | [Saunter](https://github.com/tehmantra/saunter) | Like [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) for AsyncAPI. Generates (and hosts) an AsyncAPI schema document from your code. Thanks to [@tehmantra](https://github.com/tehmantra). | C#/dotnet
 | [Java AsyncAPI](https://github.com/Pakisan/java-asyncapi) | This is a code-first tool for AsyncAPI specification | Java, Kotlin
+| [Kotlin AsyncAPI](https://github.com/OpenFolder/kotlin-asyncapi) | Kotlin DSL based AsyncAPI documentation framework | Kotlin
 | [Springwolf](https://github.com/stavshamir/springwolf) | Like [Springfox](https://github.com/springfox/springfox) for AsyncAPI. Auto-generates an AsyncAPI document and a web UI. | Java, Spring Boot
 | [KnstEventBus](https://github.com/d0972058277/KnstEventBus) | AsyncApi code-first tools for c#. Generates document and view. | C#
 | [sttp tapir](https://github.com/softwaremill/tapir) | Library for describing HTTP endpoints, and then interpreting them as a server, client, or documentation | Scala

--- a/pages/docs/tools/index.md
+++ b/pages/docs/tools/index.md
@@ -28,7 +28,7 @@ ___
 
 ## AsyncAPI Tools List
 
-Would you like to add your tool to this list? [Let us know!](https://github.com/asyncapi/website/issues/new)
+Would you like to add your tool to this list? [Let us know!](https://github.com/asyncapi/website/issues/new?template=docs.yml&title=%5B%F0%9F%93%91+Docs%5D%3A+)
 <!--more-->
 
 > Please, before you decide to create a new tool, consider contributing to the existing ones. Thanks!

--- a/pages/docs/tools/index.md
+++ b/pages/docs/tools/index.md
@@ -28,7 +28,7 @@ ___
 
 ## AsyncAPI Tools List
 
-Would you like to add your tool to this list? [Let us know!](https://github.com/asyncapi/website/issues/new?template=docs.yml&title=%5B%F0%9F%93%91+Docs%5D%3A+)
+Would you like to add your tool to this list? [Let us know!](https://github.com/asyncapi/website/issues/new/choose)
 <!--more-->
 
 > Please, before you decide to create a new tool, consider contributing to the existing ones. Thanks!


### PR DESCRIPTION
**Description**

- add a new community tool (Kotlin AsyncAPI) to the list
- fix the `Let us know!` link to add a new tool to the list

**Related issue(s)**
- Resolves #864