### PR TITLE
chore: add codeowners rule for readme.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,3 +9,5 @@
 
 # All .md files
 *.md @alequetzalli @asyncapi-bot-eve
+
+README.md @alequetzalli @fmvilas @derberg @mcturco @akshatnema @magicmatatjahu @asyncapi-bot-eve


### PR DESCRIPTION
Hey folks

I had an offline discussion with @alequetzalli if should feel comfortable with that change. And she said YES.

The basic idea is to be more efficient in merging changes to README, especially simple PRs like adding contributors to the readme. Readme is only project documentation for contributors, not something that lands on the website, so do not always have to be signed off by Alejandra.

Please also remember that even though Alejandra's approval for readme changes will no longer be mandatory, just do not overuse it. If there is a PR that changes some content or adds new content, just be a nice citizen and ping Alejandra and give her a few days to react 🙏🏼 😄 


