### PR TITLE
fix: disable cache in frontMatter to avoid mix duplicated contents

### DIFF
--- a/scripts/build-post-list.js
+++ b/scripts/build-post-list.js
@@ -38,7 +38,8 @@ function walkDirectories(directories, result, sectionWeight = 0, sectionTitle, s
       const slugElements = slug.split('/');
       if (isDirectory(fileName)) {
         if (existsSync(fileNameWithSection)) {
-          details = frontMatter(readFileSync(fileNameWithSection, 'utf-8')).data
+          // Passing a second argument to frontMatter disables cache. See https://github.com/asyncapi/website/issues/1057
+          details = frontMatter(readFileSync(fileNameWithSection, 'utf-8'), {}).data
           details.title = details.title || capitalize(basename(fileName))
         } else {
           details = {
@@ -61,7 +62,8 @@ function walkDirectories(directories, result, sectionWeight = 0, sectionTitle, s
         walkDirectories([[fileName, slug]], result, details.weight, details.title, details.sectionId, rootId)
       } else if (file.endsWith('.md') && !fileName.endsWith('/_section.md')) {
         const fileContent = readFileSync(fileName, 'utf-8')
-        const { data, content } = frontMatter(fileContent)
+        // Passing a second argument to frontMatter disables cache. See https://github.com/asyncapi/website/issues/1057
+        const { data, content } = frontMatter(fileContent, {})
         details = data
         details.toc = toc(content, { slugify: slugifyToC }).json
         details.readingTime = Math.ceil(readingTime(content).minutes)


### PR DESCRIPTION
**Description**

Since both `v2.5.0.md` and `v3.0.0-next-major-spec.4 ` are identical in terms of content, https://github.com/asyncapi/website/blob/master/scripts/build-post-list.js#L64 is returning the same exact file when processing the second, meaning it returns the same object as for `v2.5.0.md`. See cache logic in https://github.com/jonschlinkert/gray-matter/blob/8a22958e0afd4b2e09c705becec1c35e76c4f0ee/index.js#L37-L42.
Then, the issue is that any modification is being made to the same file in memory, ending up in `v2.5.0.md` being a mix of both files. 

This PR uses a workaround to disable cache: to pass `{}` as second argument to `frontMatter` function, i.e. `frontMatter(fileContent, {})`. 

**Related issue(s)**
Fixes https://github.com/asyncapi/website/issues/1057