### PR TITLE
fix: add redirect from /events to /meetings

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -71,4 +71,4 @@ https://www.asyncapi.io/* https://www.asyncapi.com/:splat 301!
 # TOOLS-REDIRECTION:END
 
 # Additional redirection
-https://deploy-preview-1949--asyncapi-website.netlify.app/community/meetings https://deploy-preview-1949--asyncapi-website.netlify.app/community/events 301!
+/community/meetings /community/events 301!

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,3 @@
-# These rules will change if you change your site’s custom domains or HTTPS settings
-
 https://asyncapi.com/* https://www.asyncapi.com/:splat 301!
 https://asyncapi.org/* https://www.asyncapi.com/:splat 301!
 https://www.asyncapi.org/* https://www.asyncapi.com/:splat 301!
@@ -69,3 +67,6 @@ https://www.asyncapi.io/* https://www.asyncapi.com/:splat 301!
 /generator /tools/generator 301!
 /github-actions /tools/github-actions 301!
 # TOOLS-REDIRECTION:END
+
+# Additional redirection
+https://www.asyncapi.com/community/meetings https://www.asyncapi.com/community/events 301!

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,5 @@
+# These rules will change if you change your site’s custom domains or HTTPS settings
+
 https://asyncapi.com/* https://www.asyncapi.com/:splat 301!
 https://asyncapi.org/* https://www.asyncapi.com/:splat 301!
 https://www.asyncapi.org/* https://www.asyncapi.com/:splat 301!

--- a/public/_redirects
+++ b/public/_redirects
@@ -71,4 +71,4 @@ https://www.asyncapi.io/* https://www.asyncapi.com/:splat 301!
 # TOOLS-REDIRECTION:END
 
 # Additional redirection
-https://www.asyncapi.com/community/meetings https://www.asyncapi.com/community/events 301!
+https://deploy-preview-1949--asyncapi-website.netlify.app/community/meetings https://deploy-preview-1949--asyncapi-website.netlify.app/community/events 301!


### PR DESCRIPTION
their was issue of meeting link not working at many place in the website because their was incorrect link at some places

so i have made some changes in _redirects that will redirect link at correct place

incorrect link :- incorrect link :- https://www.asyncapi.com/community/meetings

correct link :- incorrect link :- https://www.asyncapi.com/community/events

fixes : #1948 