### PR TITLE
feat: adding unit tests for typography component

### DIFF
--- a/components/typography/Paragraph.js
+++ b/components/typography/Paragraph.js
@@ -23,6 +23,6 @@ export default function Paragraph({
     }
 
     return (
-        <p className={`${textColor} ${classNames}`}>{children}</p>
+        <p data-testid="Paragraph-test" className={`${textColor} ${classNames}`}>{children}</p>
     )
 }

--- a/components/typography/TextLink.js
+++ b/components/typography/TextLink.js
@@ -14,7 +14,7 @@ export default function TextLink({
         <>
             {' '}
             <Link href={href}>
-                <a id={id} target={target} rel="noreferrer noopener" className={classNames}>
+                <a data-testid="TextLink-href" id={id} target={target} rel="noreferrer noopener" className={classNames}>
                     {children}
                 </a>
             </Link>

--- a/cypress/test/typography/Heading.cy.js
+++ b/cypress/test/typography/Heading.cy.js
@@ -5,13 +5,13 @@ describe('Heading Component', () => {
       cy.mount(<Heading>Default Heading</Heading>);
     });
   
-    it('renders the heading with the default style', () => {
+    it('renders the heading with the  default props', () => {
       cy.get('h2').should('have.class', 'text-primary-800');
       cy.get('h2').should( 'have.class','font-heading text-heading-md font-bold tracking-heading md:text-heading-lg' );
       cy.get('h2').should('contain', 'Default Heading');
     });
   
-    it('renders the heading with custom style', () => {
+    it('renders the heading with custom props', () => {
       cy.mount(
         <Heading typeStyle="heading-sm-semibold" level="h3" textColor="text-red-500">
           Heading with custom styles

--- a/cypress/test/typography/Heading.cy.js
+++ b/cypress/test/typography/Heading.cy.js
@@ -1,0 +1,25 @@
+import { mount } from '@cypress/react';
+import Heading from '../../../components/typography/Heading'
+describe('Heading Component', () => {
+    beforeEach(() => {
+      cy.mount(<Heading>Default Heading</Heading>);
+    });
+  
+    it('renders the heading with the default style', () => {
+      cy.get('h2').should('have.class', 'text-primary-800');
+      cy.get('h2').should( 'have.class','font-heading text-heading-md font-bold tracking-heading md:text-heading-lg' );
+      cy.get('h2').should('contain', 'Default Heading');
+    });
+  
+    it('renders the heading with custom style', () => {
+      cy.mount(
+        <Heading typeStyle="heading-sm-semibold" level="h3" textColor="text-red-500">
+          Heading with custom styles
+        </Heading>
+      );
+     cy.get('h3').should('have.class', 'text-red-500');
+      cy.get('h3').should( 'have.class','font-heading text-heading-sm font-semibold tracking-heading');
+      cy.get('h3').should('contain', 'Heading with custom styles');
+    });
+  });
+  

--- a/cypress/test/typography/Paragraph.cy.js
+++ b/cypress/test/typography/Paragraph.cy.js
@@ -1,0 +1,32 @@
+import { mount } from '@cypress/react';
+import Paragraph from '../../../components/typography/Paragraph';
+describe('Paragraph Component', () => {
+    beforeEach(() => {
+      cy.mount(
+        <Paragraph typeStyle="body-lg" textColor="text-gray-700" fontWeight="font-bold">
+          Default Paragraph
+        </Paragraph>
+      );
+    });
+  
+    it('renders the paragraph with the default style', () => {
+      cy.get('p').should('have.class', 'text-gray-700');
+      cy.get('p').should('have.class', 'text-lg');
+      cy.get('p').should('have.class', 'font-bold');
+      cy.get('p').should('contain', 'Default Paragraph');
+    });
+  
+    it('renders the paragraph with custom style', () => {
+      cy.mount(
+        <Paragraph typeStyle="body-md" textColor="text-blue-500" fontWeight="font-semibold">
+           Paragraph with custom styles
+        </Paragraph>
+      );
+  
+      cy.get('p').should('have.class', 'text-blue-500');
+      cy.get('p').should('have.class', 'text-md');
+      cy.get('p').should('have.class', 'font-semibold');
+      cy.get('p').should('contain', 'Paragraph with custom styles');
+    });
+  });
+  

--- a/cypress/test/typography/Paragraph.cy.js
+++ b/cypress/test/typography/Paragraph.cy.js
@@ -9,24 +9,24 @@ describe('Paragraph Component', () => {
       );
     });
   
-    it('renders the paragraph with the default style', () => {
-      cy.get('p').should('have.class', 'text-gray-700');
-      cy.get('p').should('have.class', 'text-lg');
-      cy.get('p').should('have.class', 'font-bold');
-      cy.get('p').should('contain', 'Default Paragraph');
+    it('renders the paragraph with the default props', () => {
+      cy.get('[data-testid="Paragraph-test" ]').should('have.class', 'text-gray-700');
+      cy.get('[data-testid="Paragraph-test" ]').should('have.class', 'text-lg');
+      cy.get('[data-testid="Paragraph-test" ]').should('have.class', 'font-bold');
+      cy.get('[data-testid="Paragraph-test" ]').should('contain', 'Default Paragraph');
     });
   
-    it('renders the paragraph with custom style', () => {
+    it('renders the paragraph with custom props', () => {
       cy.mount(
         <Paragraph typeStyle="body-md" textColor="text-blue-500" fontWeight="font-semibold">
            Paragraph with custom styles
         </Paragraph>
       );
   
-      cy.get('p').should('have.class', 'text-blue-500');
-      cy.get('p').should('have.class', 'text-md');
-      cy.get('p').should('have.class', 'font-semibold');
-      cy.get('p').should('contain', 'Paragraph with custom styles');
+      cy.get('[data-testid="Paragraph-test" ]').should('have.class', 'text-blue-500');
+      cy.get('[data-testid="Paragraph-test" ]').should('have.class', 'text-md');
+      cy.get('[data-testid="Paragraph-test" ]').should('have.class', 'font-semibold');
+      cy.get('[data-testid="Paragraph-test" ]').should('contain', 'Paragraph with custom styles');
     });
   });
   

--- a/cypress/test/typography/TextLink.cy.js
+++ b/cypress/test/typography/TextLink.cy.js
@@ -1,7 +1,7 @@
 import { mount } from '@cypress/react';
 import TextLink from '../../../components/typography/TextLink'
 describe('TextLink Component', () => {
-    it('renders a link with the provided props and content', () => {
+    it('renders a Textlink with the provided props and content', () => {
       const href = '/test';
       const className = 'custom-class';
       const target = '_blank';

--- a/cypress/test/typography/TextLink.cy.js
+++ b/cypress/test/typography/TextLink.cy.js
@@ -1,0 +1,33 @@
+import { mount } from '@cypress/react';
+import TextLink from '../../../components/typography/TextLink'
+describe('TextLink Component', () => {
+    it('renders a link with the provided props and content', () => {
+      const href = '/test';
+      const className = 'custom-class';
+      const target = '_blank';
+      const id = 'test-link';
+      const children = 'Test Link';
+  
+      cy.mount(
+        <TextLink href={href} className={className} target={target} id={id}>
+          {children}
+        </TextLink>
+      );
+  
+      cy.get('[data-testid="TextLink-href" ]')
+        .should('have.attr', 'href', href)
+        .should('have.class', 'text-secondary-500')
+        .should('have.class', 'underline')
+        .should('have.class', 'hover:text-gray-800')
+        .should('have.class', 'font-medium')
+        .should('have.class', 'transition')
+        .should('have.class', 'ease-in-out')
+        .should('have.class', 'duration-300')
+        .should('have.class', className)
+        .should('have.attr', 'target', target)
+        .should('have.attr', 'rel', 'noreferrer noopener')
+        .should('have.attr', 'id', id)
+        .should('contain', children);
+    });
+  });
+  


### PR DESCRIPTION
**Description**
- Typography in AsyncAPI includes 3 main components :

- **Heading** : This component has heading which has props like 'typeStyle' and 'textColor' , and levels , which when we pass to heading when required we can change it accordingly . 
Here are the tests I have included for this component :   

1. renders the heading with the default props
2. renders the heading with custom props

NOTE : For this component I have not included 'data-testids' since testing was required for specific level tag headings and already passed props . 

![image](https://github.com/asyncapi/website/assets/64789514/c01cc263-cfc3-41de-9aef-dc9d218077b4)
![image](https://github.com/asyncapi/website/assets/64789514/644559ff-566d-4d4c-8732-0942e7f0323c)

- **Paragraph** :  This component also has some textStyle and textColor Props . 
The tests I have included here are as follows : 
1. renders the paragraph with the default props
2. renders the paragraph with custom props
![image](https://github.com/asyncapi/website/assets/64789514/3df5cd00-7572-4929-9e19-563288e3a91a)
![image](https://github.com/asyncapi/website/assets/64789514/6c898258-efce-49c4-88b6-8c264beb1f23)

- TextLink : For this component the tests I have included are as follows :  
1. renders a link with the provided props and contentpassed

![image](https://github.com/asyncapi/website/assets/64789514/70d189c3-8631-4c9a-99b8-ed0de73e2bfe)

**Related issue(s)**
fixes #1792 