### PR TITLE
fix: enable google analytics

### DIFF
--- a/components/Head.js
+++ b/components/Head.js
@@ -30,7 +30,7 @@ export default function HeadComponent({
   title = title ? `${title} | ${permTitle}` : permTitle;
 
   //enable google analytics
-  if (typeof window !== 'undefined' && window.location.hostname === 'asyncapi.com') {
+  if (typeof window !== 'undefined' && window.location.hostname.includes('asyncapi.com')) {
     TagManager.initialize({gtmId: 'GTM-T58BTVQ'})
     ReactGA.initialize('UA-109278936-1')
     ReactGA.pageview(window.location.pathname + window.location.search)


### PR DESCRIPTION
since merge of https://github.com/asyncapi/website/pull/2177 we lost google analytics

reason is that hostname is `www.asyncapi.com`. This is why I changed to use `includes` as in case of any future changes to host name that might take place, we will be safer