### PR TITLE
fix: space in TOC section

### DIFF
--- a/components/TOC.js
+++ b/components/TOC.js
@@ -42,7 +42,7 @@ export default function TOC({
           {
             tocItems.map((item, index) => (
               <a
-                className={`pl-${(item.lvl - minLevel) * 2} block mb-1 transition duration-100 ease-in-out text-gray-900 font-normal text-sm font-sans antialiased hover:underline`}
+                className={`pl-${Math.pow(2, item.lvl-1)} block mb-1 transition duration-100 ease-in-out text-gray-900 font-normal text-sm font-sans antialiased hover:underline`}
                 href={`#${item.slug}`}
                 key={index}
               >


### PR DESCRIPTION
**Description**
pl-6 tailwind class was not working in the deployment.
So, converting padding to `2^level - 1`, as `pl-0, pl-2, pl-4, pl8` are working fine.

**Related issue(s)**
FIxed #1203 