### PR TITLE
fix: disable google analytics if domain not `asyncapi.com`

### DIFF
--- a/components/Head.js
+++ b/components/Head.js
@@ -30,7 +30,7 @@ export default function HeadComponent({
   title = title ? `${title} | ${permTitle}` : permTitle;
 
   //enable google analytics
-  if (typeof window !== 'undefined') {
+  if (typeof window !== 'undefined' && window.location.hostname === 'asyncapi.com') {
     TagManager.initialize({gtmId: 'GTM-T58BTVQ'})
     ReactGA.initialize('UA-109278936-1')
     ReactGA.pageview(window.location.pathname + window.location.search)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

-  Disabled google analytics on previews
-  Simple check condition for `asyncapi.com`

**Related issue(s)** Fixes #2156 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->