### PR TITLE
docs: updated version 2.5.0 to 2.6.0 on landing page

### DIFF
--- a/components/DemoAnimation.js
+++ b/components/DemoAnimation.js
@@ -44,7 +44,7 @@ export default function DemoAnimation({ className = '' }) {
     const common = (
       <>
         <div>
-          <span className="text-teal-400">asyncapi:</span> 2.5.0
+          <span className="text-teal-400">asyncapi:</span> 2.6.0
         </div>
         <div>
           <span className="text-teal-400">info:</span>


### PR DESCRIPTION
Fix: https://github.com/asyncapi/website/issues/1302

Updated version from 2.5.0 to 2.6.0 on the landing page