### PR TITLE
fix: enable ids in list of features from landing page

### DIFF
--- a/components/features/index.jsx
+++ b/components/features/index.jsx
@@ -89,7 +89,7 @@ export default function Features() {
                 <div className="flex justify-between">
                   {feature.links.map((link) => {
                     return (
-                      <Link href={link.href} key={link.label}>
+                      <Link href={link.href} key={link.label} id={link.id}>
                         <TextLink href={link.href} className="mt-6 inline-block">
                           {link.label}
                         </TextLink>

--- a/components/features/index.jsx
+++ b/components/features/index.jsx
@@ -89,8 +89,8 @@ export default function Features() {
                 <div className="flex justify-between">
                   {feature.links.map((link) => {
                     return (
-                      <Link href={link.href} key={link.label} id={link.id}>
-                        <TextLink href={link.href} className="mt-6 inline-block">
+                      <Link href={link.href} key={link.label}>
+                        <TextLink id={link.id} href={link.href} className="mt-6 inline-block">
                           {link.label}
                         </TextLink>
                       </Link>

--- a/components/typography/TextLink.js
+++ b/components/typography/TextLink.js
@@ -3,7 +3,8 @@ export default function TextLink({
     href,
     className,
     target,
-    children
+    children,
+    id
 }) {
 
     const classNames = `text-secondary-500 underline hover:text-gray-800 font-medium transition ease-in-out duration-300 ${className || ''}`
@@ -12,7 +13,7 @@ export default function TextLink({
         <>
             {' '}
             <Link href={href}>
-                <a target={target} rel="noreferrer noopener" className={classNames}>
+                <a id={id} target={target} rel="noreferrer noopener" className={classNames}>
                     {children}
                 </a>
             </Link>


### PR DESCRIPTION
Ids are critical for Google Tag manager. They are used to track how often people click on certain links on landing pages. The purpose is to learn if these are even useful if people care and interact with them.


cc @alequetzalli this is a fix for the issue we discussed recently. So basically answer is: there is no global issue with website that `id` are disabled. It was just a problem with single component after brand migration. So you can easily use `id` in tag manager

@alequetzalli the problem is I have no idea how we can make sure `id`s are not removed by anyone in next PRs. Without automation it can happen in future that these are removed. The only option I see is making you codeowner for `docs` related code. But this is not best solution, just responsibility is delegated to you 😄 
Else? we could introduce automated tests. So start website instance, and check if `id` are there. You would have a config file where you have to write what `id` you add, and where are they expected to be 🤔 