### PR TITLE
fix: update required versions of Node.js/npm in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ This repository contains the sources of AsyncAPI website:
 
 Use the following tools to set up the project:
 
-- [Node.js](https://nodejs.org/) v12.16+
-- [npm](https://www.npmjs.com/) v6.13.7+
+- [Node.js](https://nodejs.org/) v16.0.0+
+- [npm](https://www.npmjs.com/) v7.10.0+
 
 ## Usage
 


### PR DESCRIPTION
'package-lock.json' page at https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json states that `package-lock.json` of version `2` is used by npm v7.

Page 'Presenting v7.0.0 of the npm CLI' at https://github.blog/2020-10-13-presenting-v7-0-0-of-the-npm-cli states that npm v7.0.0 is shipped by default with Node.js v15.0.0, indirectly stating that npm v7.0.0 works best with Node.js starting from v15.0.0.

Thus update to `README.md`.