### PR TITLE
fix: update slack component's image url

### DIFF
--- a/components/slack/index.js
+++ b/components/slack/index.js
@@ -50,7 +50,7 @@ export default function Slack({
           }
         />
         <SlackMessage
-          avatar="/img/homepage/eve-and-chan.png"
+          avatar="/img/homepage/eve-and-chan.webp"
           name="Eve & Chan"
           text={
             <>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This MR fixes an image url in the "Slack" component displayed on the homepage:

<table>
<thead>
	<tr>
    	<th>Before</th>
		<th>After</th>
	</tr>
</thead>
<tr>
	<td><img width="531" alt="Screenshot 2023-04-12 at 10 39 53" src="https://user-images.githubusercontent.com/16135480/231402463-74fa10fd-eaab-4436-b73a-a0f5ac588962.png"></td>
	<td>
<img width="855" alt="Screenshot 2023-04-12 at 10 40 01" src="https://user-images.githubusercontent.com/16135480/231402800-f791040e-26e2-4746-a01e-578b71ba1a28.png">
</td>
</tr>
</table>




**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->