### PR TITLE
docs: add reusable parts

### DIFF
--- a/pages/docs/concepts/asyncapi-document/reusable-parts.md
+++ b/pages/docs/concepts/asyncapi-document/reusable-parts.md
@@ -3,13 +3,13 @@ title: Reusable parts
 weight: 280
 ---
 
-Reusable parts in AsyncAPI provide flexibility, modularity, and code reusability. You can reuse majority of document sections such as messages or schema definitions, but also channels, operations and many others.
+Reusable parts in AsyncAPI provide flexibility, modularity, and code reusability. You can reuse the majority of document sections like messages, schema definitions, channels, operations, and more.
 
-Reusable parts allow you to split up the AsyncAPI document into many files and reference them using the [Reference Object](/docs/reference/specification/v3.0.0#referenceObject). You can use the `$ref` keyword to reference the same or another local file or external URL. The diagram below describes how to reuse parts in AsyncAPI.
+Reusable parts allow you to split up the AsyncAPI document into many files and reference them using the [Reference Object](/docs/reference/specification/v3.0.0#referenceObject). You can use the `$ref` keyword to reference the same document, another local file, or an external URL. The diagram below describes how to reuse parts in AsyncAPI:
 
 ## Same document
 
-You can use the `$ref` keyword to reference a component within the same document. In the example below, you define a component called `MyMessageSchema` under the `schemas` section to describe the structure of a message. Under `myChannel` channel you have a message, its payload definition is represented as a reference to `MyMessageSchema` schema using the `$ref` keyword.
+You can use the `$ref` keyword to reference a component in an AsyncAPI document. In the example below, you define a component called `MyMessageSchema` under the `schemas` section to describe the structure of a message. Under the `myChannel` channel, you have a message with a payload definition that's represented as a reference to the `MyMessageSchema` schema via the `$ref` keyword.
 
 ```yaml
 channels:
@@ -29,7 +29,7 @@ components:
 
 ## Another local file
 
-You can use the `$ref` keyword to reference another local document. Ensure the path to the local file is correct and accessible from your main AsyncAPI document.
+You can reference another local document using the `$ref` keyword. Ensure the path to the local file is correct and accessible from your main AsyncAPI document.
 
 In the code below, you reference the component from another local document, such as `message-schema.yaml`.
 
@@ -43,7 +43,7 @@ UserSignup:
   payload: null
 ```
 
-In the code below, you use another local document `message-schema.yaml` through a reference inside AsyncAPI document.
+In the code below, you use another local document, `message-schema.yaml`, through a reference inside the AsyncAPI document. 
 
 ```yaml
 channels:
@@ -63,7 +63,7 @@ operations:
 
 ## External URL
 
-You can use the `$ref` keyword to reference an external URL. Ensure the external URL should provide the referenced component in a compatible format, such as YAML or JSON. In the example below, you reference the component from an external URL. The `$ref` value specifies the full URL to the external resource and the component's location.
+You can reference an external URL using the `$ref` keyword. Ensure the external URL provides the referenced component in a compatible format, such as YAML or JSON. In the example below, you reference the component from an external URL. The `$ref` value specifies the full URL to the external resource and the component's location.
 
 ```yaml
 channels:

--- a/pages/docs/concepts/asyncapi-document/reusable-parts.md
+++ b/pages/docs/concepts/asyncapi-document/reusable-parts.md
@@ -1,0 +1,100 @@
+---
+title: Reusable parts
+weight: 280
+---
+
+Reusable parts in AsyncAPI provide flexibility, modularity, and code reusability. You can reuse specific document sections such as Messages or schema definitions.
+
+Reusable parts allow you to split up the AsyncAPI document into many files and reference them using the Reference Object. You can use the $ref keyword to reference the same or another local file or external URL. The diagram below describes how to reuse parts in AsyncAPI.
+
+```mermaid
+graph TD
+
+    A[Message]
+    B[Payload]
+    C[Reusable Part]
+
+style A fill:#47BCEE,stroke:#47BCEE;
+style B fill:#47BCEE,stroke:#47BCEE;
+style C fill:#47BCEE,stroke:#47BCEE;
+
+  A -->|references| B
+  B -->|local file reference| C
+  B -->|same file reference| C
+  B -->|external URL reference| C
+
+```
+
+## Same file
+
+You can use the $ref keyword to reference a component within the same document. In the example below, you define a component called MyMessageSchema under the schemas section to describe the structure of a message. Under the publish operation of myChannel, you reference the MyMessageSchema component using the $ref keyword.
+
+```yaml
+channels:
+  myChannel:
+    publish:
+      message:
+        payload:
+          $ref: '#/components/schemas/MyMessageSchema'
+components:
+  schemas:
+    MyMessageSchema:
+      type: object
+      properties:
+        message:
+          type: string
+```
+
+## Another local file
+
+You can use the $ref keyword to reference another local document. Ensure the path to the local file is correct and accessible from your main AsyncAPI document.
+
+In the code below, you reference the component from another local document, such as message-schema.yaml.
+
+```yaml
+UserSignup:
+  name: UserSignup
+  title: User signup
+  summary: Action to sign a user up.
+  description: A longer description
+  contentType: application/json
+  payload: null
+```
+
+In the code below, you use another local document message-schema.yaml in another local document such as consume-schema.yaml.
+
+```yaml
+channels:
+  user/signedup:
+    address: user/signedup
+    messages:
+      publish.message:
+        $ref: './message-schema.yaml#/UserSignup'
+operations:
+  user/signedup.publish:
+    action: receive
+    channel:
+      $ref: '#/channels/user~1signedup'
+    messages:
+      - $ref: '#/channels/user~1signedup/messages/publish.message'
+```
+
+## External URL
+
+You can use the $ref keyword to reference an external URL. Ensure the external URL should provide the referenced component in a compatible format, such as YAML or JSON. In the example below, you reference the component from an external URL. The $ref value specifies the full URL to the external resource and the component's location.
+
+```yaml
+channels:
+  user/signedup:
+    address: user/signedup
+    messages:
+      publish.message:
+        $ref: https://example.com/my-components.yaml#/schemas/MySchema
+operations:
+  user/signedup.publish:
+    action: receive
+    channel:
+      $ref: '#/channels/user~1signedup'
+    messages:
+      - $ref: '#/channels/user~1signedup/messages/publish.message'
+```

--- a/pages/docs/concepts/asyncapi-document/reusable-parts.md
+++ b/pages/docs/concepts/asyncapi-document/reusable-parts.md
@@ -3,37 +3,19 @@ title: Reusable parts
 weight: 280
 ---
 
-Reusable parts in AsyncAPI provide flexibility, modularity, and code reusability. You can reuse specific document sections such as Messages or schema definitions.
+Reusable parts in AsyncAPI provide flexibility, modularity, and code reusability. You can reuse majority of document sections such as messages or schema definitions, but also channels, operations and many others.
 
-Reusable parts allow you to split up the AsyncAPI document into many files and reference them using the Reference Object. You can use the $ref keyword to reference the same or another local file or external URL. The diagram below describes how to reuse parts in AsyncAPI.
+Reusable parts allow you to split up the AsyncAPI document into many files and reference them using the [Reference Object](/docs/reference/specification/v3.0.0#referenceObject). You can use the `$ref` keyword to reference the same or another local file or external URL. The diagram below describes how to reuse parts in AsyncAPI.
 
-```mermaid
-graph TD
+## Same document
 
-    A[Message]
-    B[Payload]
-    C[Reusable Part]
-
-style A fill:#47BCEE,stroke:#47BCEE;
-style B fill:#47BCEE,stroke:#47BCEE;
-style C fill:#47BCEE,stroke:#47BCEE;
-
-  A -->|references| B
-  B -->|local file reference| C
-  B -->|same file reference| C
-  B -->|external URL reference| C
-
-```
-
-## Same file
-
-You can use the $ref keyword to reference a component within the same document. In the example below, you define a component called MyMessageSchema under the schemas section to describe the structure of a message. Under the publish operation of myChannel, you reference the MyMessageSchema component using the $ref keyword.
+You can use the `$ref` keyword to reference a component within the same document. In the example below, you define a component called `MyMessageSchema` under the `schemas` section to describe the structure of a message. Under `myChannel` channel you have a message, its payload definition is represented as a reference to `MyMessageSchema` schema using the `$ref` keyword.
 
 ```yaml
 channels:
   myChannel:
-    publish:
-      message:
+    message:
+      myMessage:
         payload:
           $ref: '#/components/schemas/MyMessageSchema'
 components:
@@ -47,9 +29,9 @@ components:
 
 ## Another local file
 
-You can use the $ref keyword to reference another local document. Ensure the path to the local file is correct and accessible from your main AsyncAPI document.
+You can use the `$ref` keyword to reference another local document. Ensure the path to the local file is correct and accessible from your main AsyncAPI document.
 
-In the code below, you reference the component from another local document, such as message-schema.yaml.
+In the code below, you reference the component from another local document, such as `message-schema.yaml`.
 
 ```yaml
 UserSignup:
@@ -61,40 +43,40 @@ UserSignup:
   payload: null
 ```
 
-In the code below, you use another local document message-schema.yaml in another local document such as consume-schema.yaml.
+In the code below, you use another local document `message-schema.yaml` through a reference inside AsyncAPI document.
 
 ```yaml
 channels:
-  user/signedup:
+  signUp:
     address: user/signedup
     messages:
-      publish.message:
+      UserSignup:
         $ref: './message-schema.yaml#/UserSignup'
 operations:
   user/signedup.publish:
     action: receive
     channel:
-      $ref: '#/channels/user~1signedup'
+      $ref: '#/channels/signUp'
     messages:
-      - $ref: '#/channels/user~1signedup/messages/publish.message'
+      - $ref: '#/channels/signUp/messages/UserSignup'
 ```
 
 ## External URL
 
-You can use the $ref keyword to reference an external URL. Ensure the external URL should provide the referenced component in a compatible format, such as YAML or JSON. In the example below, you reference the component from an external URL. The $ref value specifies the full URL to the external resource and the component's location.
+You can use the `$ref` keyword to reference an external URL. Ensure the external URL should provide the referenced component in a compatible format, such as YAML or JSON. In the example below, you reference the component from an external URL. The `$ref` value specifies the full URL to the external resource and the component's location.
 
 ```yaml
 channels:
-  user/signedup:
+  signUp:
     address: user/signedup
     messages:
-      publish.message:
+      UserSignup:
         $ref: https://example.com/my-components.yaml#/schemas/MySchema
 operations:
   user/signedup.publish:
     action: receive
     channel:
-      $ref: '#/channels/user~1signedup'
+      $ref: '#/channels/signUp'
     messages:
-      - $ref: '#/channels/user~1signedup/messages/publish.message'
+      - $ref: '#/channels/signUp/messages/UserSignup'
 ```


### PR DESCRIPTION
This document covers:

- External files within the document
- Reference messages defined in another AsyncAPI document

Refer: https://github.com/asyncapi/website/issues/1516