### PR TITLE
fix: fixed the spacing between Navbar and Heading in Newsroom page

### DIFF
--- a/components/newsroom/Newsroom.js
+++ b/components/newsroom/Newsroom.js
@@ -10,7 +10,7 @@ import TextLink from '../typography/TextLink'
 export default function Newsroom() {
   return (
     <> 
-      <div className="text-center pt-16">
+      <div className="text-center mt-16">
         <Heading
           level="h2"
           typeStyle="heading-lg"

--- a/components/newsroom/Newsroom.js
+++ b/components/newsroom/Newsroom.js
@@ -10,7 +10,7 @@ import TextLink from '../typography/TextLink'
 export default function Newsroom() {
   return (
     <> 
-      <div className="text-center">
+      <div className="text-center pt-16">
         <Heading
           level="h2"
           typeStyle="heading-lg"

--- a/components/newsroom/Newsroom.js
+++ b/components/newsroom/Newsroom.js
@@ -10,7 +10,7 @@ import TextLink from '../typography/TextLink'
 export default function Newsroom() {
   return (
     <> 
-      <div className="text-center mt-16">
+      <div className="text-center mt-12">
         <Heading
           level="h2"
           typeStyle="heading-lg"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
The spacing between the Navbar and the heading was irregular on the Newsroom page as compared to other pages on the website. Fixed the spacing by adding padding above the Heading similar to other pages.

Previous behavior- 
![image](https://user-images.githubusercontent.com/97905637/236326874-0a6bb9f1-cf2c-46e1-9dd8-5811daa12ebf.png)

Updated behavior- 
![async heading fix](https://user-images.githubusercontent.com/97905637/236326950-67aa861b-e738-425a-9a2d-9c1a8262bbd3.png)

**Related issue(s)**
Resolves #1624 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->