### PR TITLE
fix: homepage link to studio not matching asyncapi version

### DIFF
--- a/components/buttons/OpenInStudioButton.js
+++ b/components/buttons/OpenInStudioButton.js
@@ -2,7 +2,7 @@ import Button from './Button'
 import IconRocket from '../icons/Rocket'
 
 export default function OpenInStudioButton({ text = 'Open in Studio', className = '' }) {
-  const sampleSpec = encodeURI('https://raw.githubusercontent.com/asyncapi/asyncapi/v2.5.0/examples/simple.yml')
+  const sampleSpec = encodeURI('https://raw.githubusercontent.com/asyncapi/asyncapi/master/examples/simple.yml')
   return (
     <Button
       className={`text-center block md:mt-0 md:inline-block border-secondary-500 border text-secondary-500 hover:text-white shadow-md group ${className}`}

--- a/components/buttons/OpenInStudioButton.js
+++ b/components/buttons/OpenInStudioButton.js
@@ -2,7 +2,7 @@ import Button from './Button'
 import IconRocket from '../icons/Rocket'
 
 export default function OpenInStudioButton({ text = 'Open in Studio', className = '' }) {
-  const sampleSpec = encodeURI('https://raw.githubusercontent.com/asyncapi/asyncapi/v2.3.0/examples/simple.yml')
+  const sampleSpec = encodeURI('https://raw.githubusercontent.com/asyncapi/asyncapi/v2.5.0/examples/simple.yml')
   return (
     <Button
       className={`text-center block md:mt-0 md:inline-block border-secondary-500 border text-secondary-500 hover:text-white shadow-md group ${className}`}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

* homepage example showing asyncapi 2.5.0 but studio link points to 2.3.0

![Bildschirm­foto 2022-11-04 um 13 18 27](https://user-images.githubusercontent.com/242039/199971437-a620114f-fb6d-4f9c-8760-c489ae176134.png)


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
-