### PR TITLE
fix: make sure function for rewriting request supports %

### DIFF
--- a/netlify/edge-functions/serve-definitions.ts
+++ b/netlify/edge-functions/serve-definitions.ts
@@ -15,7 +15,7 @@ const URL_DEST_DEFINITIONS = "https://raw.githubusercontent.com/asyncapi/spec-js
 //   Examples: /definitions/asyncapi.yaml OR /schema-store/2.4.0.JSON (uppercase)
 //
 // Non-legitimate requests should not use our GitHub Token and affect the rate limit. Those shouldn't send metrics to NR either as they just add noise.
-const legitimateRequestRegex = /^\/[\w\-]*\/?(?:([\w\-\.]*\/)?([\w\-$\.]*\.json))?$/
+const legitimateRequestRegex = /^\/[\w\-]*\/?(?:([\w\-\.]*\/)?([\w\-$%\.]*\.json))?$/
 
 export default async (request: Request, context: Context) => {
   let rewriteRequest = buildRewrite(request);


### PR DESCRIPTION
Also had to add `%` as `http://asyncapi.com/schema-store/2.5.0-without-$id.json` might be requested by code and then `$` becomes `%24` -> `http://asyncapi.com/schema-store/2.5.0-without-%24id.json` -> https://raw.githubusercontent.com/asyncapi/spec-json-schemas/master/schemas/2.5.0-without-%24id.json