### PR TITLE
feat: make sure asyncapi: 2.5.0 is mentioned in all docs

### DIFF
--- a/components/DemoAnimation.js
+++ b/components/DemoAnimation.js
@@ -44,7 +44,7 @@ export default function DemoAnimation({ className = '' }) {
     const common = (
       <>
         <div>
-          <span className="text-teal-400">asyncapi:</span> 2.2.0
+          <span className="text-teal-400">asyncapi:</span> 2.5.0
         </div>
         <div>
           <span className="text-teal-400">info:</span>

--- a/pages/docs/tutorials/getting-started/asyncapi-documents.md
+++ b/pages/docs/tutorials/getting-started/asyncapi-documents.md
@@ -12,7 +12,7 @@ An AsyncAPI document is a file that defines and annotates the different componen
 The format of the file must be JSON or YAML; however, only the subset of YAML that matches the JSON capabilities is allowed.
 
 <CodeBlock>
-{`asyncapi: 2.2.0
+{`asyncapi: 2.5.0
 info:
   title: Example
   version: 0.1.0

--- a/pages/docs/tutorials/getting-started/hello-world.md
+++ b/pages/docs/tutorials/getting-started/hello-world.md
@@ -10,7 +10,7 @@ weight: 30
 Let's define an application that's capable of receiving a "hello {name}" message.
 
 <CodeBlock>
-{`asyncapi: 2.2.0
+{`asyncapi: 2.5.0
 info:
   title: Hello world application
   version: '0.1.0'
@@ -26,7 +26,7 @@ channels:
 Let's get into the details of this sample specification:
 
 <CodeBlock highlightedLines={[1]}>
-{`asyncapi: 2.2.0
+{`asyncapi: 2.5.0
 info:
   title: Hello world application
   version: '0.1.0'
@@ -39,10 +39,10 @@ channels:
           pattern: '^hello .+$'`}
 </CodeBlock>
 
-The first line of the specification starts with the document type `asyncapi` and the version (2.2.0). This line doesn't have to be the first one, but it's a recommended practice.
+The first line of the specification starts with the document type `asyncapi` and the version (2.5.0). This line doesn't have to be the first one, but it's a recommended practice.
 
 <CodeBlock highlightedLines={[2,3,4]}>
-{`asyncapi: 2.2.0
+{`asyncapi: 2.5.0
 info:
   title: Hello world application
   version: '0.1.0'
@@ -58,7 +58,7 @@ channels:
 The `info` object contains the minimum required information about the application. It contains the `title`, which is a memorable name for the API, and the `version`. While it's not mandatory, it's strongly recommended to change the version whenever you make changes to the API.
 
 <CodeBlock highlightedLines={[5,6,7,8,9,10,11]}>
-{`asyncapi: 2.2.0
+{`asyncapi: 2.5.0
 info:
   title: Hello world application
   version: '0.1.0'
@@ -76,7 +76,7 @@ The `channels` section of the specification houses all of the mediums where mess
 In this example, you only have one channel called `hello`. The sample application subscribes to this channel to receive `hello {name}` messages.
 
 <CodeBlock highlightedLines={[6,7,8,9]}>
-{`asyncapi: 2.2.0
+{`asyncapi: 2.5.0
 info:
   title: Hello world application
   version: '0.1.0'
@@ -93,7 +93,7 @@ You can read the highlighted lines as:
 > This is the `payload` of the `message` that the `Hello world application` is subscribed to. You can `publish` the `message` to the `hello` channel and the `Hello world application` will receive it.
 
 <CodeBlock highlightedLines={[9,10,11]}>
-{`asyncapi: 2.2.0
+{`asyncapi: 2.5.0
 info:
   title: Hello world application
   version: '0.1.0'

--- a/pages/docs/tutorials/getting-started/security.md
+++ b/pages/docs/tutorials/getting-started/security.md
@@ -20,7 +20,7 @@ If you're using AsyncAPI to define an API that connects to a message broker, you
 Continuing with the `hello world` application example, let's learn how to define a simple security scheme (mechanism) for it.
 
 <CodeBlock highlightedLines={[10,11,42,43,44]}>
-{`asyncapi: '2.2.0'
+{`asyncapi: '2.5.0'
 info:
   title: Hello world application
   version: '0.1.0'
@@ -73,7 +73,7 @@ The example above shows how to specify that your server (a Kafka broker) require
 
 <Remember title="Hint">
 
-There are many more security schemes. Learn more about them <Link href="/docs/specifications/2.2.0/#securitySchemeObject" passHref><a className="text-teal-600 font-medium hover:underline cursor-pointer">here</a></Link>.
+There are many more security schemes. Learn more about them <Link href="/docs/specifications/2.5.0/#securitySchemeObject" passHref><a className="text-teal-600 font-medium hover:underline cursor-pointer">here</a></Link>.
 
 </Remember>
 

--- a/pages/docs/tutorials/getting-started/servers.md
+++ b/pages/docs/tutorials/getting-started/servers.md
@@ -12,7 +12,7 @@ In the previous lesson, you learned how to create the definition of a simple [He
 In this article, you'll learn how to add `servers` to your AsyncAPI document. Adding and defining servers is useful, because it specifies where and how to connect. The connection facilitates where to send and receive messages.
 
 <CodeBlock highlightedLines={[5,6,7,8,9]}>
-{`asyncapi: 2.2.0
+{`asyncapi: 2.5.0
 info:
   title: Hello world application
   version: '0.1.0'

--- a/pages/docs/tutorials/streetlights-interactive.md
+++ b/pages/docs/tutorials/streetlights-interactive.md
@@ -27,8 +27,8 @@ Please become our alpha testers of the tutorial:
       type:'back',
     },
     {
-      href: '/docs/specifications/v2.4.0',
-      title: 'Specifications 2.4.0',
+      href: '/docs/specifications/v2.5.0',
+      title: 'Specifications 2.5.0',
       type:'next',
     }
   ]}

--- a/pages/docs/tutorials/streetlights.md
+++ b/pages/docs/tutorials/streetlights.md
@@ -52,7 +52,7 @@ Before you proceed to the next stage, you'll need to download a few things:
 In this step, we will create an AsyncAPI file to describe your API. It will help you generate the code and the documentation later on.
 
 <CodeBlock>
-{`asyncapi: '2.4.0'
+{`asyncapi: '2.5.0'
 info:
   title: Streetlights API
   version: '1.0.0'
@@ -93,7 +93,7 @@ channels:
 Let's break it down into pieces:
 
 <CodeBlock>
-{`asyncapi: '2.4.0'
+{`asyncapi: '2.5.0'
 info:
   title: Streetlights API
   version: '1.0.0'
@@ -105,7 +105,7 @@ info:
     url: 'https://www.apache.org/licenses/LICENSE-2.0'`}
 </CodeBlock>
 
-- The `asyncapi` field indicates you use the AsyncAPI version 2.4.0.
+- The `asyncapi` field indicates you use the AsyncAPI version 2.5.0.
 - The `info` field holds information about the API, such as its name, version, description, and license.
 
 Now lets move all the way to the `channels` section. This section is used to describe the event names your API will be publishing and/or subscribing to.
@@ -161,7 +161,7 @@ In this step, we will generate your code, you'll use the [AsyncAPI Generator](ht
 ### 3. Create a file with the AsyncAPI machine-readable description you defined before using terminal. The `cat` command is a utility command in Linux. On Windows use `type` instead of `cat`:
 <CodeBlock language="yaml">
 {`cat <<EOT >> asyncapi.yaml
-asyncapi: '2.4.0'
+asyncapi: '2.5.0'
 info:
   title: Streetlights API
   version: '1.0.0'


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- I have changed the asyncAPI version from 2.4.0 to 2.5.0 at all the possible places in docs in the form of text files, yaml files or reference links. Please request the changes if required. Thank you.

**Related issue(s)**
Resolves #998 