### PR TITLE
fix: fixing the broken specification link 

### DIFF
--- a/components/features/index.jsx
+++ b/components/features/index.jsx
@@ -8,7 +8,7 @@ const features = [
     name: "Specification",
     description:
       "Allows you to define the interfaces of asynchronous APIs and is protocol agnostic.",
-    links: [{ label: "Documentation", href: "docs/specifications/latest", id:'whyasyncapi-spec-documentation-link' }],
+    links: [{ label: "Documentation", href: "docs/reference/specification/v2.5.0", id:'whyasyncapi-spec-documentation-link' }],
   },
   {
     name: "Document APIs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15720,7 +15720,6 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.14",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- The documentation link in specification section of the main website was broken.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
#1059