### PR TITLE
docs: update cli install instructions on CLI page

### DIFF
--- a/pages/tools/cli.js
+++ b/pages/tools/cli.js
@@ -131,7 +131,7 @@ export default function CliPage() {
                       code: setUpWin()
                     },
                     {
-                      language: 'Linux',
+                      language: 'linux',
                       code: setUpLinux() 
                     }
                   ]}

--- a/pages/tools/cli.js
+++ b/pages/tools/cli.js
@@ -67,6 +67,15 @@ export default function CliPage() {
 		return `# Download latest PKG file\ncurl -OL https://github.com/asyncapi/cli/releases/latest/download/asyncapi.pkg\n# Install application on MacOS\nsudo installer -pkg asyncapi.pkg -target /`;
 	};
 
+  const setUpWin = () => {
+    return `# Download latest asyncapi.x64.exe for 64-bit Windows\n https://github.com/asyncapi/cli/releases/latest/download/asyncapi.x64.exe\n# Download asyncapi.x86.exe for 32-bit Windows\n https://github.com/asyncapi/cli/releases/latest/download/asyncapi.x86.exe`;
+  };
+
+  const setUpLinux = () => {
+    return `# For Debian based distros, you can install the AsycAPI CLI using the dpkg package manager for Debian\ncurl -OL https://github.com/asyncapi/cli/releases/latest/download/asyncapi.deb\n# To download a specific release of the CLI, run this command in your terminal\ncurl -OL https://github.com/asyncapi/cli/releases/download/<replace this with the specific CLI version e.g v0.13.0>/asyncapi.deb /`;
+  };
+  
+
   return (
     <GenericLayout title="CLI" description={description} image={image} wide>
       <div className="py-12 overflow-hidden">
@@ -116,7 +125,15 @@ export default function CliPage() {
 										{
 											language: '.pkg',
 											code: getPkgCode()
-										}
+										},
+                    {
+                      language: 'windows',
+                      code: setUpWin()
+                    },
+                    {
+                      language: 'Linux',
+                      code: setUpLinux() 
+                    }
                   ]}
                 />
               </div>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
This PR adds short installation instructions for Windows and Linux to [this](https://www.asyncapi.com/tools/cli) page.

The screenshot below shows the current state.
<img width="660" alt="image" src="https://github.com/asyncapi/website/assets/33583060/2fc33084-e79b-4d3e-953f-50aecacb6e79">

The screenshot below shows the updates made.
<img width="664" alt="image" src="https://github.com/asyncapi/website/assets/33583060/c18ed558-9e27-4db5-9eff-16a9b66d2486">


**Related issue(s)**

See also #1682
 "I just noticed we have install instructions in https://www.asyncapi.com/tools/cli. 
Do you think you could update them as well, but with all missing options? It can be a separate PR if you want"

_Originally posted by @derberg in https://github.com/asyncapi/website/pull/1682#pullrequestreview-1430895060_