### PR TITLE
fix: unresponsive button at the tools/generator page

### DIFF
--- a/pages/tools/generator.js
+++ b/pages/tools/generator.js
@@ -23,7 +23,7 @@ export default function GeneratorPage() {
           className="w-full sm:w-auto"
           href="https://www.github.com/asyncapi/generator"
         />
-      <Button text="View Docs" href="/docs/tools/generator" className="ml-2 block mt-2 md:mt-0 md:inline-block w-full sm:w-auto"/>
+      <Button text="View Docs" href="/docs/tools/generator" className="ml-2 mt-2 md:mt-0 md:inline-block w-full sm:w-auto"/>
       </div>
     );
   }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This pull request addresses the unresponsive button issue at the tools/generator page. The problem was that the "View Docs" button was unresponsive, and the changes proposed in this pull request aimed to resolve it.

**Before**
![before_issue_1](https://github.com/asyncapi/website/assets/143711255/d07eda96-c316-4df8-93f6-f27b376052b4)
![before_issue_2](https://github.com/asyncapi/website/assets/143711255/10f055bc-ec65-4f58-9144-69ff276b9e6a)

**After**
![after_issue_1](https://github.com/asyncapi/website/assets/143711255/65b2e743-90e2-4c73-acc4-79a15c1745f8)
![after_issue_2](https://github.com/asyncapi/website/assets/143711255/4d37b2f1-4367-4142-836b-d99e7ae5dcf6)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fix #2455 