### PR TITLE
fix: limit number of tweets in the list in the newsroom

### DIFF
--- a/components/newsroom/Newsroom.js
+++ b/components/newsroom/Newsroom.js
@@ -72,7 +72,7 @@ export default function Newsroom() {
               <TwitterTimelineEmbed
                 sourceType="profile"
                 screenName="AsyncAPISpec"
-                options={{height: 570, width: '100%'}}
+                options={{ tweetLimit: 1, height: 570, width: '100%'}}
               />
             </div>
           </div>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- added tweetLimit in options props to limit the number of tweets displayed in TwitterTimelineEmbed Component.
- Fixed Output:
<img width="1792" alt="Screenshot 2022-08-19 at 9 32 31 AM" src="https://user-images.githubusercontent.com/16652376/185540386-c97c7331-8c64-4b04-a65f-fe3533937e5b.png">

**Related issue(s)**

Resolves #907 

<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->