### PR TITLE
fix: newsroom script workflow

### DIFF
--- a/scripts/build-newsroom-videos.js
+++ b/scripts/build-newsroom-videos.js
@@ -1,7 +1,7 @@
 const { writeFileSync } = require('fs');
 const { resolve } = require('path');
 const fetch = require('node-fetch')
-export async function buildNewsroomVideos() {
+async function buildNewsroomVideos() {
 
     try {
         let data;
@@ -41,3 +41,4 @@ export async function buildNewsroomVideos() {
 }
 
 buildNewsroomVideos()
+module.exports={buildNewsroomVideos}


### PR DESCRIPTION
**Description**
- While writing testcases for `newsroom-scripts` , added "export" keyword to the scripts , which caused the scripts workflow to fail .
- Added additional `{module.exports}` instead of "export" keyword , so that the script and workflow runs , and the test also works /

**Related issue(s)**
fixes #2049 