### PR TITLE
chore: update slack invite link

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -56,7 +56,7 @@ https://www.asyncapi.io/* https://www.asyncapi.com/:splat 301!
 /asyncapi-react https://asyncapi.github.io/asyncapi-react 301!
 
 # Slack
-/slack-invite https://join.slack.com/t/asyncapi/shared_invite/zt-153ifujzl-fD4W~~LxiRroF8E5bx80qA 302!
+/slack-invite https://join.slack.com/t/asyncapi/shared_invite/zt-1vd6bk0j5-54Kh5C1kM6y0yxux1WikrA 302!
 
 # Central Maven repository verification
 /OSSRH-63280 https://github.com/asyncapi/java-asyncapi


### PR DESCRIPTION
resolves https://github.com/asyncapi/website/issues/1671

tbh I have no idea what happened, don't remember who created pervious invite link, especially that there is an option to generate `never expire` link. 

anyway new link in place, just need confirmation it works for others.