### PR TITLE
feat: disable Netlify caching for schemas serving + rely in GH caching

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -23,7 +23,6 @@
 [[edge_functions]]
 function = "serve-definitions"
 path = "/definitions/*"
-cache = "manual"
 
 # Used by JSON Schema definitions fetched from schemastore.org
 [[redirects]]
@@ -34,7 +33,6 @@ cache = "manual"
 [[edge_functions]]
 function = "serve-definitions"
 path = "/schema-store/*"
-cache = "manual"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
**Description**

In a [previous PR](https://github.com/asyncapi/website/pull/2020), I enabled Netlify cache for calls made to our `/schema-store` and `/definitions` paths.
It worked ok, the problem is that we can't track metrics of cached results since requests are never reaching the edge-function but rather Netlify's cache layer. In a normal env, this will be exactly the desired behaviour, since it is so performant. However, we need to track requests with a 304 from GH as well, so we rollback the previous changes and now rely directly in GH cache. That will make the request just a bit slower but we will have adoption metrics, which is a WIN.

Metrics will now have a new field called `cached` that will indicate if a 304 was returned by GH.


**Related issue(s)**
https://github.com/asyncapi/website/issues/780#issuecomment-1125358517

cc @derberg 