### PR TITLE
chore: fix typos in v2 migration guide

### DIFF
--- a/pages/docs/migration/migrating-to-v3.md
+++ b/pages/docs/migration/migrating-to-v3.md
@@ -259,7 +259,7 @@ servers:
 ...
 channels: 
   test/path:
-    severs:
+    servers:
       - production
 components:
   securitySchemes:
@@ -285,7 +285,7 @@ servers:
 ...
 channels: 
   test/path:
-    severs:
+    servers:
       - $ref: "#/servers/production"
 components:
   securitySchemes:


### PR DESCRIPTION
This PR fixes several typos in v2 migration guide.