### PR TITLE
docs: adding document for extending the AsyncAPI specification

### DIFF
--- a/pages/docs/concepts/asyncapi-document/_section.md
+++ b/pages/docs/concepts/asyncapi-document/_section.md
@@ -1,4 +1,4 @@
 ---
 title: 'AsyncAPI Document'
-weight: 0
+weight: 50
 ---

--- a/pages/docs/concepts/asyncapi-document/_section.md
+++ b/pages/docs/concepts/asyncapi-document/_section.md
@@ -1,0 +1,4 @@
+---
+title: 'AsyncAPI Document'
+weight: 0
+---

--- a/pages/docs/concepts/asyncapi-document/extending-specification.md
+++ b/pages/docs/concepts/asyncapi-document/extending-specification.md
@@ -7,13 +7,13 @@ Extending the AsyncAPI specification is a technique that allows developers to in
 
 The benefits of extending the AsyncAPI specification include enhanced specificity — delivering a clear encoding of necessary API details to applications, and consistency — allowing reusable components across the API. However, extensions should be used sparingly. Since they go beyond the Specification, they may not be universally understood.
 
-## Specification Extensions
+## Specification extensions
 
 The AsyncAPI Specification allows the addition of custom properties through patterned fields prefixed with `x-`. This helps you create unique things without causing problems with future updates.
 
 The `x-` prefix is used to define custom properties. These properties are user-defined and won't conflict with future specification versions because any property starting with `x-` is reserved for user definitions.
 
-Here is a flowchart explaining specification extensions:
+Here is a diagram explaining specification extensions:
 
 ```mermaid
 flowchart TD
@@ -53,9 +53,11 @@ In the above document, under the `user/signedup` channel, a custom property `x-c
 All available tooling might not support AsyncAPI extensions. The tooling can be extended to understand and handle the added data, especially if the tools are internal or open source.
 </Remember>
 
-## Extending Unsupported Features
+## Extending unsupported features
 
 When facing a case where the AsyncAPI specification does not support the required feature, that functionality can be extended using these extensions. If the extended part also benefits other developers, you could contribute to the AsyncAPI specification. This contribution can be made by [creating an issue](https://github.com/asyncapi/website/issues/new?assignees=alequetzalli+-&labels=%F0%9F%93%91+docs&projects=&template=docs.yml&title=%5B%F0%9F%93%91+Docs%5D%3A+) on the AsyncAPI GitHub repository.
+
+Here is a diagram showing details about extending extending unsupported features:
 
 ```mermaid
   graph TD
@@ -73,9 +75,13 @@ When facing a case where the AsyncAPI specification does not support the require
   C -->|No| E
 ```
 
-## Using the AsyncAPI Studio
+This diagram represents the process of extending AsyncAPI specifications when unsupported features are encountered, with an option to contribute to the specification if it benefits others.
+
+## Using the AsyncAPI studio
 
 When extending the AsyncAPI specification, you can use the[AsyncAPI Studio](https://studio.asyncapi.com/), a recommended dedicated editor for AsyncAPI specifications. The AsyncAPI Studio allows you to create, edit, and visualize specification files. It also performs validation checks to ensure the specifications are correct and renders them in a user-friendly manner.
+
+Here is a diagram showing when to use AsyncAPI studio:
 
 ```mermaid
 graph TD

--- a/pages/docs/concepts/asyncapi-document/extending-specification.md
+++ b/pages/docs/concepts/asyncapi-document/extending-specification.md
@@ -5,8 +5,6 @@ weight: 240
 
 Extending the AsyncAPI specification is a technique that allows developers to include domain-specific or use-case-specific information not supported by the base specification. This extension capability provides customization, enabling APIs to accommodate unique details that would not otherwise fit within the confines of the standard AsyncAPI specification.
 
-The benefits of extending the AsyncAPI specification include enhanced specificity — delivering a clear encoding of necessary API details to applications, and consistency — allowing reusable components across the API. However, extensions should be used sparingly. Since they go beyond the Specification, they may not be universally understood.
-
 ## Specification extensions
 
 The AsyncAPI Specification allows the addition of custom properties through patterned fields prefixed with `x-`. This helps you create unique things without causing problems with future updates.
@@ -43,8 +41,7 @@ channels:
     messages:
       userSignedUp:
         description: An event describing that a user just signed up.
-        $ref: '#/components/messages/UserSignedUp'
-      x-custom-property: Custom Value        
+        x-custom-property: Custom Value    
 ```
 
 In the above document, under the `user/signedup` channel, a custom property `x-custom-property` is added. The value assigned to this property is `Custom Value`.
@@ -55,7 +52,7 @@ All available tooling might not support AsyncAPI extensions. The tooling can be 
 
 ## Extending unsupported features
 
-When facing a case where the AsyncAPI specification does not support the required feature, that functionality can be extended using these extensions. If the extended part also benefits other developers, you could contribute to the AsyncAPI specification. This contribution can be made by [creating an issue](https://github.com/asyncapi/website/issues/new?assignees=alequetzalli+-&labels=%F0%9F%93%91+docs&projects=&template=docs.yml&title=%5B%F0%9F%93%91+Docs%5D%3A+) on the AsyncAPI GitHub repository.
+When facing a case where the AsyncAPI specification does not support the required feature, that functionality can be extended using these extensions. If the extended part also benefits other developers, you could contribute to the AsyncAPI specification. This contribution can be made by [creating an issue](https://github.com/asyncapi/spec) on the AsyncAPI GitHub repository. Please get familiar with [contribution guide](https://github.com/asyncapi/spec/blob/master/CONTRIBUTING.md) before making an contribution.
 
 Here is a diagram showing details about extending extending unsupported features:
 
@@ -65,32 +62,12 @@ Here is a diagram showing details about extending extending unsupported features
   B[Extend using Extensions]
   C[Beneficial to Others?]
   D[Contribute to Specification]
-  E[Create an issue on GitHub]
 
   style A fill:#47BCEE,stroke:#47BCEE;
 
   A --> B
   B --> C
   C -->|Yes| D
-  C -->|No| E
 ```
 
 This diagram represents the process of extending AsyncAPI specifications when unsupported features are encountered, with an option to contribute to the specification if it benefits others.
-
-## Using the AsyncAPI studio
-
-When extending the AsyncAPI specification, you can use the[AsyncAPI Studio](https://studio.asyncapi.com/), a recommended dedicated editor for AsyncAPI specifications. The AsyncAPI Studio allows you to create, edit, and visualize specification files. It also performs validation checks to ensure the specifications are correct and renders them in a user-friendly manner.
-
-Here is a diagram showing when to use AsyncAPI studio:
-
-```mermaid
-graph TD
-    A[Extend AsyncAPI Specification] --> B[Use AsyncAPI Studio]
-    B --> C[Create, Edit, Visualize]
-    B --> D[Perform Validation Checks]
-    B --> E[Renders User-Friendly Output]
-
-    style B fill:#47BCEE,stroke:#47BCEE;
-```
-
- The diagram shows the process of extending the AsyncAPI specification using the recommended AsyncAPI Studio editor.

--- a/pages/docs/concepts/asyncapi-document/extending-specification.md
+++ b/pages/docs/concepts/asyncapi-document/extending-specification.md
@@ -3,55 +3,67 @@ title: Extending Specification
 weight: 220
 ---
 
-AsyncAPI allows developers to describe their event-driven APIs in a machine-readable way. If there is a instance where the AsyncAPI specification does not support a specific field or a use case is needed, the specification can be extended.
+Extending the AsyncAPI specification is a technique that allows developers to include domain-specific or use-case-specific information not supported by the base specification. This extension capability provides customization, enabling APIs to accommodate unique details that would not otherwise fit within the confines of the standard AsyncAPI specification.
+
+The benefits of extending the AsyncAPI specification include enhanced specificity — delivering a clear encoding of necessary API details to clients, and consistency — allowing reusable components across the API. However, extensions should be used sparingly. Since they go beyond the Specification, they may not be universally understood.
 
 ## AsyncAPI Specification Extensions
 
-The specification allows the addition of custom properties through patterned fields prefixed with `x-`. This feature enables accommodating specific functionalities, which are not initially covered in the AsyncAPI specification.
+The AsyncAPI Specification allows the addition of custom properties through patterned fields prefixed with `x-`. This feature enables the accommodation of specific functionalities not initially included in the AsyncAPI specification.
+
+The `x-` prefix is used to define custom properties. These properties are user-defined and won't conflict with future specification versions because any property starting with `x-` is reserved for user definitions, and the AsyncAPI organization will not use this prefix for any of their future standard properties.
 
 ```mermaid
-graph TD
-A[AsyncAPI Specification]
-B[Custom Properties]
-C[Patterned Fields]
-D[Functionality Extension]
-
-A -->|allows developers to describe event-driven APIs| B
-B -->|through| C
-C -->|patterned fields prefixed with `x-`| D
+flowchart TB
+    subgraph "AsyncAPI Specification"
+        A[Specification] --> B[Custom Properties]
+    end
+    subgraph "Custom Properties"
+        B --> C[Patterned fields prefixed with x-]
+        B --> D[Reserved for user definitions]
+        B --> E[Support any valid JSON format value]
+    end
+    subgraph "Usage"
+        C --> F[Accommodate specific functionalities]
+        D --> G[Avoid conflict with future versions]
+        E --> H[May or may not be supported by tools]
+    end
+    subgraph "Tooling"
+        H --> I[Internal tools]
+        H --> J[Open-sourced tools]
+        I --> K[Extended support may be added]
+        J --> L[Extended support may be added]
+    end
 ```
 
 Here is a simple example of how to extend the AsyncAPI specification:
 
 ```yml
+asyncapi: 3.0.0
+info:
+  title: Cool Example
+  version: 0.1.0
 channels:
-  user/signedup:
-    subscribe:
-      message:
+  userSignedUp:
+    address: user/signedup
+    messages:
+      userSignedUp:
+        description: An event describing that a user just signed up.
         $ref: '#/components/messages/UserSignedUp'
-      x-custom-property: Custom Value
+      x-custom-property: Custom Value        
 ```
 
-In the above example, under the `user/signedup` channel, a custom property `x-custom-property` is added to the subscribe operation. The value assigned to this property is `Custom Value`.
+In the above example, under the `user/signedup` channel, a custom property `x-custom-property` is added. The value assigned to this property is `Custom Value`.
 
-The newly added custom property is compatible with the extended tooling and can supplement it with additional functionalities.
+The custom properties can have any valid JSON format value. For example, it could be null, a primitive, an array, or an object. The newly added custom property is compatible with the extended tooling and can supplement it with additional functionalities.
 
 <Remember>
-AsyncAPI extensions might not be supported by all available tooling. To counter this, the tooling can be extended to understand and handle the added data, especially if the tools are internal or open source.
+All available tooling might not support AsyncAPI extensions. The tooling can be extended to understand and handle the added data, especially if the tools are internal or open source.
 </Remember>
-
-## Versioning and Extensions
-
-AsyncAPI specification and its extensions are versioned. This means that it is necessary to specify the AsyncAPI version your document complies with. The format for this string should be `major.minor.patch`.
-
-```mermaid
-graph LR
-    A[AsyncAPI Specification] -- version --> B[Major.Minor.Patch]
-```
 
 ## Extending Unsupported Features
 
-When encountering a case where the AsyncAPI specification does not support the feature which is required, that functionality can be extended using these extensions. If the extended feature proves beneficial to other developers as well, contributing to the AsyncAPI specification can be an advisable step. This contribution can be done by creating an issue on the AsyncAPI GitHub repository.
+When encountering a case where the AsyncAPI specification does not support the required feature, that functionality can be extended using these extensions. If the extended part also benefits other developers, contributing to the AsyncAPI specification can be advisable. This contribution can be made by [creating an issue](https://github.com/asyncapi/website/issues/new?assignees=alequetzalli+-&labels=%F0%9F%93%91+docs&projects=&template=docs.yml&title=%5B%F0%9F%93%91+Docs%5D%3A+) on the AsyncAPI GitHub repository.
 
 ```mermaid
 graph TD
@@ -69,17 +81,23 @@ C -->|No| E
 
 ## Extending Specification Tools
 
-When extending the AsyncAPI specification, the use of the [AsyncAPI Playground](https://studio.asyncapi.com/) is recommended. This dedicated editor for AsyncAPI specifications presents specification file in a legible way. Simultaneously, it performs validation checks and renders the specifications as you continue your work on it.
+When extending the AsyncAPI specification, the [AsyncAPI Studio](https://studio.asyncapi.com/) is recommended. This dedicated editor for AsyncAPI specifications legibly presents specification files. Simultaneously, it performs validation checks and renders the specifications as you continue your work.
 
 ```mermaid
 sequenceDiagram
     participant User
-    participant AsyncAPI_Playground
+    participant AsyncAPI_Studio
 
-    User -> AsyncAPI_Playground: Open AsyncAPI Playground
-    User -> AsyncAPI_Playground: Add/Edit AsyncAPI Spec
-    AsyncAPI_Playground -> AsyncAPI_Playground: Perform Validation Checks
-    AsyncAPI_Playground -> AsyncAPI_Playground: Render Specifications
+    User -> AsyncAPI_Studio: Open AsyncAPI Studio
+    User -> AsyncAPI_Studio: Add/Edit AsyncAPI Spec
+    AsyncAPI_Studio -> AsyncAPI_Studio: Perform Validation Checks
+    AsyncAPI_Studio -> AsyncAPI_Studio: Render Specifications
 ```
 
-Extending the AsyncAPI specification when it doesn't support something which is needed involves using patterned fields prefixed with `x-`, specifying the version of AsyncAPI the extensions comply with, and using the AsyncAPI Playground for easy visualization and validation of the specifications. Contributions to support the community can also be made by issuing the extension on the AsyncAPI GitHub repository.
+Extending the AsyncAPI specification when it doesn't support something which is needed involves:
+
+* Using patterned fields prefixed with `x-`.
+* Specifying the version of AsyncAPI the extensions comply with.
+* Using the AsyncAPI Studio for easy visualization and validation of the specifications.
+  
+Contributions can be made to support the community by issuing the extension on the AsyncAPI GitHub repository.

--- a/pages/docs/concepts/asyncapi-document/extending-specification.md
+++ b/pages/docs/concepts/asyncapi-document/extending-specification.md
@@ -1,6 +1,6 @@
 ---
 title: Extending Specification
-weight: 220
+weight: 240
 ---
 
 Extending the AsyncAPI specification is a technique that allows developers to include domain-specific or use-case-specific information not supported by the base specification. This extension capability provides customization, enabling APIs to accommodate unique details that would not otherwise fit within the confines of the standard AsyncAPI specification.
@@ -18,7 +18,8 @@ flowchart TD
     subgraph "AsyncAPI Specification"
         A[Specification] --> B[Custom Properties]
     end
-    subgraph "Custom Properties"
+    style B fill:#47BCEE,stroke:#47BCEE;
+    subgraph "Custom Properties" 
         B --> C[Patterned fields prefixed with x-]
         C --> D[User-defined properties]
         C --> E[Reserved for user definitions]
@@ -54,17 +55,19 @@ All available tooling might not support AsyncAPI extensions. The tooling can be 
 When encountering a case where the AsyncAPI specification does not support the required feature, that functionality can be extended using these extensions. If the extended part also benefits other developers, contributing to the AsyncAPI specification can be advisable. This contribution can be made by [creating an issue](https://github.com/asyncapi/website/issues/new?assignees=alequetzalli+-&labels=%F0%9F%93%91+docs&projects=&template=docs.yml&title=%5B%F0%9F%93%91+Docs%5D%3A+) on the AsyncAPI GitHub repository.
 
 ```mermaid
-graph TD
-A[Encounter Unsupported Feature]
-B[Extend using Extensions]
-C[Beneficial to Others?]
-D[Contribute to Specification]
-E[Create an issue on GitHub]
+  graph TD
+  A[Encounter Unsupported Feature]
+  B[Extend using Extensions]
+  C[Beneficial to Others?]
+  D[Contribute to Specification]
+  E[Create an issue on GitHub]
 
-A --> B
-B --> C
-C -->|Yes| D
-C -->|No| E
+  style A fill:#47BCEE,stroke:#47BCEE;
+
+  A --> B
+  B --> C
+  C -->|Yes| D
+  C -->|No| E
 ```
 
 ## Using the AsyncAPI Studio

--- a/pages/docs/concepts/asyncapi-document/extending-specification.md
+++ b/pages/docs/concepts/asyncapi-document/extending-specification.md
@@ -7,11 +7,13 @@ Extending the AsyncAPI specification is a technique that allows developers to in
 
 The benefits of extending the AsyncAPI specification include enhanced specificity — delivering a clear encoding of necessary API details to applications, and consistency — allowing reusable components across the API. However, extensions should be used sparingly. Since they go beyond the Specification, they may not be universally understood.
 
-## AsyncAPI Specification Extensions
+## Specification Extensions
 
-The AsyncAPI Specification allows the addition of custom properties through patterned fields prefixed with `x-`. This feature enables the accommodation of specific functionalities not initially included in the AsyncAPI specification.
+The AsyncAPI Specification allows the addition of custom properties through patterned fields prefixed with `x-`. This helps you create unique things without causing problems with future updates.
 
-The `x-` prefix is used to define custom properties. These properties are user-defined and won't conflict with future specification versions because any property starting with `x-` is reserved for user definitions, and the AsyncAPI organization will not use this prefix for any of their future standard properties.
+The `x-` prefix is used to define custom properties. These properties are user-defined and won't conflict with future specification versions because any property starting with `x-` is reserved for user definitions.
+
+Here is a flowchart explaining specification extensions:
 
 ```mermaid
 flowchart TD
@@ -23,9 +25,10 @@ flowchart TD
         B --> C[Patterned fields prefixed with x-]
         C --> D[User-defined properties]
         C --> E[Reserved for user definitions]
-        E --> F[Avoid conflict with future versions]
     end
 ```
+
+The above diagram explains how AsyncAPI specification uses `x-` prefixed fields for custom properties.
 
 Here is a simple example of how to extend the AsyncAPI specification:
 
@@ -44,7 +47,7 @@ channels:
       x-custom-property: Custom Value        
 ```
 
-In the above example, under the `user/signedup` channel, a custom property `x-custom-property` is added. The value assigned to this property is `Custom Value`.
+In the above document, under the `user/signedup` channel, a custom property `x-custom-property` is added. The value assigned to this property is `Custom Value`.
 
 <Remember>
 All available tooling might not support AsyncAPI extensions. The tooling can be extended to understand and handle the added data, especially if the tools are internal or open source.
@@ -52,7 +55,7 @@ All available tooling might not support AsyncAPI extensions. The tooling can be 
 
 ## Extending Unsupported Features
 
-When encountering a case where the AsyncAPI specification does not support the required feature, that functionality can be extended using these extensions. If the extended part also benefits other developers, contributing to the AsyncAPI specification can be advisable. This contribution can be made by [creating an issue](https://github.com/asyncapi/website/issues/new?assignees=alequetzalli+-&labels=%F0%9F%93%91+docs&projects=&template=docs.yml&title=%5B%F0%9F%93%91+Docs%5D%3A+) on the AsyncAPI GitHub repository.
+When facing a case where the AsyncAPI specification does not support the required feature, that functionality can be extended using these extensions. If the extended part also benefits other developers, you could contribute to the AsyncAPI specification. This contribution can be made by [creating an issue](https://github.com/asyncapi/website/issues/new?assignees=alequetzalli+-&labels=%F0%9F%93%91+docs&projects=&template=docs.yml&title=%5B%F0%9F%93%91+Docs%5D%3A+) on the AsyncAPI GitHub repository.
 
 ```mermaid
   graph TD
@@ -75,20 +78,13 @@ When encountering a case where the AsyncAPI specification does not support the r
 When extending the AsyncAPI specification, you can use the[AsyncAPI Studio](https://studio.asyncapi.com/), a recommended dedicated editor for AsyncAPI specifications. The AsyncAPI Studio allows you to create, edit, and visualize specification files. It also performs validation checks to ensure the specifications are correct and renders them in a user-friendly manner.
 
 ```mermaid
-sequenceDiagram
-    participant User
-    participant AsyncAPI_Studio
+graph TD
+    A[Extend AsyncAPI Specification] --> B[Use AsyncAPI Studio]
+    B --> C[Create, Edit, Visualize]
+    B --> D[Perform Validation Checks]
+    B --> E[Renders User-Friendly Output]
 
-    User -> AsyncAPI_Studio: Open AsyncAPI Studio
-    User -> AsyncAPI_Studio: Add/Edit AsyncAPI Spec
-    AsyncAPI_Studio -> AsyncAPI_Studio: Perform Validation Checks
-    AsyncAPI_Studio -> AsyncAPI_Studio: Render Specifications
+    style B fill:#47BCEE,stroke:#47BCEE;
 ```
 
-Extending the AsyncAPI specification when it doesn't support something which is needed involves:
-
-* Using patterned fields prefixed with `x-`.
-* Specifying the version of AsyncAPI the extensions comply with.
-* Using the AsyncAPI Studio for easy visualization and validation of the specifications.
-  
-Contributions can be made to support the community by issuing the extension on the AsyncAPI GitHub repository.
+ The diagram shows the process of extending the AsyncAPI specification using the recommended AsyncAPI Studio editor.

--- a/pages/docs/concepts/asyncapi-document/extending-specification.md
+++ b/pages/docs/concepts/asyncapi-document/extending-specification.md
@@ -1,0 +1,43 @@
+---
+title: Extending Specification
+weight: 220
+---
+
+AsyncAPI allows developers to describe their event-driven APIs in a machine-readable way. If there is a instance where the AsyncAPI specification does not support a specific field or a use case is needed, the specification can be extended.
+
+## AsyncAPI Specification Extensions
+
+The specification allows the addition of custom properties through patterned fields prefixed with `x-`. This feature enables accommodating specific functionalities, which are not initially covered in the AsyncAPI specification.
+
+Here is a simple example of how to extend the AsyncAPI specification:
+
+```yml
+channels:
+  user/signedup:
+    subscribe:
+      message:
+        $ref: '#/components/messages/UserSignedUp'
+      x-custom-property: Custom Value
+```
+
+In the above example, under the `user/signedup` channel, a custom property `x-custom-property` is added to the subscribe operation. The value assigned to this property is `Custom Value`.
+
+The newly added custom property is compatible with the extended tooling and can supplement it with additional functionalities.
+
+<Remember>
+AsyncAPI extensions might not be supported by all available tooling. To counter this, the tooling can be extended to understand and handle the added data, especially if the tools are internal or open source.
+</Remember>
+
+## Versioning and Extensions
+
+AsyncAPI specification and its extensions are versioned. This means that it is necessary to specify the AsyncAPI version your document complies with. The format for this string should be `major.minor.patch`.
+
+## Extending Unsupported Features
+
+When encountering a case where the AsyncAPI specification does not support the feature which is required, that functionality can be extended using these extensions. If the extended feature proves beneficial to other developers as well, contributing to the AsyncAPI specification can be an advisable step. This contribution can be done by creating an issue on the AsyncAPI GitHub repository.
+
+## Extending Specification Tools
+
+When extending the AsyncAPI specification, the use of the [AsyncAPI Playground](https://studio.asyncapi.com/) is recommended. This dedicated editor for AsyncAPI specifications presents specification file in a legible way. Simultaneously, it performs validation checks and renders the specifications as you continue your work on it.
+
+Extending the AsyncAPI specification when it doesn't support something which is needed involves using patterned fields prefixed with `x-`, specifying the version of AsyncAPI the extensions comply with, and using the AsyncAPI Playground for easy visualization and validation of the specifications. Contributions to support the community can also be made by issuing the extension on the AsyncAPI GitHub repository.

--- a/pages/docs/concepts/asyncapi-document/extending-specification.md
+++ b/pages/docs/concepts/asyncapi-document/extending-specification.md
@@ -9,6 +9,18 @@ AsyncAPI allows developers to describe their event-driven APIs in a machine-read
 
 The specification allows the addition of custom properties through patterned fields prefixed with `x-`. This feature enables accommodating specific functionalities, which are not initially covered in the AsyncAPI specification.
 
+```mermaid
+graph TD
+A[AsyncAPI Specification]
+B[Custom Properties]
+C[Patterned Fields]
+D[Functionality Extension]
+
+A -->|allows developers to describe event-driven APIs| B
+B -->|through| C
+C -->|patterned fields prefixed with `x-`| D
+```
+
 Here is a simple example of how to extend the AsyncAPI specification:
 
 ```yml
@@ -32,12 +44,42 @@ AsyncAPI extensions might not be supported by all available tooling. To counter 
 
 AsyncAPI specification and its extensions are versioned. This means that it is necessary to specify the AsyncAPI version your document complies with. The format for this string should be `major.minor.patch`.
 
+```mermaid
+graph LR
+    A[AsyncAPI Specification] -- version --> B[Major.Minor.Patch]
+```
+
 ## Extending Unsupported Features
 
 When encountering a case where the AsyncAPI specification does not support the feature which is required, that functionality can be extended using these extensions. If the extended feature proves beneficial to other developers as well, contributing to the AsyncAPI specification can be an advisable step. This contribution can be done by creating an issue on the AsyncAPI GitHub repository.
 
+```mermaid
+graph TD
+A[Encounter Unsupported Feature]
+B[Extend using Extensions]
+C[Beneficial to Others?]
+D[Contribute to Specification]
+E[Create an issue on GitHub]
+
+A --> B
+B --> C
+C -->|Yes| D
+C -->|No| E
+```
+
 ## Extending Specification Tools
 
 When extending the AsyncAPI specification, the use of the [AsyncAPI Playground](https://studio.asyncapi.com/) is recommended. This dedicated editor for AsyncAPI specifications presents specification file in a legible way. Simultaneously, it performs validation checks and renders the specifications as you continue your work on it.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant AsyncAPI_Playground
+
+    User -> AsyncAPI_Playground: Open AsyncAPI Playground
+    User -> AsyncAPI_Playground: Add/Edit AsyncAPI Spec
+    AsyncAPI_Playground -> AsyncAPI_Playground: Perform Validation Checks
+    AsyncAPI_Playground -> AsyncAPI_Playground: Render Specifications
+```
 
 Extending the AsyncAPI specification when it doesn't support something which is needed involves using patterned fields prefixed with `x-`, specifying the version of AsyncAPI the extensions comply with, and using the AsyncAPI Playground for easy visualization and validation of the specifications. Contributions to support the community can also be made by issuing the extension on the AsyncAPI GitHub repository.

--- a/pages/docs/concepts/asyncapi-document/extending-specification.md
+++ b/pages/docs/concepts/asyncapi-document/extending-specification.md
@@ -5,7 +5,7 @@ weight: 220
 
 Extending the AsyncAPI specification is a technique that allows developers to include domain-specific or use-case-specific information not supported by the base specification. This extension capability provides customization, enabling APIs to accommodate unique details that would not otherwise fit within the confines of the standard AsyncAPI specification.
 
-The benefits of extending the AsyncAPI specification include enhanced specificity — delivering a clear encoding of necessary API details to clients, and consistency — allowing reusable components across the API. However, extensions should be used sparingly. Since they go beyond the Specification, they may not be universally understood.
+The benefits of extending the AsyncAPI specification include enhanced specificity — delivering a clear encoding of necessary API details to applications, and consistency — allowing reusable components across the API. However, extensions should be used sparingly. Since they go beyond the Specification, they may not be universally understood.
 
 ## AsyncAPI Specification Extensions
 
@@ -14,25 +14,15 @@ The AsyncAPI Specification allows the addition of custom properties through patt
 The `x-` prefix is used to define custom properties. These properties are user-defined and won't conflict with future specification versions because any property starting with `x-` is reserved for user definitions, and the AsyncAPI organization will not use this prefix for any of their future standard properties.
 
 ```mermaid
-flowchart TB
+flowchart TD
     subgraph "AsyncAPI Specification"
         A[Specification] --> B[Custom Properties]
     end
     subgraph "Custom Properties"
         B --> C[Patterned fields prefixed with x-]
-        B --> D[Reserved for user definitions]
-        B --> E[Support any valid JSON format value]
-    end
-    subgraph "Usage"
-        C --> F[Accommodate specific functionalities]
-        D --> G[Avoid conflict with future versions]
-        E --> H[May or may not be supported by tools]
-    end
-    subgraph "Tooling"
-        H --> I[Internal tools]
-        H --> J[Open-sourced tools]
-        I --> K[Extended support may be added]
-        J --> L[Extended support may be added]
+        C --> D[User-defined properties]
+        C --> E[Reserved for user definitions]
+        E --> F[Avoid conflict with future versions]
     end
 ```
 
@@ -54,8 +44,6 @@ channels:
 ```
 
 In the above example, under the `user/signedup` channel, a custom property `x-custom-property` is added. The value assigned to this property is `Custom Value`.
-
-The custom properties can have any valid JSON format value. For example, it could be null, a primitive, an array, or an object. The newly added custom property is compatible with the extended tooling and can supplement it with additional functionalities.
 
 <Remember>
 All available tooling might not support AsyncAPI extensions. The tooling can be extended to understand and handle the added data, especially if the tools are internal or open source.
@@ -79,9 +67,9 @@ C -->|Yes| D
 C -->|No| E
 ```
 
-## Extending Specification Tools
+## Using the AsyncAPI Studio
 
-When extending the AsyncAPI specification, the [AsyncAPI Studio](https://studio.asyncapi.com/) is recommended. This dedicated editor for AsyncAPI specifications legibly presents specification files. Simultaneously, it performs validation checks and renders the specifications as you continue your work.
+When extending the AsyncAPI specification, you can use the[AsyncAPI Studio](https://studio.asyncapi.com/), a recommended dedicated editor for AsyncAPI specifications. The AsyncAPI Studio allows you to create, edit, and visualize specification files. It also performs validation checks to ensure the specifications are correct and renders them in a user-friendly manner.
 
 ```mermaid
 sequenceDiagram


### PR DESCRIPTION
**Description**
 Added **Extending Specification** page.

It is a part of GSoD'23 project.


**Related issue(s):** 
fixes #1519 