### PR TITLE
docs: migrate code generation and message validation tutorials to use Glee

### DIFF
--- a/pages/docs/tutorials/generate-code.md
+++ b/pages/docs/tutorials/generate-code.md
@@ -13,6 +13,15 @@ In this tutorial, you'll learn how to generate an application that uses [Glee](h
 
 Glee is often used with the [AsyncAPI CLI](/tools/cli) for a better development experience.
 
+In the previous tutorial, you created an AsyncAPI document that is used in this tutorial.
+
+<Remember>
+
+If you did not follow the previous tutorial and do not have an `asyncapi.yaml` file for overview, then generate one by running the following command using AsyncAPI CLI: 
+`asyncapi new --example=tutorial.yml --no-tty`.
+
+</Remember>
+
 ## Installation guide
 <Remember>
 

--- a/pages/docs/tutorials/generate-code.md
+++ b/pages/docs/tutorials/generate-code.md
@@ -35,7 +35,7 @@ import CliInstallation from '../../../assets/docs/fragments/cli-installation.md'
     Let's break down the previous command:
     - `asyncapi new glee` is how you use Glee via the AsyncAPI CLI. 
     - `--name=tutorial` is how you tell the AsyncAPI CLI to name your new Glee project. 
-    - `--template=tutorial` is how you tell the AsyncAPI CLI to use the a template of a Glee project that was created especifically for this tutorial. 
+    - `--template=tutorial` is how you tell the AsyncAPI CLI to use the template of a Glee project that was created especifically for this tutorial. 
 
 2. List all files in directory and check that the Glee project is created:
     <CodeBlock language="bash">
@@ -49,13 +49,7 @@ import CliInstallation from '../../../assets/docs/fragments/cli-installation.md'
     README.md
     asyncapi.yaml
     functions
-    package-lock.json
     package.json`}
-    </CodeBlock>
-
-3. Create the necessary functions:
-    <CodeBlock language="bash">
-    {`touch functions/onLightMeasured.js`}
     </CodeBlock>
 
 ## Start generated application

--- a/pages/docs/tutorials/generate-code.md
+++ b/pages/docs/tutorials/generate-code.md
@@ -6,7 +6,7 @@ weight: 100
 
 ## Introduction
 
-In this tutorial, you'll learn how to generate code from your AsyncAPI document using [Glee](https://github.com/asyncapi/glee).
+In this tutorial, you'll learn how to generate an application that uses [Glee](https://github.com/asyncapi/glee) framework. You'll do it with AsyncAPI document and [AsyncAPI CLI](/tools/cli).
 
 ## Background context
 [Glee](https://github.com/asyncapi/glee) is a TS/JS framework that enables you to create APIs and messaging clients based on the AsyncAPI document. Instead of generating code, this framework tightly integrates with your AsyncAPI document and binds functions to specific

--- a/pages/docs/tutorials/generate-code.md
+++ b/pages/docs/tutorials/generate-code.md
@@ -9,8 +9,7 @@ weight: 100
 In this tutorial, you'll learn how to generate an application that uses [Glee](https://github.com/asyncapi/glee) framework. You'll do it with AsyncAPI document and [AsyncAPI CLI](/tools/cli).
 
 ## Background context
-[Glee](https://github.com/asyncapi/glee) is a TS/JS framework that enables you to create APIs and messaging clients based on the AsyncAPI document. Instead of generating code, this framework tightly integrates with your AsyncAPI document and binds functions to specific
-AsyncAPI operations. You only have to provide the code for these functions and Glee will take care of the rest.
+[Glee](https://github.com/asyncapi/glee) is a TS/JS framework that enables you to create APIs and messaging clients based on the AsyncAPI document. Instead of generating code, this framework tightly integrates with your AsyncAPI document and binds functions to specific AsyncAPI operations. You only have to provide the code for these functions and Glee will take care of the rest.
 
 Glee is often used with the [AsyncAPI CLI](/tools/cli) for a better development experience.
 

--- a/pages/docs/tutorials/generate-code.md
+++ b/pages/docs/tutorials/generate-code.md
@@ -29,12 +29,13 @@ import CliInstallation from '../../../assets/docs/fragments/cli-installation.md'
 
 1. Trigger the creation of the Glee project:
     <CodeBlock language="bash">
-    {`asyncapi new glee --name=tutorial`}
+    {`asyncapi new glee --name=tutorial --template tutorial`}
     </CodeBlock>
 
     Let's break down the previous command:
     - `asyncapi new glee` is how you use Glee via the AsyncAPI CLI. 
     - `--name=tutorial` is how you tell the AsyncAPI CLI to name your new Glee project. 
+    - `--template=tutorial` is how you tell the AsyncAPI CLI to use the a template of a Glee project that was created especifically for this tutorial. 
 
 2. List all files in directory and check that the Glee project is created:
     <CodeBlock language="bash">
@@ -52,19 +53,10 @@ import CliInstallation from '../../../assets/docs/fragments/cli-installation.md'
     package.json`}
     </CodeBlock>
 
-    By default, Glee provides a sample `asyncapi.yaml` file. If you want to use the [AsyncAPI document created in the previous tutorial](https://asyncapi.com/docs/tutorials/create-asyncapi-document), either replace the file if you have it somewhere else or generate a new one by running `rm asyncapi.yaml && asyncapi new --example=tutorial.yml --no-tty`.
-
 3. Create the necessary functions:
     <CodeBlock language="bash">
     {`touch functions/onLightMeasured.js`}
     </CodeBlock>
-
-    <Remember>
-
-    If you look at the content of the `functions` folder, you should also see another file named `onHello.js`. You can safely delete it
-    by running `rm functions/onHello.js`. 
-
-    </Remember>
 
 ## Start generated application
 1. Install dependencies of the newly generated application:
@@ -90,7 +82,7 @@ import CliInstallation from '../../../assets/docs/fragments/cli-installation.md'
 
 3. Go back to the previous terminal to check if your application logged the streetlight condition you just sent. You should see something like this displayed in the terminal:
     <CodeBlock language="bash">
-    {`light/measured was received:
+    {`lightMeasured was received from mosquitto:
     { id: 1, lumens: 3, sentAt: '2017-06-07T12:34:32.000Z' }`}
     </CodeBlock>
 ## Summary

--- a/pages/docs/tutorials/generate-code.md
+++ b/pages/docs/tutorials/generate-code.md
@@ -6,10 +6,10 @@ weight: 100
 
 ## Introduction
 
-In this tutorial, you'll learn how to generate an application that uses [Glee](https://github.com/asyncapi/glee) framework. You'll do it with AsyncAPI document and [AsyncAPI CLI](/tools/cli).
+In this tutorial, you'll learn how to generate an application that uses the [Glee](https://github.com/asyncapi/glee) framework. You'll do it with an AsyncAPI document and the [AsyncAPI CLI](/tools/cli).
 
 ## Background context
-[Glee](https://github.com/asyncapi/glee) is a TS/JS framework that enables you to create APIs and messaging clients based on the AsyncAPI document. Instead of generating code, this framework tightly integrates with your AsyncAPI document and binds functions to specific AsyncAPI operations. You only have to provide the code for these functions and Glee will take care of the rest.
+[Glee](https://github.com/asyncapi/glee) is a TypeScript/JavaScript framework that enables you to create APIs and messaging clients based on your AsyncAPI document. Instead of generating code, this framework tightly integrates with your AsyncAPI document and binds functions to specific AsyncAPI operations. You only have to provide the code for these functions and Glee handles the rest.
 
 Glee is often used with the [AsyncAPI CLI](/tools/cli) for a better development experience.
 
@@ -17,7 +17,7 @@ In the previous tutorial, you created an AsyncAPI document that is used in this 
 
 <Remember>
 
-If you did not follow the previous tutorial and do not have an `asyncapi.yaml` file for overview, then generate one by running the following command using AsyncAPI CLI: 
+If you did not follow the previous tutorial and do not have an `asyncapi.yaml` file for overview, then generate one by running the following command using the AsyncAPI CLI: 
 `asyncapi new --example=tutorial.yml --no-tty`.
 
 </Remember>
@@ -43,9 +43,9 @@ import CliInstallation from '../../../assets/docs/fragments/cli-installation.md'
     Let's break down the previous command:
     - `asyncapi new glee` is how you use Glee via the AsyncAPI CLI. 
     - `--name=tutorial` is how you tell the AsyncAPI CLI to name your new Glee project. 
-    - `--template=tutorial` is how you tell the AsyncAPI CLI to use the template of a Glee project that was created especifically for this tutorial. 
+    - `--template=tutorial` is how you tell the AsyncAPI CLI to use the template of a Glee project that was created specifically for this tutorial. 
 
-2. List all files in directory and check that the Glee project is created:
+2. List all files in the directory and confirm your Glee project creation:
     <CodeBlock language="bash">
     {`cd tutorial && ls`}
     </CodeBlock>

--- a/pages/docs/tutorials/generate-code.md
+++ b/pages/docs/tutorials/generate-code.md
@@ -77,7 +77,8 @@ import CliInstallation from '../../../assets/docs/fragments/cli-installation.md'
 3. Go back to the previous terminal to check if your application logged the streetlight condition you just sent. You should see something like this displayed in the terminal:
     <CodeBlock language="bash">
     {`lightMeasured was received from mosquitto:
-    { id: 1, lumens: 3, sentAt: '2017-06-07T12:34:32.000Z' }`}
+    { id: 1, lumens: 3, sentAt: '2017-06-07T12:34:32.000Z' }
+    Streetlight with id "1" updated its lighting information to 3 lumens at 2017-06-07T12:34:32.000Z.`}
     </CodeBlock>
 ## Summary
 In this tutorial, you learned how to create a Glee project from the [Streetlights API specification document created in a previous tutorial](https://asyncapi.com/docs/tutorials/create-asyncapi-document). 

--- a/pages/docs/tutorials/generate-code.md
+++ b/pages/docs/tutorials/generate-code.md
@@ -6,12 +6,13 @@ weight: 100
 
 ## Introduction
 
-In this tutorial, you'll learn how to generate code from your AsyncAPI document using the AsyncAPI generator tool.
+In this tutorial, you'll learn how to generate code from your AsyncAPI document using [Glee](https://github.com/asyncapi/glee).
 
 ## Background context
-The [AsyncAPI Generator](https://github.com/asyncapi/generator) is a tool that you can use to generate whatever you want based on the AsyncAPI document. You can generate docs and code. It can be used as a library in a Node.js application or through the [AsyncAPI CLI](https://github.com/asyncapi/cli).
+[Glee](https://github.com/asyncapi/glee) is a TS/JS framework that enables you to create APIs and messaging clients based on the AsyncAPI document. Instead of generating code, this framework tightly integrates with your AsyncAPI document and binds functions to specific
+AsyncAPI operations. You only have to provide the code for these functions and Glee will take care of the rest.
 
-The generator tool supports a number of templates to generate code for a variety of different languages and protocols as the output. These templates help to specify what exactly must be generated, and in this tutorial, you'll use a [Node.js template](https://github.com/asyncapi/nodejs-template).
+Glee is often used with the [AsyncAPI CLI](/tools/cli) for a better development experience.
 
 ## Installation guide
 <Remember>
@@ -24,44 +25,46 @@ import CliInstallation from '../../../assets/docs/fragments/cli-installation.md'
 
 <CliInstallation/>
 
-## Generate code
+## Create a Glee project
 
-To generate code from the [AsyncAPI document created in a previous tutorial](https://asyncapi.com/docs/tutorials/create-asyncapi-document), follow the steps listed below:
-
-<Remember>
-
-If you did not follow the previous tutorial and do not have an `asyncapi.yaml` file ready, generate one running `asyncapi new --example=tutorial.yml --no-tty`.
-
-</Remember>
-
-1. Trigger generation of the Node.js code:
+1. Trigger the creation of the Glee project:
     <CodeBlock language="bash">
-    {`asyncapi generate fromTemplate asyncapi.yaml @asyncapi/nodejs-template -o output -p server=mosquitto`}
+    {`asyncapi new glee --name=tutorial`}
     </CodeBlock>
 
     Let's break down the previous command:
-    - `asyncapi generate fromTemplate` is how you use AsyncAPI Generator via the AsyncAPI CLI. 
-    - ` asyncapi.yaml` is how you point to your AsyncAPI document and can be a URL. 
-    - `@asyncapi/nodejs-template` is how you specify the Node.js template.
-    - `-o` determines where to output the result.
-    - `-p` defines additional parameters you want to pass to the template. Here, the `server` parameter specifies the server's name as it is defined in AsyncAPI document.
+    - `asyncapi new glee` is how you use Glee via the AsyncAPI CLI. 
+    - `--name=tutorial` is how you tell the AsyncAPI CLI to name your new Glee project. 
 
-2. List all files in directory and check that the Node.js application is generated:
+2. List all files in directory and check that the Glee project is created:
     <CodeBlock language="bash">
-    {`cd output && ls`}
+    {`cd tutorial && ls`}
     </CodeBlock>
 
     Upon execution of the command above, the following is an example of the expected result:
     <CodeBlock language="bash">
     {`$ ls
-    Dockerfile
-    asyncapi.yaml
-    docs
-    src
+    LICENSE
     README.md
-    config
+    asyncapi.yaml
+    functions
+    package-lock.json
     package.json`}
     </CodeBlock>
+
+    By default, Glee provides a sample `asyncapi.yaml` file. If you want to use the [AsyncAPI document created in the previous tutorial](https://asyncapi.com/docs/tutorials/create-asyncapi-document), either replace the file if you have it somewhere else or generate a new one by running `rm asyncapi.yaml && asyncapi new --example=tutorial.yml --no-tty`.
+
+3. Create the necessary functions:
+    <CodeBlock language="bash">
+    {`touch functions/onLightMeasured.js`}
+    </CodeBlock>
+
+    <Remember>
+
+    If you look at the content of the `functions` folder, you should also see another file named `onHello.js`. You can safely delete it
+    by running `rm functions/onHello.js`. 
+
+    </Remember>
 
 ## Start generated application
 1. Install dependencies of the newly generated application:
@@ -71,7 +74,7 @@ If you did not follow the previous tutorial and do not have an `asyncapi.yaml` f
 
 2. Start the application:
     <CodeBlock language="bash">
-    {`npm start`}
+    {`npm run dev`}
     </CodeBlock>
 
 ## Send message to broker
@@ -91,9 +94,9 @@ If you did not follow the previous tutorial and do not have an `asyncapi.yaml` f
     { id: 1, lumens: 3, sentAt: '2017-06-07T12:34:32.000Z' }`}
     </CodeBlock>
 ## Summary
-In this tutorial, you learned how to generate your code from the [Streetlights API specification document created in a previous tutorial](https://asyncapi.com/docs/tutorials/create-asyncapi-document) using the AsyncAPI generator tool. 
+In this tutorial, you learned how to create a Glee project from the [Streetlights API specification document created in a previous tutorial](https://asyncapi.com/docs/tutorials/create-asyncapi-document). 
 
-Additionally, you've learned how to run your code by installing the generated code's dependencies and sending several test messages to the Streelights application using the MQTT client.
+Additionally, you've learned how to run your code by installing the project's dependencies and sending several test messages to the Streelights application using the MQTT client.
 
 ## Next steps
 Now that you've completed this tutorial, go ahead and learn how to [validate your AsyncAPI messages (events)](https://asyncapi.com/docs/tutorials/message-validation) through the message validation techniques supported by AsyncAPI.

--- a/pages/docs/tutorials/message-validation.md
+++ b/pages/docs/tutorials/message-validation.md
@@ -13,20 +13,7 @@ Message validation can be performed at both the **producer** and **consumer** le
 
 You will be using the [Eclipse Mosquitto](https://mosquitto.org/) broker. The MQTT protocol provides a lightweight method of messaging using a publish/subscribe model. You will also use an MQTT client that runs an MQTT library and connects to an MQTT broker over a network. Here publishers and subscribers are MQTT clients. The publisher and subscriber labels refer to whether the client is publishing or subscribing to receive messages.
 
-In the previous tutorial, you generated your application using the [AsyncAPI Generator](https://github.com/asyncapi/generator) Node.js template.
-<Remember>
-
-If you did not follow the previous tutorial and do not have an `asyncapi.yaml` file ready, then generate one by running: 
-`asyncapi new --example=tutorial.yml --no-tty`.
-
-Next, generate a server by running:
-
-    asyncapi generate fromTemplate asyncapi.yaml @asyncapi/nodejs-template -o output -p server=mosquitto
-    cd output && npm install
-
-</Remember>
-
-Now you will be validating the messages which you will be sending to your application using a Mosquitto broker and an MQTT client.
+In the [previous tutorial](https://asyncapi.com/docs/tutorials/generate-code), you generated your application using [Glee](https://github.com/asyncapi/glee). Now you will be validating the messages which you will be sending to your application using a Mosquitto broker and an MQTT client.
 
 ## Validate messages
 In this step, you will send a message to your application using an MQTT broker and check the errors logged when you accidentally send an invalid message.
@@ -34,7 +21,7 @@ In this step, you will send a message to your application using an MQTT broker a
 1. Start your generated application.
 
 <CodeBlock language="bash">
-{`npm start`}
+{`npm run dev`}
 </CodeBlock>
 
 2. Let's send a message:
@@ -46,7 +33,7 @@ In this step, you will send a message to your application using an MQTT broker a
 Go back to the previous terminal and check if your application logged the streetlight condition you just sent, with errors related to the invalid message. You should see something displayed in the terminal similar to the following:
 
 <CodeBlock language="bash">
-  {`light/measured was received:
+  {`lightMeasured was received from mosquitto:
 { id: 1, lumens: '3', sentAt: '2017-06-07T12:34:32.000Z' }
 ❗  Message Rejected. data.lumens should be integer`}
 </CodeBlock>
@@ -78,11 +65,11 @@ Here, you can see that the property `lumens` has type `integer`, but you are sen
 You can see that your generated application received a message in the terminal:
 
 <CodeBlock language="bash">
-  {`light/measured was received:
+  {`lightMeasured was received from mosquitto:
 { id: 1, lumens: 3, sentAt: '2017-06-07T12:34:32.000Z' }`}
 </CodeBlock>
 
-This indicates that your message is valid and the application recieved it correctly.
+This indicates that your message is valid and the application received it correctly.
 
 ## Summary
 In this tutorial, you learned how to connect your generated application to an MQTT broker, send messages through it, identify when an invalid message is sent to your application, and how to correct an invalid message. 

--- a/pages/docs/tutorials/message-validation.md
+++ b/pages/docs/tutorials/message-validation.md
@@ -13,7 +13,16 @@ Message validation can be performed at both the **producer** and **consumer** le
 
 You will be using the [Eclipse Mosquitto](https://mosquitto.org/) broker. The MQTT protocol provides a lightweight method of messaging using a publish/subscribe model. You will also use an MQTT client that runs an MQTT library and connects to an MQTT broker over a network. Here publishers and subscribers are MQTT clients. The publisher and subscriber labels refer to whether the client is publishing or subscribing to receive messages.
 
-In the [previous tutorial](https://asyncapi.com/docs/tutorials/generate-code), you generated your application using [Glee](https://github.com/asyncapi/glee). Now you will be validating the messages which you will be sending to your application using a Mosquitto broker and an MQTT client.
+In the [previous tutorial](https://asyncapi.com/docs/tutorials/generate-code), you generated your application that uses [Glee](https://github.com/asyncapi/glee) framework. Now you will be validating the messages which you will be sending to your application using a Mosquitto broker and an MQTT client.
+
+<Remember>
+
+If you did not follow the previous tutorial and do not have an application generated, then follow these instructions: 
+
+    asyncapi new glee --name=tutorial --template tutorial`.
+    cd tutorial && npm install
+
+</Remember>
 
 ## Validate messages
 In this step, you will send a message to your application using an MQTT broker and check the errors logged when you accidentally send an invalid message.

--- a/pages/docs/tutorials/message-validation.md
+++ b/pages/docs/tutorials/message-validation.md
@@ -11,7 +11,7 @@ In this tutorial, you'll learn how to validate messages (events) that are sent t
 ## Background context
 Message validation can be performed at both the **producer** and **consumer** levels. Message validation requires the participation of the producer, consumer, and broker. We will learn how to validate messages at the consumer level by discarding invalid messages based on the parameters provided.
 
-You will be using the [Eclipse Mosquitto](https://mosquitto.org/) broker. The MQTT protocol provides a lightweight method of messaging using a publish/subscribe model. You will also use an MQTT client that runs an MQTT library and connects to an MQTT broker over a network. Here publishers and subscribers are MQTT clients. The publisher and subscriber labels refer to whether the client is publishing or subscribing to receive messages.
+You will be using the [Eclipse Mosquitto](https://mosquitto.org/) broker. The MQTT protocol provides a lightweight method of messaging using a publish/subscribe model. You will also use an MQTT client that runs an MQTT library and connects to an MQTT broker over a network. Here producers and consumers are MQTT clients. The producer and consumer labels refer to whether the client is sending or receiving messages.
 
 In the [previous tutorial, you generated an application](https://asyncapi.com/docs/tutorials/generate-code) that uses [Glee](https://github.com/asyncapi/glee) framework. Now you will be validating the messages that you will be sending to your application using a Mosquitto broker and an MQTT client.
 

--- a/pages/docs/tutorials/message-validation.md
+++ b/pages/docs/tutorials/message-validation.md
@@ -46,16 +46,16 @@ Go back to the previous terminal and check if your application logged the street
 { id: 1, lumens: '3', sentAt: '2017-06-07T12:34:32.000Z' }
 x You have received a malformed event or there has been error processing it. Please review the error below:
 TYPE should be integer
-
+ 
   1 | {
   2 |   "id": 1,
 > 3 |   "lumens": "3",
     |             ^^^ 👈🏽  type should be integer
   4 |   "sentAt": "2017-06-07T12:34:32.000Z"
   5 | }
-
+ 
 ONEOF should match exactly one schema in oneOf
-
+ 
 > 1 | {
     | ^
 > 2 |   "id": 1,
@@ -65,7 +65,7 @@ ONEOF should match exactly one schema in oneOf
 > 4 |   "sentAt": "2017-06-07T12:34:32.000Z"
     | ^^^^^^^^^^
 > 5 | }
-    | ^^ 👈🏽  oneOf should match exactly one schema in oneOf
+    | ^^ 👈🏽  oneOf should match exactly one schema in oneOf`}
 </CodeBlock>
 
 Here, you can see that the property `lumens` has type `integer`, but you are sending a message with type `string`:

--- a/pages/docs/tutorials/message-validation.md
+++ b/pages/docs/tutorials/message-validation.md
@@ -75,7 +75,8 @@ You can see that your generated application received a message in the terminal:
 
 <CodeBlock language="bash">
   {`lightMeasured was received from mosquitto:
-{ id: 1, lumens: 3, sentAt: '2017-06-07T12:34:32.000Z' }`}
+{ id: 1, lumens: 3, sentAt: '2017-06-07T12:34:32.000Z' }
+Streetlight with id "1" updated its lighting information to 3 lumens at 2017-06-07T12:34:32.000Z.`}
 </CodeBlock>
 
 This indicates that your message is valid and the application received it correctly.

--- a/pages/docs/tutorials/message-validation.md
+++ b/pages/docs/tutorials/message-validation.md
@@ -18,7 +18,7 @@ In the [previous tutorial](https://asyncapi.com/docs/tutorials/generate-code), y
 ## Validate messages
 In this step, you will send a message to your application using an MQTT broker and check the errors logged when you accidentally send an invalid message.
 
-1. Start your generated application.
+1. Start your generated application:
 
 <CodeBlock language="bash">
 {`npm run dev`}
@@ -38,7 +38,7 @@ Go back to the previous terminal and check if your application logged the street
 ❗  Message Rejected. data.lumens should be integer`}
 </CodeBlock>
 
-Here, you can see that the property `lumens` has type `integer`, but you are sending a message with type `string`.
+Here, you can see that the property `lumens` has type `integer`, but you are sending a message with type `string`:
 
 <CodeBlock language="yaml" highlightedLines={[10,11]}>
   {`  message:

--- a/pages/docs/tutorials/message-validation.md
+++ b/pages/docs/tutorials/message-validation.md
@@ -44,7 +44,28 @@ Go back to the previous terminal and check if your application logged the street
 <CodeBlock language="bash">
   {`lightMeasured was received from mosquitto:
 { id: 1, lumens: '3', sentAt: '2017-06-07T12:34:32.000Z' }
-❗  Message Rejected. data.lumens should be integer`}
+x You have received a malformed event or there has been error processing it. Please review the error below:
+TYPE should be integer
+
+  1 | {
+  2 |   "id": 1,
+> 3 |   "lumens": "3",
+    |             ^^^ 👈🏽  type should be integer
+  4 |   "sentAt": "2017-06-07T12:34:32.000Z"
+  5 | }
+
+ONEOF should match exactly one schema in oneOf
+
+> 1 | {
+    | ^
+> 2 |   "id": 1,
+    | ^^^^^^^^^^
+> 3 |   "lumens": "3",
+    | ^^^^^^^^^^
+> 4 |   "sentAt": "2017-06-07T12:34:32.000Z"
+    | ^^^^^^^^^^
+> 5 | }
+    | ^^ 👈🏽  oneOf should match exactly one schema in oneOf
 </CodeBlock>
 
 Here, you can see that the property `lumens` has type `integer`, but you are sending a message with type `string`:

--- a/pages/docs/tutorials/message-validation.md
+++ b/pages/docs/tutorials/message-validation.md
@@ -13,7 +13,7 @@ Message validation can be performed at both the **producer** and **consumer** le
 
 You will be using the [Eclipse Mosquitto](https://mosquitto.org/) broker. The MQTT protocol provides a lightweight method of messaging using a publish/subscribe model. You will also use an MQTT client that runs an MQTT library and connects to an MQTT broker over a network. Here publishers and subscribers are MQTT clients. The publisher and subscriber labels refer to whether the client is publishing or subscribing to receive messages.
 
-In the [previous tutorial](https://asyncapi.com/docs/tutorials/generate-code), you generated your application that uses [Glee](https://github.com/asyncapi/glee) framework. Now you will be validating the messages which you will be sending to your application using a Mosquitto broker and an MQTT client.
+In the [previous tutorial, you generated an application](https://asyncapi.com/docs/tutorials/generate-code) that uses [Glee](https://github.com/asyncapi/glee) framework. Now you will be validating the messages that you will be sending to your application using a Mosquitto broker and an MQTT client.
 
 <Remember>
 
@@ -33,7 +33,7 @@ In this step, you will send a message to your application using an MQTT broker a
 {`npm run dev`}
 </CodeBlock>
 
-2. Let's send a message:
+2. Send a message:
 
 <CodeBlock language="bash">
   {`mqtt pub -t 'light/measured' -h 'test.mosquitto.org' -m '{"id": 1, "lumens": "3", "sentAt": "2017-06-07T12:34:32.000Z"}'`}
@@ -100,7 +100,7 @@ You can see that your generated application received a message in the terminal:
 Streetlight with id "1" updated its lighting information to 3 lumens at 2017-06-07T12:34:32.000Z.`}
 </CodeBlock>
 
-This indicates that your message is valid and the application received it correctly.
+Such a terminal message indicates that your message is valid and the application received it correctly.
 
 ## Summary
 In this tutorial, you learned how to connect your generated application to an MQTT broker, send messages through it, identify when an invalid message is sent to your application, and how to correct an invalid message. 
@@ -108,4 +108,3 @@ In this tutorial, you learned how to connect your generated application to an MQ
 ## Next steps
 Now that you've completed this tutorial, enjoy our [AsyncAPI message validation guide](https://www.asyncapi.com/docs/guides/message-validation).
 
----


### PR DESCRIPTION
**Description**
This tutorial uses Glee instead of the code generator now. It simplifies getting started with it.

TODO:
- [x] Check that every step that's needed is thoroughly documented. So far, updating the `.env` file is missing and it must be there.
- [x] Ideally, we should wait on [this issue](https://github.com/asyncapi/cli/pull/887). This would simplify the tutorial by a lot, making the above point unimportant.

**Related issue(s)**
https://github.com/asyncapi/cli/pull/887