### PR TITLE
fix: remove unnecessary step in Streetlights tutorial

### DIFF
--- a/pages/docs/tutorials/streetlights.md
+++ b/pages/docs/tutorials/streetlights.md
@@ -222,27 +222,22 @@ EOT`}
 {`npm start`}
 </CodeBlock>
 
-### 3. In another terminal start MQTT broker:
-<CodeBlock language="bash">
-{`docker run -it -p 1883:1883 eclipse-mosquitto:1.5`}
-</CodeBlock>
-
-### 4. In another terminal install the MQTT.js library:
+### 3. In another terminal install the MQTT.js library:
 <CodeBlock language="bash">
 {`npm install mqtt -g`}
 </CodeBlock>
 
-### 5. Send a correct message to your application:
+### 4. Send a correct message to your application:
 <CodeBlock language="bash">
 {`mqtt pub -t 'light/measured' -h 'test.mosquitto.org' -m '{"id": 1, "lumens": 3, "sentAt": "2017-06-07T12:34:32.000Z"}'`}
 </CodeBlock>
 
-### 6. Send an incorrect message to your application:
+### 5. Send an incorrect message to your application:
 <CodeBlock language="bash">
 {`mqtt pub -t 'light/measured' -h 'test.mosquitto.org' -m '{"id": 1, "lumens": "3", "sentAt": "2017-06-07T12:34:32.000Z"}'`}
 </CodeBlock>
 
-### 7. Go back to the previous terminal and check if your application logged the streetlight condition you just sent, with errors related to the invalid message.
+### 6. Go back to the previous terminal and check if your application logged the streetlight condition you just sent, with errors related to the invalid message.
 
 # Summary
 


### PR DESCRIPTION
**Description**

This PR removes the current 3rd step in the [Running your code](https://www.asyncapi.com/docs/tutorials/streetlights#running-your-code) section of the Streetlights tutorial.

Running a broker is not needed since the **server** defined in the AsyncAPI document points to `test.mosquitto.org` and not to any local MQTT broker. 