### PR TITLE
fix: redirected /docs/tutorials/getting-started

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -15,6 +15,7 @@ https://www.asyncapi.io/* https://www.asyncapi.com/:splat 301!
 /docs/getting-started/servers /docs/tutorials/getting-started/servers 301!
 /docs/getting-started/security /docs/tutorials/getting-started/security 301!
 /docs/community/tooling /docs/tools 301!
+/docs/tutorials/getting-started /docs/tutorials/getting-started/event-driven-architectures 301!
 
 # Redirection will be handled automatically by Action.
 # LATEST-SPEC-REDIRECTION:START


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
Fixes #1356 

-> The Getting-started link in the docs https://www.asyncapi.com/docs/tutorials/getting-started doesn't exist and needs to be redirected to the first subheading under Getting Started https://www.asyncapi.com/docs/tutorials/getting-started/event-driven-architectures.