### PR TITLE
fix: specification doc items not rendered properly

### DIFF
--- a/components/layout/DocsLayout.js
+++ b/components/layout/DocsLayout.js
@@ -81,7 +81,7 @@ function buildNavTree(navItems) {
 
         // point in slug for specification subgroup to the latest specification version
         if (rootKey === 'reference' && key === 'specification') {
-          allChildren[key].item.href = allChildren[key].children[0].slug;
+          allChildren[key].item.href = allChildren[key].children.find(c => c.isPrerelease === undefined).slug;
         }
       }
     }

--- a/components/layout/DocsLayout.js
+++ b/components/layout/DocsLayout.js
@@ -168,11 +168,6 @@ export default function DocsLayout({ post, navItems = {}, children }) {
               <Heading level="h1" typeStyle="heading-lg">
                 {post.title}
               </Heading>
-            {
-              post.isPrerelease 
-              ? <h3 className="text-lxl font-normal text-gray-800 font-sans antialiased">To be released on {post.releaseDate}</h3> 
-              : null
-            }
             <div>
               <p className="text-sm font-normal text-gray-600 font-sans antialiased">
                 Found an error? Have a suggestion? 

--- a/scripts/build-post-list.js
+++ b/scripts/build-post-list.js
@@ -75,12 +75,8 @@ function walkDirectories(directories, result, sectionWeight = 0, sectionTitle, s
         details.isIndex = fileName.endsWith('/index.md')
         details.slug = details.isIndex ? sectionSlug : slug.replace(/\.md$/, '')
         if(details.slug.includes('/reference/specification/') && !details.title) {
-          const fileBaseName = basename(data.slug)  // ex. v2.0.0 | v2.1.0-2021-06-release
+          const fileBaseName = basename(data.slug)  // ex. v2.0.0 | v2.1.0-next-spec.1
           const fileName = fileBaseName.split('-')[0] // v2.0.0 | v2.1.0
-
-          if(fileBaseName.includes('next-spec') || fileBaseName.includes('next-major-spec')) {
-            details.isPrerelease = true
-          }
 
           details.weight = specWeight--
 
@@ -90,7 +86,8 @@ function walkDirectories(directories, result, sectionWeight = 0, sectionTitle, s
             details.title = capitalize(fileName)
           }
 
-          if(details.isPrerelease) {
+          if (fileBaseName.includes('next-spec') || fileBaseName.includes('next-major-spec')) {
+            details.isPrerelease = true
             // this need to be separate because the `-` in "Pre-release" will get removed by `capitalize()` function
             details.title += " (Pre-release)"
           }

--- a/scripts/build-post-list.js
+++ b/scripts/build-post-list.js
@@ -1,6 +1,5 @@
 const { readdirSync, statSync, existsSync, readFileSync, writeFileSync } = require('fs')
 const { join, resolve, basename } = require('path')
-const { inspect } = require('util')
 const frontMatter = require('gray-matter')
 const toc = require('markdown-toc')
 const { slugify } = require('markdown-toc/lib/utils')
@@ -79,9 +78,8 @@ function walkDirectories(directories, result, sectionWeight = 0, sectionTitle, s
           const fileBaseName = basename(data.slug)  // ex. v2.0.0 | v2.1.0-2021-06-release
           const fileName = fileBaseName.split('-')[0] // v2.0.0 | v2.1.0
 
-          if(fileBaseName.includes('release')) {
+          if(fileBaseName.includes('next-spec') || fileBaseName.includes('next-major-spec')) {
             details.isPrerelease = true
-            details.releaseDate = getReleaseDate(fileBaseName)
           }
 
           details.weight = specWeight--
@@ -123,11 +121,4 @@ function isDirectory(dir) {
 
 function capitalize(text) {
   return text.split(/[\s\-]/g).map(word => `${word[0].toUpperCase()}${word.substr(1)}`).join(' ')
-}
-
-function getReleaseDate(text) {
-  // ex. filename = v2.1.0-2021-06-release
-  const splittedText = text.split('-') // ['v2.1.0', '2021', '06', 'release']
-  const releaseDate = `${splittedText[1]}-${splittedText[2]}` // '2021-06'
-  return releaseDate
 }


### PR DESCRIPTION
The current specifications menu is not showing if a spec is in pre-release or not. This is how it looks now in production:

![Captura de Pantalla 2022-09-26 a las 17 05 22](https://user-images.githubusercontent.com/242119/192312701-ed7b0e16-f4e5-46fb-b324-d1693fa85891.png)


This is how it will look after this PR:

![Captura de Pantalla 2022-09-26 a las 17 05 28](https://user-images.githubusercontent.com/242119/192312752-8db23097-b08c-49e8-99c2-fe11c1a56e2f.png)