### PR TITLE
docs: fix typo in Polymorphism section

### DIFF
--- a/pages/docs/reference/specification/v2.0.0.md
+++ b/pages/docs/reference/specification/v2.0.0.md
@@ -1492,7 +1492,7 @@ While composition offers model extensibility, it does not imply a hierarchy betw
 To support polymorphism, AsyncAPI Specification adds the support of the `discriminator` field.
 When used, the `discriminator` will be the name of the property used to decide which schema definition is used to validate the structure of the model.
 As such, the `discriminator` field MUST be a required field.
-There are are two ways to define the value of a discriminator for an inheriting instance.
+There are two ways to define the value of a discriminator for an inheriting instance.
 - Use the schema's name.
 - Override the schema's name by overriding the property with a new value. If exists, this takes precedence over the schema's name.
 As such, inline schema definitions, which do not have a given id, *cannot* be used in polymorphism.

--- a/pages/docs/reference/specification/v2.1.0.md
+++ b/pages/docs/reference/specification/v2.1.0.md
@@ -1543,7 +1543,7 @@ While composition offers model extensibility, it does not imply a hierarchy betw
 To support polymorphism, AsyncAPI Specification adds the support of the `discriminator` field.
 When used, the `discriminator` will be the name of the property used to decide which schema definition is used to validate the structure of the model.
 As such, the `discriminator` field MUST be a required field.
-There are are two ways to define the value of a discriminator for an inheriting instance.
+There are two ways to define the value of a discriminator for an inheriting instance.
 
 - Use the schema's name.
 - Override the schema's name by overriding the property with a new value. If exists, this takes precedence over the schema's name.

--- a/pages/docs/reference/specification/v2.2.0.md
+++ b/pages/docs/reference/specification/v2.2.0.md
@@ -1639,7 +1639,7 @@ While composition offers model extensibility, it does not imply a hierarchy betw
 To support polymorphism, AsyncAPI Specification adds the support of the `discriminator` field.
 When used, the `discriminator` will be the name of the property used to decide which schema definition is used to validate the structure of the model.
 As such, the `discriminator` field MUST be a required field.
-There are are two ways to define the value of a discriminator for an inheriting instance.
+There are two ways to define the value of a discriminator for an inheriting instance.
 
 - Use the schema's name.
 - Override the schema's name by overriding the property with a new value. If exists, this takes precedence over the schema's name.

--- a/pages/docs/reference/specification/v2.3.0.md
+++ b/pages/docs/reference/specification/v2.3.0.md
@@ -1674,7 +1674,7 @@ While composition offers model extensibility, it does not imply a hierarchy betw
 To support polymorphism, AsyncAPI Specification adds the support of the `discriminator` field.
 When used, the `discriminator` will be the name of the property used to decide which schema definition is used to validate the structure of the model.
 As such, the `discriminator` field MUST be a required field.
-There are are two ways to define the value of a discriminator for an inheriting instance.
+There are two ways to define the value of a discriminator for an inheriting instance.
 
 - Use the schema's name.
 - Override the schema's name by overriding the property with a new value. If exists, this takes precedence over the schema's name.

--- a/pages/docs/reference/specification/v2.4.0.md
+++ b/pages/docs/reference/specification/v2.4.0.md
@@ -1732,7 +1732,7 @@ While composition offers model extensibility, it does not imply a hierarchy betw
 To support polymorphism, AsyncAPI Specification adds the support of the `discriminator` field.
 When used, the `discriminator` will be the name of the property used to decide which schema definition is used to validate the structure of the model.
 As such, the `discriminator` field MUST be a required field.
-There are are two ways to define the value of a discriminator for an inheriting instance.
+There are two ways to define the value of a discriminator for an inheriting instance.
 
 - Use the schema's name.
 - Override the schema's name by overriding the property with a new value. If exists, this takes precedence over the schema's name.

--- a/pages/docs/reference/specification/v2.5.0.md
+++ b/pages/docs/reference/specification/v2.5.0.md
@@ -1765,7 +1765,7 @@ While composition offers model extensibility, it does not imply a hierarchy betw
 To support polymorphism, AsyncAPI Specification adds the support of the `discriminator` field.
 When used, the `discriminator` will be the name of the property used to decide which schema definition is used to validate the structure of the model.
 As such, the `discriminator` field MUST be a required field.
-There are are two ways to define the value of a discriminator for an inheriting instance.
+There are two ways to define the value of a discriminator for an inheriting instance.
 
 - Use the schema's name.
 - Override the schema's name by overriding the property with a new value. If exists, this takes precedence over the schema's name.

--- a/pages/docs/reference/specification/v2.6.0.md
+++ b/pages/docs/reference/specification/v2.6.0.md
@@ -1769,7 +1769,7 @@ While composition offers model extensibility, it does not imply a hierarchy betw
 To support polymorphism, AsyncAPI Specification adds the support of the `discriminator` field.
 When used, the `discriminator` will be the name of the property used to decide which schema definition is used to validate the structure of the model.
 As such, the `discriminator` field MUST be a required field.
-There are are two ways to define the value of a discriminator for an inheriting instance.
+There are two ways to define the value of a discriminator for an inheriting instance.
 
 - Use the schema's name.
 - Override the schema's name by overriding the property with a new value. If exists, this takes precedence over the schema's name.

--- a/pages/docs/reference/specification/v3.0.0-next-major-spec.9.md
+++ b/pages/docs/reference/specification/v3.0.0-next-major-spec.9.md
@@ -1829,7 +1829,7 @@ While composition offers model extensibility, it does not imply a hierarchy betw
 To support polymorphism, AsyncAPI Specification adds the support of the `discriminator` field.
 When used, the `discriminator` will be the name of the property used to decide which schema definition is used to validate the structure of the model.
 As such, the `discriminator` field MUST be a required field.
-There are are two ways to define the value of a discriminator for an inheriting instance.
+There are two ways to define the value of a discriminator for an inheriting instance.
 
 - Use the schema's name.
 - Override the schema's name by overriding the property with a new value. If exists, this takes precedence over the schema's name.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This PR suggest to fix a typo in polymorphism section, duplicated in every version of AsyncAPI documentations, from 2.0.0 to 3.0.0:

s/There are are two ways/ There are two ways/

➡️ two `ways` , but only one `are`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

---

Context: noticed by working on polymorphism and discriminator support with https://github.com/bump-sh