### PR TITLE
feat: added canonical metadata to blog

### DIFF
--- a/components/layout/BlogLayout.js
+++ b/components/layout/BlogLayout.js
@@ -80,6 +80,7 @@ export default function BlogLayout({ post, children }) {
                     display: none !important;
                 }
               `}</style>
+              {post.canonical && <link rel="canonical" href={post.canonical} />}
             </HtmlHead>
             <img src={post.cover} alt={post.coverCaption} title={post.coverCaption} className="mt-6 mb-6 w-full" />
             {children}

--- a/pages/blog/async_standards_compare.md
+++ b/pages/blog/async_standards_compare.md
@@ -3,6 +3,7 @@ type: Engineering
 cover: /img/posts/async_standards_compare/devops-specs_pic-01.webp
 title: "AsyncAPI, CloudEvents, OpenTelemetry: Which Event-Driven Specs Should Your DevOps Include?"
 date: 2021-05-25T06:00:00+01:00
+canonical: https://solace.com/blog/asyncapi-cloudevents-opentelemetry-event-driven-specs-devops/
 tags:
    - OpenTelemetry
    - Specification

--- a/pages/blog/asyncapi-discovery-intro.md
+++ b/pages/blog/asyncapi-discovery-intro.md
@@ -3,6 +3,7 @@ type: Engineering
 cover: /img/posts/asyncapi-discovery-intro/asyncapi-discovery-tool-header.webp
 title: 'Align Production Reality and Event Documentation with the AsyncAPI Discovery Tool'
 date: 2021-12-07T06:00:00+01:00
+canonical: https://solace.com/blog/asyncapi-discovery-tool/
 tags:
   - Discovery
   - Specification

--- a/pages/blog/asyncapi_codegen_scst.md
+++ b/pages/blog/asyncapi_codegen_scst.md
@@ -3,6 +3,7 @@ type: Engineering
 cover: /img/posts/asyncapi-codegen_pic-00.webp
 title: "AsyncAPI Code Generation: Microservices Using Spring Cloud Stream"
 date: 2020-06-02T06:00:00+01:00
+canonical: https://solace.com/blog/asyncapi-codegen-microservices-using-spring-cloud-stream/
 tags:
    - Solace
    - Java

--- a/pages/blog/openapi-vs-asyncapi-burning-questions.md
+++ b/pages/blog/openapi-vs-asyncapi-burning-questions.md
@@ -3,6 +3,7 @@ type: Engineering
 cover: /img/posts/openapi-vs-asyncapi-burning-questions/asyncapi-openapi-post_pic-15.webp
 title: "AsyncAPI vs OpenAPI: Answers to Your Burning Questions About Two Leading API Specs"
 date: 2021-09-08T06:00:00+01:00
+canonical: https://solace.com/blog/asyncapi-vs-openapi/
 tags:
    - Specification
    - OpenAPI

--- a/scripts/compose.js
+++ b/scripts/compose.js
@@ -22,6 +22,7 @@ const genFrontMatter = (answers) => {
   title: ${answers.title ? answers.title : 'Untitled'}
   date: ${moment().format("YYYY-MM-DDTh:mm:ssZ")}
   type: ${answers.type}
+  canonical: ${answers.canonical ? answers.canonical : ''}
   tags: [${answers.tags ? tags : ''}]
   cover: /img/posts/may-2021-at-asyncapi/cover.webp
   authors:
@@ -118,6 +119,11 @@ inquirer
       message: 'Enter the post type:',
       type: 'list',
       choices: ['Communication', 'Community', 'Engineering', 'Marketing', 'Strategy', 'Video'],
+    },
+    {
+      name: 'canonical',
+      message: 'Enter the canonical URL if any:',
+      type: 'input',
     },
   ])
   .then((answers) => {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Provide option to add canonical URL for blogs on `npm run write:blog`
- Added `<link rel=canonical href="https://solace.com/blog/asyncapi-vs-openapi/"/>` to the head of the blogs having canonical URL
- Mapped the canonical URLs for the blogs @jessemenning asked for

**Related issue(s)**
#1430 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->