### PR TITLE
fix: better error handling for discussion saviour bot

### DIFF
--- a/netlify/functions/save-discussion-background/Reposity.ts
+++ b/netlify/functions/save-discussion-background/Reposity.ts
@@ -116,7 +116,7 @@ _This discussion has been created from a [slack discussion](${slackURL}). Please
    */
   export async function markAnswer(commentId: string) {
     console.log('marking the answer...');
-    fetchGraphql(
+    await fetchGraphql(
       `
       mutation {
         markDiscussionCommentAsAnswer(input: {id: "${commentId}" }) {

--- a/netlify/functions/save-discussion-background/Slack.ts
+++ b/netlify/functions/save-discussion-background/Slack.ts
@@ -18,7 +18,7 @@ export namespace Slack {
     discussionCategories: DiscussionCategory[],
     triggerId: string
   ) {
-    slackClient.dialog
+    await slackClient.dialog
       .open({
         dialog: {
           callback_id: 'ryde-46e2b0',
@@ -123,7 +123,7 @@ export namespace Slack {
     threadTS: string
   ) {
     try {
-      slackClient.chat.postMessage({
+      await slackClient.chat.postMessage({
         channel: channelId,
         text: message,
         as_user: true,

--- a/netlify/functions/save-discussion-background/helpers.ts
+++ b/netlify/functions/save-discussion-background/helpers.ts
@@ -15,12 +15,11 @@ export function toTitleCase(title: string): string {
  * @param query the graphql query.
  * @returns {GraphQlResponse} the GitHub response object.
  */
-export function fetchGraphql(query: string): Promise<any> {
+export async function fetchGraphql(query: string): Promise<any> {
   const parameters = {
     headers: {
       authorization: `token ${process.env.GITHUB_TOKEN}`,
     },
   };
-
-  return graphql(query, parameters);
+  return await graphql(query, parameters);
 }

--- a/netlify/functions/save-discussion-background/index.ts
+++ b/netlify/functions/save-discussion-background/index.ts
@@ -14,12 +14,7 @@ const REPO_NAME = process.env.DISCUSSION_TARGET_REPO_NAME;
 const handler = async (event: HandlerEvent) => {
   // since slack always sends Only POST methods along with a body, we can ignore all other requests.
   if (event.httpMethod != 'POST' || !event.body) {
-    return {
-      statusCode: 400,
-      body: JSON.stringify({
-        message: "The specified HTTP method is either not allowed or the method is called in incomplete manner."
-      })
-    }
+    return;
   }
 
   // Slack encodes the body in application/x-www-form-urlencoded
@@ -29,22 +24,20 @@ const handler = async (event: HandlerEvent) => {
 
   // When the `Save Discussion` option selected in slack.
   if (payload.type === REQUEST_TYPE.MESSAGE_ACTION) {
-    handleMessageAction(payload);
+    await handleMessageAction(payload);
     //When the user submits the dialog.
   } else if (payload.type === REQUEST_TYPE.DIALOG_SUBMISSION) {
-    handleDialogSubmission(payload);
+    await handleDialogSubmission(payload);
   }
 };
 
 async function handleMessageAction(payload: any) {
   const channelId = payload.channel.id;
   const threadTS = payload.message.thread_ts;
-  console.log(payload);
-
   if (!threadTS) {
     const errorMessage =
       'Unable to save this discussion since it has no replies.';
-    Slack.sendResponse(payload.response_url, errorMessage);
+    await Slack.sendResponse(payload.response_url, errorMessage);
     return;
   }
 
@@ -53,40 +46,64 @@ async function handleMessageAction(payload: any) {
     REPO_NAME!
   );
   const state = `${channelId} ${threadTS}`;
-  Slack.openSaveDialog(state, discussionCategories, payload.trigger_id);
+  await Slack.openSaveDialog(state, discussionCategories, payload.trigger_id);
 }
 async function handleDialogSubmission(payload: any) {
   const dialogState = payload.state.split(' ');
   const channelId = dialogState[0];
   const threadTS = dialogState[1];
-  const discussion = await Slack.getSlackDiscussion(channelId, threadTS);
-  const categoryId = payload.submission.category;
-  if (!discussion) return;
-  discussion.title = payload.submission.title;
-  const repositoryId = await Repository.getRepositoryId(
-    process.env.DISCUSSION_TARGET_REPO_OWNER!,
-    process.env.DISCUSSION_TARGET_REPO_NAME!
-  );
-  const { discussionId, discussionURL } = await Repository.createDiscussion(
-    discussion,
-    repositoryId,
-    categoryId,
-    discussion.slackURL || ''
-  );
-  if (discussion.replies) {
-    for (const reply of discussion.replies) {
-      const replyId = await Repository.createDicussionReply(
-        discussionId,
-        reply
-      );
-      if (reply.isAnswer) {
-        Repository.markAnswer(replyId);
+  try {
+    const discussion = await Slack.getSlackDiscussion(channelId, threadTS);
+    console.log('got the following discussion', discussion);
+    const categoryId = payload.submission.category;
+    if (!discussion) return;
+    discussion.title = payload.submission.title;
+    const repositoryId = await Repository.getRepositoryId(
+      process.env.DISCUSSION_TARGET_REPO_OWNER!,
+      process.env.DISCUSSION_TARGET_REPO_NAME!
+    );
+    const { discussionId, discussionURL } = await Repository.createDiscussion(
+      discussion,
+      repositoryId,
+      categoryId,
+      discussion.slackURL || ''
+    );
+    if (discussion.replies) {
+      for (const reply of discussion.replies) {
+        const replyId = await Repository.createDicussionReply(
+          discussionId,
+          reply
+        );
+        if (reply.isAnswer) {
+          await Repository.markAnswer(replyId);
+        }
       }
     }
+    console.log(payload);
+    const message = `Thanks to <@${payload.user.id}>, this discussion has been preserved here: ${discussionURL}`;
+    await Slack.postReplyInThread(message, channelId, threadTS);
+  } catch (e) {
+    let errorMessage;
+
+    switch (e.data?.error) {
+      case 'missing_scope':
+        errorMessage =
+          'Sorry, This operation is only supposed to be used in public channels.';
+        break;
+      case 'channel_not_found':
+        errorMessage =
+          "Can't find the channel, are you sure that this is a public channel?";
+        break;
+      case 'not_in_channel':
+        errorMessage =
+          "Can't access this channel. Are you sure that I am a member of this channel? please add `BotTheSavior` in integration settings of this channel. :)";
+        break;
+    }
+
+    await Slack.sendResponse(payload.response_url, errorMessage);
+    console.error(e);
+    return;
   }
-  console.log(payload);
-  const message = `Thanks to <@${payload.user.id}>, this discussion has been preserved here: ${discussionURL}`;
-  Slack.postReplyInThread(message, channelId, threadTS);
 }
 
 export { handler };


### PR DESCRIPTION
**Description**
- fix the lambda function by awaiting its operations.
- add better error handling.
- remove unnecessary return statements.

**How to test?**
the function is currently being hosted [here](http://teal-profiterole-814511.netlify.app/.netlify/functions/save-discussion-background).

it can be tested in any AsyncAPI Slack's public channels. from the overflow menu of the message, select `Store in GitHub` but I would suggest doing it in a [test channel](https://asyncapi.slack.com/archives/C0579CUA7GD).