### PR TITLE
chore: update the link to AsyncAPI shop in the footer

### DIFF
--- a/components/footer/FooterList.js
+++ b/components/footer/FooterList.js
@@ -49,7 +49,7 @@ export const initiativeLinks = [
   },
   {
     label: "Shop",
-    url: "https://asyncapi.threadless.com",
+    url: "https://www.store.asyncapi.com/collections/all-products",
   },
   {
     label: "Jobs",

--- a/components/navigation/StickyNavbar.js
+++ b/components/navigation/StickyNavbar.js
@@ -1,5 +1,5 @@
 export default function StickyNavbar({children, className=''}) {
-  return <div className={`sticky top-0 w-full bg-white border-b border-gray-300 ${className}`} data-testid="Sticky-div">
+  return <div className={`sticky top-0 w-full bg-white border-b border-gray-300 z-30 ${className}`} data-testid="Sticky-div">
       {children}
   </div>;
 }

--- a/components/navigation/StickyNavbar.js
+++ b/components/navigation/StickyNavbar.js
@@ -1,5 +1,5 @@
 export default function StickyNavbar({children, className=''}) {
-  return <div className={`sticky top-0 w-full bg-white border-b border-gray-300 z-50 ${className}`} data-testid="Sticky-div">
+  return <div className={`sticky top-0 w-full bg-white border-b border-gray-300 ${className}`} data-testid="Sticky-div">
       {children}
   </div>;
 }


### PR DESCRIPTION
**Description**
This PR updates the link to Shop in the footer section from the [old shop](https://asyncapi.threadless.com/) to the [new shop](https://www.store.asyncapi.com/collections/all-products).

**Related issue(s)**
Fixes #2465 