### PR TITLE
chore: add proper `robots.txt` config

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
-Disallow: /
+Disallow: /definitions/
+Disallow: /schema-store/


### PR DESCRIPTION
Before we release new version of website, we need to merge this PR. It reverts https://github.com/asyncapi/website/pull/1846 that was done for the purpose of v3.asyncapi.com