### PR TITLE
chore: adjust address for reply

### DIFF
--- a/pages/blog/the-new-era-approaches.md
+++ b/pages/blog/the-new-era-approaches.md
@@ -64,7 +64,7 @@ channels:
       - $ref: "#/servers/websocket"
 
   turnStreetlightOnReplyChannel:
-    address: null
+    address: "/"
     messages:
       turnOnReply: 
         $ref: "#/components/messages/turnOnReply"


### PR DESCRIPTION
**Description**
After some back and furth with @derberg its better to use `address: "/"` then null.