### PR TITLE
docs: fix capitalization: Github -> GitHub, Javascript -> JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This repository has the following structure:
 <!-- If you make any changes in the project structure, remember to update it. -->
 
 ```text
-  ├── .github                     # Definitions of Github workflows, pull request and issue templates
+  ├── .github                     # Definitions of GitHub workflows, pull request and issue templates
   ├── components                  # Various generic components such as "Button", "Figure", etc.
   ├── config                      # Transformed static data to display on the pages such as blog posts etc.
   ├── context                     # Various React's contexts used in website

--- a/components/buttons/GithubButton.js
+++ b/components/buttons/GithubButton.js
@@ -2,7 +2,7 @@ import Button from './Button'
 import IconGithub from '../icons/Github'
 
 export default function GithubButton({
-  text = 'View on Github',
+  text = 'View on GitHub',
   href,
   target = '_blank',
   iconPosition = 'left',

--- a/components/layout/DocsLayout.js
+++ b/components/layout/DocsLayout.js
@@ -15,9 +15,9 @@ import AnnouncementHero from '../campaigns/AnnoucementHero'
 
 function generateEditLink(post) {
   if (post.slug.includes('/specifications/')) {
-    return <a target="_blank" rel="noopener noreferrer" href={`https://github.com/asyncapi/spec/blob/master/spec/asyncapi.md`} className="ml-1 underline">Edit this page on Github</a>
+    return <a target="_blank" rel="noopener noreferrer" href={`https://github.com/asyncapi/spec/blob/master/spec/asyncapi.md`} className="ml-1 underline">Edit this page on GitHub</a>
   } 
-  return <a target="_blank" rel="noopener noreferrer" href={`https://github.com/asyncapi/website/blob/master/pages${post.isIndex ? post.slug + '/index' : post.slug}.md`} className="ml-1 underline">Edit this page on Github</a>
+  return <a target="_blank" rel="noopener noreferrer" href={`https://github.com/asyncapi/website/blob/master/pages${post.isIndex ? post.slug + '/index' : post.slug}.md`} className="ml-1 underline">Edit this page on GitHub</a>
 }
 
 export default function DocsLayout({ post, navItems = {}, children }) {

--- a/components/navigation/communityItems.js
+++ b/components/navigation/communityItems.js
@@ -1,5 +1,5 @@
 export default [
   { text: 'Tools & Services', href: '/docs/community/tooling', description: 'Explore the tools and services our awesome community has created.' },
-  { text: 'Github Organization', href: 'https://github.com/asyncapi', target: '_blank', description: 'Want to sneak in the code? Everything we do is open-sourced in our Github organization.' },
+  { text: 'GitHub Organization', href: 'https://github.com/asyncapi', target: '_blank', description: 'Want to sneak in the code? Everything we do is open-sourced in our GitHub organization.' },
   { text: 'Slack Workspace', href: 'https://asyncapi.com/slack-invite', target: '_blank', description: `Need help? Want to share something? Join our Slack workspace. We're nice people :)` },
 ]

--- a/components/navigation/toolingItems.js
+++ b/components/navigation/toolingItems.js
@@ -9,7 +9,7 @@ export default [
   { href: '/studio', icon: IconHub, title: 'Studio', description: 'Visually design your AsyncAPI files and event-driven architecture.', comingSoon: true },
   { href: '/generator', icon: IconGenerator, title: 'Generator', description: 'Use your AsyncAPI files to generate documentation, code, anything!' },
   // { href: '/react', icon: IconReact, title: 'React Component', description: 'Embed your AsyncAPI documentation in your React application.' },
-  { href: '/github-actions', icon: IconGithubActions, title: 'Github Actions', description: 'Automate the validation and generation of documentation.' },
+  { href: '/github-actions', icon: IconGithubActions, title: 'GitHub Actions', description: 'Automate the validation and generation of documentation.' },
   { href: '/parsers', icon: IconParser, title: 'Parsers', description: 'Parse AsyncAPI documents right inside your tools and products.' },
   // { href: '/ide-plugins', icon: IconPlugins, title: 'IDE plugins and extensions', description: 'Edit your AsyncAPI files right inside your favourite code editor.' },
 ]

--- a/pages/blog/an-api-strategist-explores-event-driven-apis.md
+++ b/pages/blog/an-api-strategist-explores-event-driven-apis.md
@@ -230,6 +230,6 @@ A vast variety of low-price devices (sensors, thermostats, robots, etc.) with in
 
 EDA enables a loose coupling between the components/apps in order regain agility, increases innovation pace and reduces time-to-market for new features/services.
 > # In general, I’m studying API Design Patterns and how various kinds of APIs expedite R&D adoption. What business results are accelerated from these kinds of patterns?
-> Thanks for suggesting topics and connecting with feedback. You can also reach me via Twitter @lifewingmate DM or via the AsyncAPI community via our [Github](https://github.com/asyncapi) or [Slack channel](http://asyncapi.slack.com).
+> Thanks for suggesting topics and connecting with feedback. You can also reach me via Twitter @lifewingmate DM or via the AsyncAPI community via our [GitHub](https://github.com/asyncapi) or [Slack channel](http://asyncapi.slack.com).
 
 Disclaimer: The professional opinions of those interviewed do not necessarily reflect the organizations they represent. These interviewees volunteered their time and contributions to support the AsyncAPI initiative and community.

--- a/pages/blog/asyncapi-github-actions.md
+++ b/pages/blog/asyncapi-github-actions.md
@@ -1,5 +1,5 @@
 ---
-title: "Automate AsyncAPI workflows with Github Actions"
+title: "Automate AsyncAPI workflows with GitHub Actions"
 date: 2020-04-02T06:00:00+01:00
 type: Engineering
 tags:

--- a/pages/blog/intent-driven-api.md
+++ b/pages/blog/intent-driven-api.md
@@ -130,7 +130,7 @@ components:
             description: Light intensity measured in lumens.
 ```
 
-By the time of this post, there is only one implementation of the parser, which is written in Javascript. 
+By the time of this post, there is only one implementation of the parser, which is written in JavaScript. 
 [Parser-js][parser-js] parses AsyncAPI spec documents and provides functions to work with them and access the different objects and their values.
 
 In the hypothetical case a user wants to parse this document and *get all the messages a consumer of the application can consume*, this is needed: 
@@ -224,7 +224,7 @@ We then wrote down a draft of our first list of intents.
 
 ## 3. Build a mock API
 
-After getting a list of intents to implement, we built a simple mock API in Javascript with that list. 
+After getting a list of intents to implement, we built a simple mock API in JavaScript with that list. 
 
 Methods were returning hardcoded data but were enough for getting an idea of how difficult it would be to create such API from the point of view of a maintainer.
 
@@ -237,7 +237,7 @@ At this point, we faced up some API design decisions, such as:
 
 ## 4. Validate the intents and their UX
 
-With the new API mock built-in Javascript, we chose some of the most used [generator templates][templates] and replaced all the calls made to the old [Parser-js][parser-js] API with the new ones.
+With the new API mock built-in JavaScript, we chose some of the most used [generator templates][templates] and replaced all the calls made to the old [Parser-js][parser-js] API with the new ones.
 
 This step made us realize that some of the intents we mocked up worked like a charm: We were pretty happy seeing how the code got simplified.
 
@@ -256,7 +256,7 @@ You can find the new repository holding the new Parsers API specification [here]
 # What's next?
 
 Even though we do now have an alpha version of the new parser API, work is pending around implementation.
-We are actively asking for feedback. Please submit yours via Github Discussions [here][api-discussions].
+We are actively asking for feedback. Please submit yours via GitHub Discussions [here][api-discussions].
 
 Our next steps are going to be:
 

--- a/pages/blog/mistake-odyssey.md
+++ b/pages/blog/mistake-odyssey.md
@@ -1,6 +1,6 @@
 ---
 title: "Mistake Odyssey"
-Subtitle: "Git, Github, VS Code and Markdown for non-programmers"
+Subtitle: "Git, GitHub, VS Code and Markdown for non-programmers"
 date: 2021-07-15T06:00:00+01:00
 type: Communication
 tags:

--- a/pages/blog/understanding-asyncapis.md
+++ b/pages/blog/understanding-asyncapis.md
@@ -291,7 +291,7 @@ But our journey doesn’t stop here. The AsyncAPI project brings in a rich set o
 
 Application developers can speed up their work by automatically generating scaffoldings by specifying the specification file. This design-first strategy provides boilerplate code for dealing with brokers and marshaling/unmarshalling messages over the wire.
 
-Generators are available for mainstream applications like Java, .NET, Javascript, etc. You can check out [this](https://github.com/asyncapi/generator) repo for more information.
+Generators are available for mainstream applications like Java, .NET, JavaScript, etc. You can check out [this](https://github.com/asyncapi/generator) repo for more information.
 
 ## Validators
 

--- a/pages/docs/community/tooling.md
+++ b/pages/docs/community/tooling.md
@@ -39,7 +39,7 @@ The following is a list of tools that do not yet belong to any specific category
 
 | Link           | Description    | Language/Framework |
 | :------------- | :------------- | :----------------- |
-| [Converter](https://github.com/asyncapi/converter) | Converts old versions of AsyncAPI files into the latest version. | Javascript
+| [Converter](https://github.com/asyncapi/converter) | Converts old versions of AsyncAPI files into the latest version. | JavaScript
 | [Converter Go](https://github.com/asyncapi/converter-go) | Converts old versions of AsyncAPI files into the latest version. Thanks to [@Kyma team](https://kyma-project.io/). | Go
 
 # Directories
@@ -57,10 +57,10 @@ The following is a list of tools that generate human-readable documentation from
 
 | Link           | Description    | Language/Kind |
 | :------------- | :------------- | :------------- |
-| [AsyncAPI Generator](https://github.com/asyncapi/generator) | Use your AsyncAPI definition to generate literally anything. Markdown documentation, Node.js code, HTML documentation, anything! **[Click here](https://github.com/search?q=topic%3Aasyncapi+topic%3Agenerator+topic%3Atemplate) to get a list of the existing templates**. | CLI / Javascript
-| [AsyncAPI React](https://github.com/asyncapi/asyncapi-react) | React component for rendering documentation from your specification in real-time in the browser. Thanks to [@Kyma team](https://kyma-project.io/). | Javascript
+| [AsyncAPI Generator](https://github.com/asyncapi/generator) | Use your AsyncAPI definition to generate literally anything. Markdown documentation, Node.js code, HTML documentation, anything! **[Click here](https://github.com/search?q=topic%3Aasyncapi+topic%3Agenerator+topic%3Atemplate) to get a list of the existing templates**. | CLI / JavaScript
+| [AsyncAPI React](https://github.com/asyncapi/asyncapi-react) | React component for rendering documentation from your specification in real-time in the browser. Thanks to [@Kyma team](https://kyma-project.io/). | JavaScript
 | [Bump](https://bump.sh) | OpenApi 2 & 3 / AsyncAPI 2 documentation generator, with automatic changelog and visual diff. | SaaS
-| [Widdershins](https://github.com/Mermade/widdershins) | OpenApi 3.0 / Swagger 2.0 / AsyncAPI 1.0 definition to Slate / Shins compatible markdown. Thanks to [@PermittedSoc](https://twitter.com/@Permittedsoc). | CLI / Javascript
+| [Widdershins](https://github.com/Mermade/widdershins) | OpenApi 3.0 / Swagger 2.0 / AsyncAPI 1.0 definition to Slate / Shins compatible markdown. Thanks to [@PermittedSoc](https://twitter.com/@Permittedsoc). | CLI / JavaScript
 
 # DSL
 
@@ -86,7 +86,7 @@ The following is a list of [GitHub Actions](https://github.com/features/actions)
 | :------------- | :------------- |
 | [AsyncAPI Github Action](https://github.com/marketplace/actions/asyncapi-github-action) | This action validates if the AsyncAPI schema file is valid or not.
 | [Generator for AsyncAPI documents](https://github.com/marketplace/actions/generator-for-asyncapi-documents) | This action generates whatever you want using your AsyncAPI document. It uses [AsyncAPI Generator](https://github.com/asyncapi/generator).
-| [API documentation on Bump](https://github.com/marketplace/actions/api-documentation-on-bump) | With this Github Action you can automatically generate your API reference (with the changelog and diff) on [Bump](https://bump.sh) from any AsyncAPI file.
+| [API documentation on Bump](https://github.com/marketplace/actions/api-documentation-on-bump) | With this GitHub Action you can automatically generate your API reference (with the changelog and diff) on [Bump](https://bump.sh) from any AsyncAPI file.
 
 # Mocking and Testing {#mocking}
 
@@ -102,9 +102,9 @@ The following is a list of tools that validate AsyncAPI documents.
 
 | Link           | Description    | Language/Framework |
 | :------------- | :------------- | :----------------- |
-| [AsyncAPI Parser](https://github.com/asyncapi/parser-js) | It parses and validates AsyncAPI documents. | Javascript
-| [Check-API](https://github.com/Mermade/check_api) | It allows you to validate a local file or remote URL with a single command-line or programmatic invocation. It returns an exitCode of 0 on success and 1 on failure, making it suitable for use in Continuous Integration environments. Thanks to [@PermittedSoc](https://twitter.com/@Permittedsoc). | Javascript
-| [asyncapi-validator](https://github.com/WaleedAshraf/asyncapi-validator) | It allows you to validate the schema of your messages against your AsyncAPI schema definition. You can use it with Kafka, RabbitMQ or any other messaging/queue. Thanks to [@waleedashraf](https://twitter.com/@waleedashraf01). | Javascript
+| [AsyncAPI Parser](https://github.com/asyncapi/parser-js) | It parses and validates AsyncAPI documents. | JavaScript
+| [Check-API](https://github.com/Mermade/check_api) | It allows you to validate a local file or remote URL with a single command-line or programmatic invocation. It returns an exitCode of 0 on success and 1 on failure, making it suitable for use in Continuous Integration environments. Thanks to [@PermittedSoc](https://twitter.com/@Permittedsoc). | JavaScript
+| [asyncapi-validator](https://github.com/WaleedAshraf/asyncapi-validator) | It allows you to validate the schema of your messages against your AsyncAPI schema definition. You can use it with Kafka, RabbitMQ or any other messaging/queue. Thanks to [@waleedashraf](https://twitter.com/@waleedashraf01). | JavaScript
 | [AsyncAPI Parser](https://github.com/asyncapi/parser) | It parses and validates AsyncAPI documents. | Go
-| [Spectral](https://github.com/stoplightio/spectral) | A command-line linter for AsyncAPI & OpenAPI documents. | Javascript
+| [Spectral](https://github.com/stoplightio/spectral) | A command-line linter for AsyncAPI & OpenAPI documents. | JavaScript
 | [AMF](https://github.com/aml-org/amf) | Unified RAML / OAS / AsyncAPI parser and validator, including linting | ScalaJS / JVM and JS support

--- a/pages/docs/tutorials/streetlights.md
+++ b/pages/docs/tutorials/streetlights.md
@@ -215,4 +215,4 @@ EOT`}
 You've learned how to create an AsyncAPI description file and how to generate code from it. The code is a bootstrap and you'll need to add your business logic into it. Take some time to play with it.
 There are still lots of things to be covered but intent of this tutorial is to be simple so you get an idea of the potential.
 
-We would also like to see what you create with AsyncAPI. As an open-source project, we're open to proposals, questions, suggestions, and contributions. If you don't feel in the mood to contribute but you're using AsyncAPI, just raise your hand [creating a issue in our Github repo](https://github.com/asyncapi/asyncapi/issues/new) or [join our Slack channel](https://www.asyncapi.com/slack-invite/). Don't be shy :)
+We would also like to see what you create with AsyncAPI. As an open-source project, we're open to proposals, questions, suggestions, and contributions. If you don't feel in the mood to contribute but you're using AsyncAPI, just raise your hand [creating a issue in our GitHub repo](https://github.com/asyncapi/asyncapi/issues/new) or [join our Slack channel](https://www.asyncapi.com/slack-invite/). Don't be shy :)

--- a/pages/github-actions.js
+++ b/pages/github-actions.js
@@ -23,12 +23,12 @@ export default function GithubActionsPage() {
     )
   }
 
-  const description = 'Generate docs and code on your Github Actions pipeline.'
+  const description = 'Generate docs and code on your GitHub Actions pipeline.'
   const image = '/img/social/github-actions.png'
 
   return (
     <GenericLayout
-      title="Github Actions"
+      title="GitHub Actions"
       description={description}
       image={image}
       wide
@@ -37,7 +37,7 @@ export default function GithubActionsPage() {
         <div className="relative max-w-xl mx-auto px-4 sm:px-6 lg:px-8 lg:max-w-screen-xl">
           <div className="relative">
             <h3 className="text-center text-3xl leading-8 font-normal tracking-tight text-gray-900 sm:text-4xl sm:leading-10">
-              Automate using Github Actions
+              Automate using GitHub Actions
             </h3>
             <p className="mt-4 max-w-3xl mx-auto text-center text-xl leading-7 text-gray-500">
               {description}
@@ -50,7 +50,7 @@ export default function GithubActionsPage() {
               Generate docs
               </h4>
               <p className="mt-3 text-lg leading-7 text-gray-500 lg:pr-4">
-                Seamlessly integrate the docs generation process with your Github pipeline. Make sure your documentation is always up to date. It will be a gift to your team and your future self.
+                Seamlessly integrate the docs generation process with your GitHub pipeline. Make sure your documentation is always up to date. It will be a gift to your team and your future self.
               </p>
               {renderButtons()}
             </div>

--- a/pages/jobs/dev-rel-postman.md
+++ b/pages/jobs/dev-rel-postman.md
@@ -17,7 +17,7 @@ Postman’s Open Technologies function was created to establish Postman as a lea
 
 Through our collaboration with the AsyncAPI Initiative, we are looking for a Developer Advocate to work closely with the AsyncAPI team within our Open Technologies function to help shape and build the future of API tooling. Everything is open-source and, therefore, much of your work will be open-source too.
 
-We believe that building a strong community and investing in their success is essential to our own success as a company. You will engage with open source communities on Github while collaborating within the AsyncAPI team to drive API better practices throughout the broader API ecosystem. In addition to advocacy, you will also have shared responsibilities for user education and community engagement.
+We believe that building a strong community and investing in their success is essential to our own success as a company. You will engage with open source communities on GitHub while collaborating within the AsyncAPI team to drive API better practices throughout the broader API ecosystem. In addition to advocacy, you will also have shared responsibilities for user education and community engagement.
 
 ## Responsibilities
 

--- a/pages/jobs/ui-ux-dx-designer.md
+++ b/pages/jobs/ui-ux-dx-designer.md
@@ -32,7 +32,7 @@ You'd spend your time improving the user experience of existing and new tools, f
 * Designing delightful experiences for our documentation and website.
 * Researching how our users use AsyncAPI, what they would love to do with it that's not yet possible, etc.
 
-Everything we do is open-source and, therefore, all your work will be 100% open-source too. We do everything on Github, however, we're not rigid as to what tools you should use, as long as you keep your work public, open, and accessible to everyone.
+Everything we do is open-source and, therefore, all your work will be 100% open-source too. We do everything on GitHub, however, we're not rigid as to what tools you should use, as long as you keep your work public, open, and accessible to everyone.
 
 We're just a team of four people at the time of this writing. We plan to triple the size of the team on the first half of 2021.
 
@@ -54,7 +54,7 @@ We're looking for someone who meets some or all of the following points:
 * A good understanding of how APIs work and what AsyncAPI does is important. It’s okay if you’re not an expert as long as you take initiative and are excited to learn about how things work together.
 * Detailed understanding of quantitative research techniques.
 * Ability to plan ahead and expand UX Research into a mature practice.
-* Experience with team collaboration, product management, and support processes (Github and Zenhub helpful).
+* Experience with team collaboration, product management, and support processes (GitHub and Zenhub helpful).
 * Advanced experience in multiple and mixed methods of research including but not limited to surveys, polls, interjection and in-app surveys, interviews, and log file analysis.
 
 ## Pay and benefits

--- a/pages/roadmap.js
+++ b/pages/roadmap.js
@@ -142,9 +142,9 @@ export default function RoadmapPage() {
             <Warning
               className="lg:w-1/2 mt-8 mx-auto"
               title="Warning for Contributors"
-              description="This road map reflects the priorities of the core team. If you want to contribute a feature that's not a priority, feel free to let us know on the corresponding Github issue so we can discuss what's the best way to proceed and implement it yourself." />
+              description="This road map reflects the priorities of the core team. If you want to contribute a feature that's not a priority, feel free to let us know on the corresponding GitHub issue so we can discuss what's the best way to proceed and implement it yourself." />
             <p className="text-xs text-center text-gray-600 mt-8">
-              <strong>Attention:</strong> this road map is synchronized with the Github issues in the <a href="https://github.com/asyncapi/shape-up-process/issues?q=is%3Aopen+is%3Aissue+label%3A%22Key+Result%22" target="_blank" className="underline hover:text-gray-900">asyncapi/shape-up-process</a> repository.
+              <strong>Attention:</strong> this road map is synchronized with the GitHub issues in the <a href="https://github.com/asyncapi/shape-up-process/issues?q=is%3Aopen+is%3Aissue+label%3A%22Key+Result%22" target="_blank" className="underline hover:text-gray-900">asyncapi/shape-up-process</a> repository.
             </p>
           </div>
         </div>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This PR fixes the capitalization of some product / language names that appear on the AsyncAPI website, specifically:
- Github -> Git**H**ub
- Javascript -> Java**S**cript

Some of these fixes update the metadata, titles, and text labels used in the components and GitHub Actions in this repo. I believe these changes are cosmetic and don't affect the actual functionality of those components and GH Actions. But if something needs to be rolled back, let me know.

**Related issue(s)**
n/a

<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->