### PR TITLE
fix: blog page displays wrong list of articles first before displaying the correct articles #1603

### DIFF
--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -125,7 +125,7 @@ export default function BlogIndexPage() {
               </div>
             ) : (
               <ul className="mt-12 grid gap-5 max-w-lg mx-auto lg:grid-cols-3 lg:max-w-none">
-                {posts.map((post, index) => (
+                {router.isReady && posts.map((post, index) => (
                   <BlogPostItem key={index} post={post} />
                 ))}
               </ul>


### PR DESCRIPTION
…g the correct articles #1603

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
This PR resolved the issue of when filters are applied on the blog page and the page is refreshed, the page displays all articles first before applying the filters.
Now it is showing a correct list of articles when filters are applied on the blog page and the page is refreshed.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Resolve #1603