### PR TITLE
feat: adding stylesheets to cypress components 

### DIFF
--- a/cypress/support/component.js
+++ b/cypress/support/component.js
@@ -20,6 +20,7 @@ import './commands'
 // require('./commands')
 
 import { mount } from 'cypress/react'
+import '../../styles/globals.css'
 
 Cypress.Commands.add('mount', mount)
 


### PR DESCRIPTION
**Description**
- Currently , on running cypress tests , only the content of component was rendered on the cypress test window , it is important that even styles are rendered on the screen . For this I have imported the global styles file in the cypress component file , and thus the css is also rendered on the test window . 

-For eg :       
1. **Tests for DocsCards :** 
![image](https://github.com/asyncapi/website/assets/64789514/bf95a77f-1d81-4c38-8893-210e6f8a0809)

2. **Tests for features  :**  
![image](https://github.com/asyncapi/website/assets/64789514/4726c2f4-3dbc-4502-8ccf-f9f060a13b6d)

3. **Typography tests :** 
![image](https://github.com/asyncapi/website/assets/64789514/c4e8c401-59ab-4660-83e5-f7957d9ca0ae)

4. **Community tests :** 
1. Header   
![image](https://github.com/asyncapi/website/assets/64789514/0a173c7a-0a0d-4284-873e-27935593e32f)
2 . HomeCard 
![image](https://github.com/asyncapi/website/assets/64789514/15181bb1-a420-4ac3-8fbb-79966ecf5bb5)

**Related issue(s)**
fixes #1801 