### PR TITLE
fix: responsive button at tools/generator and up next button at Overview Page. 

### DIFF
--- a/components/buttons/DocsButton.js
+++ b/components/buttons/DocsButton.js
@@ -35,7 +35,7 @@ export default function DocsButton({ post, className='' }) {
       <div className="w-1/2 h-auto">
         { post?.nextPage && <Link href={post.nextPage.href} className='h-auto' passHref>
             <a>
-            <div className="p-4 rounded shadow-md border border-gray-200 transition-all duration-300 ease-in-out hover:shadow-lg hover:border-gray-300 text-center lg:text-right cursor-pointer">
+            <div className="p-4 rounded shadow-md border border-gray-200 transition-all duration-300 ease-in-out hover:shadow-lg hover:border-gray-300 text-center lg:text-right cursor-pointer h-[100%]">
               <div className="text-secondary-500" data-testid="DocsButton-Nextdiv">
                 <div className="font-bold my-auto text-sm inline uppercase">
                   Up Next

--- a/components/buttons/GithubButton.js
+++ b/components/buttons/GithubButton.js
@@ -1,6 +1,6 @@
-import Button from './Button'
-import IconGithub from '../icons/Github'
-import { useTranslation } from '../../lib/i18n'
+import Button from './Button';
+import IconGithub from '../icons/Github';
+import { useTranslation } from '../../lib/i18n';
 
 export default function GithubButton({
   text = 'githubButton',
@@ -8,23 +8,21 @@ export default function GithubButton({
   target = '_blank',
   iconPosition = 'left',
   className,
-  inNav = "false"
+  inNav = 'false',
 }) {
-
-  const { t } = useTranslation("common");
+  const { t } = useTranslation('common');
 
   return (
     <Button
       text={t(text)}
-      icon={<IconGithub className="inline-block -mt-1 w-6 h-6" />}
+      icon={<IconGithub className="inline-block  -mt-1 w-6 h-6" />}
       href={href}
       iconPosition={iconPosition}
       target={target}
       className={className}
       data-testid="Github-button"
       bgClassName="bg-gray-800 hover:bg-gray-700"
-      buttonSize={ inNav == "true" ? "small" : "default" }
+      buttonSize={inNav == 'true' ? 'small' : 'default'}
     />
-  )
+  );
 }
-

--- a/pages/tools/generator.js
+++ b/pages/tools/generator.js
@@ -1,35 +1,37 @@
-import GenericLayout from '../../components/layout/GenericLayout'
-import IconDocuments from '../../components/icons/Documents'
-import IconCode from '../../components/icons/Code'
-import IconPowerPlug from '../../components/icons/PowerPlug'
-import GithubButton from '../../components/buttons/GithubButton'
-import GeneratorInstallation from '../../components/GeneratorInstallation'
-import Heading from '../../components/typography/Heading'
-import Paragraph from '../../components/typography/Paragraph'
-import Button from '../../components/buttons/Button'
+import GenericLayout from '../../components/layout/GenericLayout';
+import IconDocuments from '../../components/icons/Documents';
+import IconCode from '../../components/icons/Code';
+import IconPowerPlug from '../../components/icons/PowerPlug';
+import GithubButton from '../../components/buttons/GithubButton';
+import GeneratorInstallation from '../../components/GeneratorInstallation';
+import Heading from '../../components/typography/Heading';
+import Paragraph from '../../components/typography/Paragraph';
+import Button from '../../components/buttons/Button';
 
 export default function GeneratorPage() {
-  function renderButtons () {
+  function renderButtons() {
     return (
       <div className="mt-8">
-        {/* <Button
-          text="Learn more"
-          href="/docs/tools/generator"
-          iconPosition="left"
-          icon={<IconRocket className="inline-block w-6 h-6 -mt-1" />}
-          className="w-full mb-2 sm:w-auto sm:mb-0 sm:mr-2"
-        /> */}
-        <GithubButton
-          className="w-full sm:w-auto"
-          href="https://www.github.com/asyncapi/generator"
-        />
-      <Button text="View Docs" href="/docs/tools/generator" className="ml-2 block mt-2 md:mt-0 md:inline-block w-full sm:w-auto"/>
+        <div
+        className='flex'
+        >
+          <GithubButton
+            className="w-full sm:w-auto text-xs sm:text-lg flex justify-center items-center "
+            href="https://www.github.com/asyncapi/generator"
+          />
+          <Button
+            text="View Docs"
+            href="/docs/tools/generator"
+            className="ml-2 block text-center  md:inline-block w-full sm:w-auto text-xs sm:text-xl"
+          />
+        </div>
       </div>
     );
   }
 
-  const description = 'Generate documentation, code, and more out of your AsyncAPI files with the Generator.'
-  const image = '/img/social/generator-card.jpg'
+  const description =
+    'Generate documentation, code, and more out of your AsyncAPI files with the Generator.';
+  const image = '/img/social/generator-card.jpg';
 
   return (
     <GenericLayout
@@ -44,9 +46,7 @@ export default function GeneratorPage() {
             <Heading level="h1" typeStyle="heading-lg">
               Docs, Code, Anything!
             </Heading>
-            <Paragraph className="mt-4">
-              {description}
-            </Paragraph>
+            <Paragraph className="mt-4">{description}</Paragraph>
           </div>
 
           <div className="relative mt-12 lg:mt-20 lg:grid lg:grid-cols-2 lg:gap-8 lg:items-center">
@@ -55,7 +55,9 @@ export default function GeneratorPage() {
                 Installation & Usage
               </Heading>
               <Paragraph className="mt-3 lg:pr-4">
-                Start using Generator really quickly. Select one of the multiple templates we offer and start generating documentation and code in a few seconds.
+                Start using Generator really quickly. Select one of the multiple
+                templates we offer and start generating documentation and code
+                in a few seconds.
               </Paragraph>
               {renderButtons()}
             </div>
@@ -67,7 +69,9 @@ export default function GeneratorPage() {
                 Ready to use
               </Heading>
               <Paragraph className="mt-3 lg:pr-4">
-                The Generator is our solution to automatically generate documentation and code from your AsyncAPI files. It comes packed with lots of cool features you can't miss. Have a look!
+                The Generator is our solution to automatically generate
+                documentation and code from your AsyncAPI files. It comes packed
+                with lots of cool features you can't miss. Have a look!
               </Paragraph>
 
               <ul className="mt-10 lg:pr-4">
@@ -83,7 +87,9 @@ export default function GeneratorPage() {
                         HTML &amp; Markdown
                       </Heading>
                       <Paragraph typeStyle="body-md" className="mt-2">
-                        Generate beautiful HTML documentation that's easy to share with your team and customers. Markdown docs that will seat along with your code? Perfect!
+                        Generate beautiful HTML documentation that's easy to
+                        share with your team and customers. Markdown docs that
+                        will seat along with your code? Perfect!
                       </Paragraph>
                     </div>
                   </div>
@@ -100,7 +106,10 @@ export default function GeneratorPage() {
                         Node.js, Java, Python, and more...
                       </Heading>
                       <Paragraph typeStyle="body-md" className="mt-2">
-                        Generate code out of your AsyncAPI files in your favourite programming language. Speed up the time-to-first-prototype. Keep using it even after you wrote your custom business logic.
+                        Generate code out of your AsyncAPI files in your
+                        favourite programming language. Speed up the
+                        time-to-first-prototype. Keep using it even after you
+                        wrote your custom business logic.
                       </Paragraph>
                     </div>
                   </div>
@@ -117,7 +126,9 @@ export default function GeneratorPage() {
                         Highly extensible
                       </Heading>
                       <Paragraph typeStyle="body-md" className="mt-2">
-                        Don't see your programming language of choice? Want to generate docs that meet your brand look and feel? Create your custom templates or extend existing ones.
+                        Don't see your programming language of choice? Want to
+                        generate docs that meet your brand look and feel? Create
+                        your custom templates or extend existing ones.
                       </Paragraph>
                     </div>
                   </div>
@@ -126,16 +137,22 @@ export default function GeneratorPage() {
             </div>
 
             <div className="mt-10 -mx-4 relative lg:mt-0">
-              <img className="relative rounded shadow-lg mx-auto" src="/img/tools/generator-1.png" alt="" />
-              <img className="relative rounded mt-8 shadow-lg mx-auto" src="/img/tools/generator-2.png" alt="" />
+              <img
+                className="relative rounded shadow-lg mx-auto"
+                src="/img/tools/generator-1.png"
+                alt=""
+              />
+              <img
+                className="relative rounded mt-8 shadow-lg mx-auto"
+                src="/img/tools/generator-2.png"
+                alt=""
+              />
             </div>
           </div>
         </div>
 
-        <div className="mt-16 text-center">
-          {renderButtons()}
-        </div>
+        <div className="mt-16 text-center">{renderButtons()}</div>
       </div>
     </GenericLayout>
-  )
+  );
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
#### Fix the issue Non-Responsive Next Button for Up Next at docs/tools in overview page issue  #2445 
#### Earlier
![image](https://github.com/asyncapi/website/assets/94506000/e64bb012-38e0-426b-af7b-1a76c57bfacc)
#### Now

![image](https://github.com/asyncapi/website/assets/94506000/d30223c4-a5d1-426f-8d94-1bd18ee01da3)

#### Fix the Issue Non-Responsive Button at the tools/generator Page linked at issue  #2455
#### Earlier
![image](https://github.com/asyncapi/website/assets/94506000/80197ba1-32d7-4d46-a7b4-92f824b2ba9d)
![image](https://github.com/asyncapi/website/assets/94506000/82c2841c-b79d-40ce-9542-5a5e65acb3d7)

### Mobile View 
![image](https://github.com/asyncapi/website/assets/94506000/f19db10b-380b-4550-86d9-a99cb369881b)
![image](https://github.com/asyncapi/website/assets/94506000/67942f54-5438-43ff-b748-34e4e21bcd38)

**Related issue(s)**
 Resolves #2445 
Resolves #2455 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->