### PR TITLE
chore: add Missy Turco and Akshat Nema as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
-* @fmvilas @derberg @magicmatatjahu @asyncapi-bot-eve
+* @fmvilas @derberg @mcturco @akshatnema @magicmatatjahu @asyncapi-bot-eve
 
 # All .md files
 *.md @alequetzalli @asyncapi-bot-eve


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

As in title: add Missy Turco and Akshat Nema as codeowners.

These two people have contributed a lot to the development of this project and I think they should be codeowners of this repository. Anyone against this?

cc @derberg @fmvilas @alequetzalli @mcturco @akshatnema 