### PR TITLE
fix: update slack link

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -56,7 +56,7 @@ https://www.asyncapi.io/* https://www.asyncapi.com/:splat 301!
 /asyncapi-react https://asyncapi.github.io/asyncapi-react 301!
 
 # Slack
-/slack-invite https://join.slack.com/t/asyncapi/shared_invite/zt-2329g7esz-jPKWhnRBX0NKJMK4gatqKQ 302!
+/slack-invite https://join.slack.com/t/asyncapi/shared_invite/zt-27m89oa1t-ZC~UIa5B2Vujm6oq7fa~gQ 302!
 
 # Central Maven repository verification
 /OSSRH-63280 https://github.com/asyncapi/java-asyncapi


### PR DESCRIPTION
- Update the Slack link to the new one that never expires