### PR TITLE
fix: responsive button at up next button at docs/tools in overview page linked issue #2445

### DIFF
--- a/components/buttons/DocsButton.js
+++ b/components/buttons/DocsButton.js
@@ -35,7 +35,7 @@ export default function DocsButton({ post, className='' }) {
       <div className="w-1/2 h-auto">
         { post?.nextPage && <Link href={post.nextPage.href} className='h-auto' passHref>
             <a>
-            <div className="p-4 rounded shadow-md border border-gray-200 transition-all duration-300 ease-in-out hover:shadow-lg hover:border-gray-300 text-center lg:text-right cursor-pointer">
+            <div className="p-4 rounded shadow-md border border-gray-200 transition-all duration-300 ease-in-out hover:shadow-lg hover:border-gray-300 text-center lg:text-right cursor-pointer h-[100%]">
               <div className="text-secondary-500" data-testid="DocsButton-Nextdiv">
                 <div className="font-bold my-auto text-sm inline uppercase">
                   Up Next


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
### This PR Fixes Non-Responsive Next Button for Up Next at docs/tools in overview page
### Fixes #2445 
### Before Fix
![image](https://github.com/asyncapi/website/assets/94506000/9a15f759-5903-4979-9839-88d4e4cb48cb)
### After Fix
![image](https://github.com/asyncapi/website/assets/94506000/029dfe38-a641-4b79-a4e1-230412a8c7ec)
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->