### PR TITLE
feat(metrics): add `url_rewrite` and `file_type` fields to metrics sent to NR

### DIFF
--- a/netlify/edge-functions/serve-definitions.ts
+++ b/netlify/edge-functions/serve-definitions.ts
@@ -18,10 +18,12 @@ const URL_DEST_DEFINITIONS = "https://raw.githubusercontent.com/asyncapi/spec-js
 const legitimateRequestRegex = /^\/[\w\-]*\/?(?:([\w\-\.]*\/)?([\w\-\.]*\.json))?$/
 
 export default async (request: Request, context: Context) => {
-  const rewriteRequest = buildRewrite(request);
+  let rewriteRequest = buildRewrite(request);
 
   let response: Response;
   if (rewriteRequest === null) {
+    rewriteRequest = request;
+
     response = await context.next();
   } else {
     // Fetching the definition file
@@ -39,7 +41,7 @@ export default async (request: Request, context: Context) => {
       response.headers.set("Content-Type", "application/schema+json");
 
       // Sending metrics to NR.
-      const metric = newNRMetricCount("asyncapi.jsonschema.download.success", request)
+      const metric = newNRMetricCount("asyncapi.jsonschema.download.success", request, rewriteRequest)
 
       await sendMetricToNR(context, metric);
     } else {
@@ -48,7 +50,7 @@ export default async (request: Request, context: Context) => {
         "responseStatus": response.status,
         "responseStatusText": response.statusText,
       };
-      const metric = newNRMetricCount("asyncapi.jsonschema.download.error", request, attributes);
+      const metric = newNRMetricCount("asyncapi.jsonschema.download.error", request, rewriteRequest, attributes);
 
       await sendMetricToNR(context, metric);
     }
@@ -122,11 +124,11 @@ async function sendMetricToNR(context: Context, metric: NRMetric) {
   }
 }
 
-function newNRMetricCount(name: string, request: Request, attributes: any = {}): NRMetric {
+function newNRMetricCount(name: string, originalRequest: Request, rewriteRequest: Request, attributes: any = {}): NRMetric {
   var metric = new NRMetric(name, NRMetricType.Count, 1);
   metric["interval.ms"] = 1;
 
-  const splitPath = new URL(request.url).pathname.split("/");
+  const splitPath = new URL(originalRequest.url).pathname.split("/");
   // Examples: 
   //   /definitions/2.4.0/info.json => file = info.json
   //   /definitions/2.4.0.json      => file = 2.4.0.json
@@ -136,8 +138,10 @@ function newNRMetricCount(name: string, request: Request, attributes: any = {}):
   metric.attributes = {
     "source": splitPath[1],
     "file": file,
-    "url": request.url,
+    "url": originalRequest.url,
+    "url_rewrite": rewriteRequest.url,
     "version": version,
+    "file_type": rewriteRequest.url.startsWith(URL_DEST_SCHEMAS) ? "schema" : "definition",
     ...attributes,
   };
 


### PR DESCRIPTION
**Description**

This PR adds the following fields to metrics sent to NR by the Edge Function that runs whenever a JSON Schema file is downloaded:

- `url_rewrite`: The URL of final destination, where the JSON Schema file is served from. I.e. https://raw.githubusercontent.com/asyncapi/spec-json-schemas/master/definitions/2.3.0/asyncapi.json
- `file_type`: Can be either `schema` or `definition`, depending on what is being downloaded.

This helps creating better dashboards by faceting by this new data.