### PR TITLE
fix: navbar floating above menu in mobile view

### DIFF
--- a/components/navigation/StickyNavbar.js
+++ b/components/navigation/StickyNavbar.js
@@ -1,5 +1,5 @@
 export default function StickyNavbar({children, className=''}) {
-  return <div className={`sticky top-0 w-full bg-white border-b border-gray-300 ${className}`} data-testid="Sticky-div">
+  return <div className={`sticky top-0 w-full bg-white border-b border-gray-300 z-30 ${className}`} data-testid="Sticky-div">
       {children}
   </div>;
 }

--- a/components/navigation/StickyNavbar.js
+++ b/components/navigation/StickyNavbar.js
@@ -1,5 +1,5 @@
 export default function StickyNavbar({children, className=''}) {
-  return <div className={`sticky top-0 w-full bg-white border-b border-gray-300 z-50 ${className}`} data-testid="Sticky-div">
+  return <div className={`sticky top-0 w-full bg-white border-b border-gray-300 ${className}`} data-testid="Sticky-div">
       {children}
   </div>;
 }


### PR DESCRIPTION
**Description**
This issue fixes the navbar floating above the menu in mobile view. This bug was due to the wrong z-index in sticky navbar.

**Related issue(s)**
Fixes #2427 