### PR TITLE
fix: filter section is overflowing for small screen in dashboard section

### DIFF
--- a/components/dashboard/table/Filters.js
+++ b/components/dashboard/table/Filters.js
@@ -63,18 +63,19 @@ export default function Filters({
         className={`cursor-pointer ${className}`}
         data-testid="Filters-img-container"
       />
-        
+
         <div ref={wrapperRef} >
         {open && (
           <div
             ref={floating}
+            className={`${strategy} ${(x && x > 0) ? `left-[${x}px]` : "left-[14px]"}`}
             style={{
               position: strategy,
               top: y ?? '',
-              left: x ?? '',
+              left: x > 0 ? x : "",
             }}
             data-testid="Filter-menu">
-            <div className="bg-white w-96 shadow-xl rounded">
+            <div className="bg-white w-96 shadow-xl rounded max-w-[19rem]">
               <div className="flex p-4">
                 <h4 className="text-base">Filter Issues</h4>
                 <button onClick={() => setOpen(!open)} className="ml-auto">


### PR DESCRIPTION
**Description**
![image](https://github.com/asyncapi/website/assets/129717259/1348bd7c-f006-44dc-9518-72cc9d91942f)

As requested by @sambhavgupta0705, opening a new PR that replicated and verified code change from https://github.com/asyncapi/website/pull/1690 


**Related issue(s)**
Resolve https://github.com/asyncapi/website/issues/1564