### PR TITLE
fix: auto scroll of sidebar on navigating to different section in docs

### DIFF
--- a/components/navigation/DocsNavItem.js
+++ b/components/navigation/DocsNavItem.js
@@ -20,7 +20,7 @@ export default function DocsNavItem({ title, slug, href, activeSlug, sectionSlug
   useEffect(() => {
     if (activeRef.current) {
       activeRef.current.scrollIntoView({ 
-        behavior: 'auto', 
+        behavior: 'smooth', 
         block: 'center', 
         inline: 'start',
     }

--- a/components/navigation/DocsNavItem.js
+++ b/components/navigation/DocsNavItem.js
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { useEffect,useRef, useState } from 'react';
 
 function isActiveSlug(slug, activeSlug, sectionSlug) {
   if(slug === '/docs' || (sectionSlug !== undefined && slug === sectionSlug)) {
@@ -14,9 +15,22 @@ function isActiveSlug(slug, activeSlug, sectionSlug) {
 export default function DocsNavItem({ title, slug, href, activeSlug, sectionSlug, onClick = () => {}, defaultClassName = '', inactiveClassName = '', activeClassName = '', bucket }) {
   const isActive = isActiveSlug(slug, activeSlug, sectionSlug);
   const classes = `${isActive ? activeClassName : inactiveClassName} ${defaultClassName} inline-block`;
+  const activeRef = useRef(null);
+    
+  useEffect(() => {
+    if (activeRef.current) {
+      activeRef.current.scrollIntoView({ 
+        behavior: 'auto', 
+        block: 'center', 
+        inline: 'start',
+    }
+    )};
+  }, [activeSlug]);
+
+
 
   return (
-    <div className='inline-block'>
+    <div className='inline-block' ref = {slug === activeSlug ? activeRef : null}>
       <div className={classes}>
         <Link href={href || slug}>
           <a href={href || slug} onClick={onClick}>


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

The PR adds  the auto scroll functionality in the sidebar when the user goes to the Doc section. This is achieved by adding a useEffect hook which gets triggered when the activeSlug in the sidebar changes.

**Proof of Work**


https://github.com/asyncapi/website/assets/96513964/77dec513-1158-425e-8878-6a6b8418cea1




**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

Fixes #1582 