### PR TITLE
chore: update finance information and success stories

### DIFF
--- a/components/FinancialSummary/AsyncAPISummary.js
+++ b/components/FinancialSummary/AsyncAPISummary.js
@@ -32,8 +32,8 @@ export default function AsyncAPISummary() {
             </div>
             <div className="text-center my-4 text-base max-width text-darkGunMetal">
                 <Paragraph typeStyle="body-sm" className="my-4">
-                    The easiest way to support AsyncAPI is by becoming a financial sponsor. While <br class="hidden lg:inline-block"></br>there are alternative options,
-                    they may involve greater effort. Contribute <br class="hidden lg:inline-block"></br>monetarily using the following channels.
+                    The easiest way to support AsyncAPI is by becoming a financial sponsor. While <br className="hidden lg:inline-block" />there are alternative options,
+                    they may involve greater effort. Contribute <br className="hidden lg:inline-block" />monetarily using the following channels.
                 </Paragraph>
             </div>
 

--- a/components/FinancialSummary/ContactUs.js
+++ b/components/FinancialSummary/ContactUs.js
@@ -1,6 +1,7 @@
 import Button from '../buttons/Button'
 import Heading from '../typography/Heading'
 import Paragraph from '../typography/Paragraph'
+import TextLink from '../typography/TextLink'
 
 export default function ContactUs() {
     return (
@@ -8,10 +9,10 @@ export default function ContactUs() {
             <div className="grid lg:grid-cols-9 lg:gap-8 lg:text-center my-4">
                 <div className="col-start-3 col-span-5">
                     <div className="mx-2">
-                    <Heading level="h1" typeStyle="heading-lg"><h1 id="contact-us">Interested in getting in touch?</h1></Heading>
+                    <Heading level="h1" typeStyle="heading-lg">Interested in getting in touch?</Heading>
                     <Paragraph typeStyle="body-md" className="my-2 max-w-4xl">
                         Feel free to contact us if you need more explanation. We are happy to hop on a call and help with
-                        onboarding to the project as a sponsor. Write email to <span><a className="text-violet text-base font-semibold" href="mailto:info@asyncapi.io" target='_blank'>info@asyncapi.io</a></span>
+                        onboarding to the project as a sponsor. Write email to <span><TextLink className="text-violet text-base font-semibold" href="mailto:info@asyncapi.io" target='_blank'>info@asyncapi.io</TextLink></span>
                     </Paragraph>
                     </div>
                 </div>

--- a/components/FinancialSummary/OtherFormsComponent.js
+++ b/components/FinancialSummary/OtherFormsComponent.js
@@ -1,4 +1,3 @@
-import Container from '../layout/Container'
 import Heading from '../typography/Heading'
 import Paragraph from '../typography/Paragraph'
 
@@ -12,38 +11,34 @@ export default function OtherFormsComponent() {
                             Other Forms Of Financial Support
                         </Heading>
                         <Paragraph typeStyle="body-md" className="mb-3 max-w-4xl mx-auto text-center text-darkGunMetal">
-                            You can also support AsyncAPI initiative by getting<br class="hidden lg:inline-block"></br> involved through employment, providing services and<br class="hidden lg:inline-block"></br> organizing events
+                            You can also support AsyncAPI initiative by getting<br className="hidden lg:inline-block"></br> involved through employment, providing services and<br className="hidden lg:inline-block"></br> organizing events
                         </Paragraph>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-3 gap-10 mt-8 mx-3">
-
-                        <div class="bg-white rounded-md shadow-md p-4 flex flex-col items-center text-center">
-                            <img src="/img/illustrations/EmployeeInvolvement.webp" alt="Employee involvement" class="w-1/3 h-auto object-cover m-2" />
-                            <h2 class="text-2xl font-semibold my-2">Employee involvement</h2>
-                            <p class="text-base text-darkGunMetal mt-1 mx-2">
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-10 mt-8 mx-3">
+                        <div className="bg-white rounded-md shadow-md p-4 flex flex-col items-center text-center">
+                            <img src="/img/illustrations/EmployeeInvolvement.webp" alt="Employee involvement" className="w-1/3 h-auto object-cover m-2" />
+                            <h2 className="text-2xl font-semibold my-2">Employee involvement</h2>
+                            <p className="text-base text-darkGunMetal mt-1 mx-2">
                                 Assign your employees to contribute to projects under the AsyncAPI Initiative on a regular basis, and we'll welcome them as new maintainers.
                             </p>
                         </div>
 
-                        <div class="bg-white rounded-md shadow-md p-4 flex flex-col items-center text-center">
-                            <img src="/img/illustrations/ServiceProvision.webp" alt="Service provision" class="w-1/3 h-auto object-cover m-2" />
-                            <h2 class="text-2xl font-semibold my-2">Service provision</h2>
-                            <p class="text-base text-darkGunMetal mt-1 mx-2">
+                        <div className="bg-white rounded-md shadow-md p-4 flex flex-col items-center text-center">
+                            <img src="/img/illustrations/ServiceProvision.webp" alt="Service provision" className="w-1/3 h-auto object-cover m-2" />
+                            <h2 className="text-2xl font-semibold my-2">Service provision</h2>
+                            <p className="text-base text-darkGunMetal mt-1 mx-2">
                                 AsyncAPI Initiative relies on numerous tools, many of which incur costs. Your organization can provide services such as hosting or storage to support our efforts.
                             </p>
                         </div>
                         
-                        <div class="bg-white rounded-md shadow-md p-4 flex flex-col items-center text-center">
-                            <img src="/img/illustrations/EventOrganization.webp" alt="Event organization" class="w-1/3 h-auto object-cover m-2" />
-                            <h2 class="text-2xl font-semibold my-2">Event organization</h2>
-                            <p class="text-base text-darkGunMetal mt-1 mx-2">
+                        <div className="bg-white rounded-md shadow-md p-4 flex flex-col items-center text-center">
+                            <img src="/img/illustrations/EventOrganization.webp" alt="Event organization" className="w-1/3 h-auto object-cover m-2" />
+                            <h2 className="text-2xl font-semibold my-2">Event organization</h2>
+                            <p className="text-base text-darkGunMetal mt-1 mx-2">
                                 Host AsyncAPI conferences by sponsoring and organizing events under the AsyncAPI brand at your provided venue.
                             </p>
                         </div>
-
-
                     </div>
-
                 </div>
             </div>
         </div>

--- a/components/FinancialSummary/SponsorshipTiers.js
+++ b/components/FinancialSummary/SponsorshipTiers.js
@@ -6,13 +6,13 @@ export default function SponsorshipTiers() {
         <div className="grid lg:grid-cols-9 lg:gap-8 px-4 sm:px-6 lg:px-8 lg:text-center mt-16 bg-purple-100">
             <div className="col-start-2 col-span-7 my-12">
                 <div id="sponsorship" className="mx-2">
-                    <Heading level="h1" typeStyle="heading-md my-3 mx-3 text-base">
-                        <h1 id="sponsorship-tiers" className="md:text-4xl">Sponsorship Tiers</h1>
+                    <Heading level="h1" typeStyle="heading-lg" className='my-3 text-base'>
+                        Sponsorship Tiers
                     </Heading>
 
                     <Paragraph typeStyle="body-md" className="my-3 max-w-4xl mx-auto text-base text-darkGunMetal">
-                        AsyncAPI offers various sponsorship tiers, each with its own set <br class="hidden lg:inline-block"></br>
-                        of benefits and privileges. These tiers include Bronze, Silver,<br class="hidden lg:inline-block"></br>
+                        AsyncAPI offers various sponsorship tiers, each with its own set <br className="hidden lg:inline-block" />
+                        of benefits and privileges. These tiers include Bronze, Silver,<br className="hidden lg:inline-block" />
                         Gold, and Platinum.
                     </Paragraph>
                 </div>
@@ -22,39 +22,38 @@ export default function SponsorshipTiers() {
                         <table className="my-8 w-full max-w-full border-collapse border border-gray-500">
                             <thead className="bg-[#805CDA] text-lg text-white">
                                 <tr>
-                                    <th className="border border-gray-500 md:px-6 md:py-4 md:px-10 md:py-6 md:text-2xl">Tiers</th>
-                                    <th className="border border-gray-500 md:px-6 md:py-4 md:px-10 md:py-6 md:text-2xl">Amounts</th>
-                                    <th className="border border-gray-500 md:px-6 md:py-4 md:px-10 md:py-6 md:text-2xl">Benefits</th>
+                                    <th className="border border-gray-500 md:px-10 md:py-6 md:text-2xl">Tiers</th>
+                                    <th className="border border-gray-500 md:px-10 md:py-6 md:text-2xl">Amounts</th>
+                                    <th className="border border-gray-500 md:px-10 md:py-6 md:text-2xl">Benefits</th>
                                 </tr>
-
                             </thead>
 
                             <tbody className="text-sm font-normal">
                                 <tr>
-                                    <td className="border border-gray-500 p-2 md:px-6 md:py-2 md:px-10 md:py-4 md:text-base text-darkGunMetal text-left">Bronze</td>
-                                    <td className="border border-gray-500 p-2 md:px-6 md:py-2 md:px-10 md:py-4 md:text-base text-darkGunMetal">$100/month</td>
-                                    <td className="border border-gray-500 p-2 md:px-6 md:py-2 md:px-10 md:py-4 text-left md:text-base text-darkGunMetal">
+                                    <td className="border border-gray-500 p-2 md:py-2 md:px-10 md:text-base text-darkGunMetal text-left">Bronze</td>
+                                    <td className="border border-gray-500 p-2 md:py-2 md:px-10 md:text-base text-darkGunMetal">$100/month</td>
+                                    <td className="border border-gray-500 p-2 md:py-2 md:px-10 text-left md:text-base text-darkGunMetal">
                                         Company logo in README on GitHub
                                     </td>
                                 </tr>
                                 <tr>
-                                    <td className="border border-gray-500 p-2 md:px-6 md:py-2 md:px-10 md:py-4 md:text-base text-darkGunMetal text-left">Silver</td>
-                                    <td className="border border-gray-500 p-2 md:px-6 md:py-2 md:px-10 md:py-4 md:text-base text-darkGunMetal">$500/month</td>
-                                    <td className="border border-gray-500 p-2 md:px-6 md:py-2 md:px-10 md:py-4 text-left md:text-base text-darkGunMetal">
+                                    <td className="border border-gray-500 p-2 md:py-2 md:px-10 md:text-base text-darkGunMetal text-left">Silver</td>
+                                    <td className="border border-gray-500 p-2 md:py-2 md:px-10 md:text-base text-darkGunMetal">$500/month</td>
+                                    <td className="border border-gray-500 p-2 md:py-2 md:px-10 text-left md:text-base text-darkGunMetal">
                                         Company logo in README on GitHub and asyncapi.com
                                     </td>
                                 </tr>
                                 <tr>
-                                    <td className="border border-gray-500 p-2 md:px-6 md:py-2 md:px-10 md:py-4 md:text-base text-darkGunMetal text-left">Gold</td>
-                                    <td className="border border-gray-500 p-2 md:px-6 md:py-2 md:px-10 md:py-4 md:text-base text-darkGunMetal">$1000/month</td>
-                                    <td className="border border-gray-500 p-2 md:px-6 md:py-2 md:px-10 md:py-4 md:text-left text-base text-darkGunMetal">
+                                    <td className="border border-gray-500 p-2 md:py-2 md:px-10 md:text-base text-darkGunMetal text-left">Gold</td>
+                                    <td className="border border-gray-500 p-2 md:py-2 md:px-10 md:text-base text-darkGunMetal">$1000/month</td>
+                                    <td className="border border-gray-500 p-2 md:py-2 md:px-10 md:text-left text-base text-darkGunMetal">
                                         Company logo in README on GitHub and asyncapi.com
                                     </td>
                                 </tr>
                                 <tr>
-                                    <td className="border border-gray-500 p-2 md:px-6 md:py-2 md:px-10 md:py-4 md:text-base text-darkGunMetal">Platinum</td>
-                                    <td className="border border-gray-500 p-2 md:px-6 md:py-2 md:px-10 md:py-4 md:text-base text-darkGunMetal">$2000/month</td>
-                                    <td className="border border-gray-500 p-2 md:px-6 md:py-2 md:px-10 md:py-4 text-left md:text-base text-darkGunMetal">
+                                    <td className="border border-gray-500 p-2 md:py-2 md:px-10 md:text-base text-darkGunMetal">Platinum</td>
+                                    <td className="border border-gray-500 p-2 md:py-2 md:px-10 md:text-base text-darkGunMetal">$2000/month</td>
+                                    <td className="border border-gray-500 p-2 md:py-2 md:px-10 text-left md:text-base text-darkGunMetal">
                                         Company logo in README on GitHub and asyncapi.com.
                                         Up to 2 hours of support per month. Support will be
                                         remote with the option of a shared screen or via private chat.

--- a/components/FinancialSummary/SuccessStories.js
+++ b/components/FinancialSummary/SuccessStories.js
@@ -1,6 +1,3 @@
-import Heading from '../typography/Heading'
-import Paragraph from '../typography/Paragraph'
-
 export default function SuccessStories() {
     return (
         <div className="px-4 sm:px-6 lg:px-8 bg-purple-100">
@@ -21,7 +18,7 @@ export default function SuccessStories() {
                             <p className="text-base text-darkGunMetal">
                                 With the addition of a dedicated Community Manager, we now have a monthly newsletter,
                                 regular status updates, an active social media presence, and the ability to drive
-                                initiatives such as event organization.
+                                initiatives such as event organization. Dedicated focus enables us to also focus on <a href="https://github.com/orgs/asyncapi/discussions/948" target='_blank' className="dark:text-purple-900 font-medium underline">a year to year vision</a>.
                             </p>
                         </div>
                         <div className="m-4 p-2">
@@ -35,9 +32,8 @@ export default function SuccessStories() {
                         <div className="m-4 p-2">
                             <h1 className="mb-2 text-2xl font-semibold">AsyncAPI Conference</h1>
                             <p className="text-base text-darkGunMetal">
-                                Every year we organize a conference that attracts many participants. Only last year
-                                the conference generated <span><a href="https://www.youtube.com/playlist?list=PLbi1gRlP7pijRiA32SU36hD_FW-2qyPhl" target='_blank' style={{ color: "rgb(128,92,218)", fontWeight: 700, textDecoration: "underline" }}>3k views</a></span>. We
-                                plan to do a series of events in different locations every year.
+                                Every year we organize a conference that attracts many participants. In 2022
+                                the online conference generated <a href="https://www.youtube.com/playlist?list=PLbi1gRlP7pijRiA32SU36hD_FW-2qyPhl" target='_blank' className="dark:text-purple-900 font-medium underline">3k views</a>. In 2023 we organized <a href="https://conference.asyncapi.com" target='_blank' className="dark:text-purple-900 font-medium underline">four different in person events</a>, some that was also live streamed.
                             </p>
                         </div>
                     </div>

--- a/components/FinancialSummary/SuccessStories.js
+++ b/components/FinancialSummary/SuccessStories.js
@@ -1,3 +1,5 @@
+import TextLink from '../typography/TextLink'
+
 export default function SuccessStories() {
     return (
         <div className="px-4 sm:px-6 lg:px-8 bg-purple-100">
@@ -8,7 +10,7 @@ export default function SuccessStories() {
                         Success Stories
                     </h1>
                     <p className="my-3 max-w-4xl mx-auto text-lg text-darkGunMetal text-center">
-                        Thanks to financial support we can already see many<br class="hidden lg:inline-block"></br> success stories in
+                        Thanks to financial support we can already see many<br className="hidden lg:inline-block" /> success stories in
                         the project.
                     </p>
                     </div>
@@ -18,7 +20,7 @@ export default function SuccessStories() {
                             <p className="text-base text-darkGunMetal">
                                 With the addition of a dedicated Community Manager, we now have a monthly newsletter,
                                 regular status updates, an active social media presence, and the ability to drive
-                                initiatives such as event organization. Dedicated focus enables us to also focus on <a href="https://github.com/orgs/asyncapi/discussions/948" target='_blank' className="dark:text-purple-900 font-medium underline">a year to year vision</a>.
+                                initiatives such as event organization. Dedicated focus enables us to also focus on  <TextLink href='https://github.com/orgs/asyncapi/discussions/948' target='_blank' className='text-violet'>a year to year vision</TextLink>.
                             </p>
                         </div>
                         <div className="m-4 p-2">
@@ -33,11 +35,10 @@ export default function SuccessStories() {
                             <h1 className="mb-2 text-2xl font-semibold">AsyncAPI Conference</h1>
                             <p className="text-base text-darkGunMetal">
                                 Every year we organize a conference that attracts many participants. In 2022
-                                the online conference generated <a href="https://www.youtube.com/playlist?list=PLbi1gRlP7pijRiA32SU36hD_FW-2qyPhl" target='_blank' className="dark:text-purple-900 font-medium underline">3k views</a>. In 2023 we organized <a href="https://conference.asyncapi.com" target='_blank' className="dark:text-purple-900 font-medium underline">four different in person events</a>, some that was also live streamed.
+                                the online conference generated <TextLink href="https://www.youtube.com/playlist?list=PLbi1gRlP7pijRiA32SU36hD_FW-2qyPhl" target='_blank' className='text-violet'>3k views</TextLink>. In 2023 we organized <TextLink href="https://conference.asyncapi.com" target='_blank' className='text-violet'>four different in person events</TextLink>, some that was also live streamed.
                             </p>
                         </div>
                     </div>
-
                 </div>
             </div>
         </div>

--- a/components/icons/Twitter.js
+++ b/components/icons/Twitter.js
@@ -5,7 +5,7 @@ export default function IconTwitter({ className }) {
         fillRule="evenodd"
         d="M714.163 519.284L1160.89 0H1055.03L667.137 450.887L357.328 0H0L468.492 681.821L0 1226.37H105.866L515.491 750.218L842.672 1226.37H1200L714.137 519.284H714.163ZM569.165 687.828L521.697 619.934L144.011 79.6944H306.615L611.412 515.685L658.88 583.579L1055.08 1150.3H892.476L569.165 687.854V687.828Z"
         fill="currentColor"
-        clip-fillRule="evenodd" >
+        clip-fillrule="evenodd" >
         </path>
     </svg>
   )

--- a/config/finance/2023/Expenses.yml
+++ b/config/finance/2023/Expenses.yml
@@ -1,5 +1,5 @@
 January:
-  - Category: AsyncAPI Ambassador
+  - Category: Ambassador Program
     Amount: '68.95'
   - Category: Google Season of Docs 2022
     Amount: '35.62'
@@ -13,13 +13,13 @@ January:
     Amount: '1500'
 
 February:
-  - Category: Community Manager Salary
+  - Category: Community Manager
     Amount: '1000.39'
   - Category: AsyncAPI Mentorship 2022
     Amount: '1500'
 
 March:
-  - Category: Community Manager Salary
+  - Category: Community Manager
     Amount: '2000.39'
   - Category: AsyncAPI Mentorship 2022
     Amount: '1500'
@@ -27,48 +27,81 @@ March:
     Amount: '1500'
 
 April:
-  - Category: Community Manager Salary
+  - Category: Community Manager
     Amount: '2000.39'
 
 May:
-  - Category: Community Manager Salary
+  - Category: Community Manager
     Amount: '2000.39'
-  - Category: "AsyncAPI Webstore"
+  - Category: Swag Store
     Amount: '75.11'
-  - Category: AsyncAPI Bounty
+  - Category: Bounty Program
     Amount: '400'
 
 June:
-  - Category: Community Manager Salary
+  - Category: Community Manager
     Amount: '2000.39'
-  - Category: AsyncAPI Bounty
+  - Category: Bounty Program
     Amount: '200'
   - Category: 3rd Party Services
     Amount: '28.31'
-  - Category: AsyncAPI Bounty
+  - Category: Bounty Program
     Amount: '200'
-  - Category: AsyncAPI Bounty
+  - Category: Bounty Program
     Amount: '200'
-  - Category: AsyncAPI Bounty
+  - Category: Bounty Program
     Amount: '200'
 
 July:
-  - Category: Community Manager Salary
+  - Category: Community Manager
     Amount: '2000.39'
-  - Category: 3rd Party Services
-    Amount: '1088.27'
-  - Category: AsyncAPI Bounty
+  - Category: Bounty Program
     Amount: '400'
+
 August:
-  - Category: AsyncAPI Webstore
-    Amount: '15671.63'
-  - Category: AsyncAPI Bounty
-    Amount: '400'
-  - Category: Community Manager Salary
-    Amount: '2000'
+  - Category: 3rd Party Services
+    Amount: '1093.92'
+  - Category: Swag Store
+    Amount: '15672.02'
+  - Category: Bounty Program
+    Amount: '800.78'
+  - Category: Community Manager
+    Amount: '2000.39'
     
 September:
-  - Category: AsyncAPI Ambassador
-    Amount: '129.48'
-  - Category: Community Manager Salary
-    Amount: '2000'
+  - Category: Ambassador Program
+    Amount: '139.10'
+  - Category: Community Manager
+    Amount: '2000.39'
+
+October:
+  - Category: Mentorship Program 2023
+    Amount: '5277.78'
+  - Category: Community Manager
+    Amount: '2000.39'
+  - Category: AsyncAPI Conf on Tour 2023
+    Amount: '943.07'
+  - Category: Swag Store
+    Amount: '7893.72'
+  - Category: 3rd Party Services
+    Amount: '247.04'
+
+November:
+  - Category: Mentorship Program 2023
+    Amount: '1363.50'
+  - Category: Community Manager
+    Amount: '2000.39'
+  - Category: Swag Store
+    Amount: '873.87'
+
+December:
+  - Category: Mentorship Program 2023
+    Amount: '675.39'
+  - Category: Community Manager
+    Amount: '2000.39'
+  - Category: AsyncAPI Conf on Tour 2023
+    Amount: '1356.34'
+  - Category: Swag Store
+    Amount: '1415.90'
+  - Category: Bounty Program
+    Amount: '201.10'

--- a/config/finance/2023/ExpensesLink.yml
+++ b/config/finance/2023/ExpensesLink.yml
@@ -1,4 +1,4 @@
-- category: "AsyncAPI Ambassador"
+- category: "Ambassador Program"
   link: "https://github.com/orgs/asyncapi/discussions/425"
 
 - category: "Google Season of Docs 2022"
@@ -7,14 +7,21 @@
 - category: "AsyncAPI Mentorship 2022"
   link: "https://github.com/orgs/asyncapi/discussions/284"
 
-- category: "AsyncAPI Webstore"
+- category: "Swag Store"
   link: "https://github.com/orgs/asyncapi/discussions/710"
 
-- category: "AsyncAPI Bounty"
+- category: "Bounty Program"
   link: "https://github.com/orgs/asyncapi/discussions/541"
 
 - category: "3rd Party Services"
   link: "https://github.com/orgs/asyncapi/discussions/295"
 
-- category: "Community Manager Salary"
+- category: "Community Manager"
   link: "https://github.com/orgs/asyncapi/discussions/515"
+
+- category: "AsyncAPI Conf on Tour 2023"
+  link: "https://github.com/orgs/asyncapi/discussions/598"
+
+- category: "Mentorship Program 2023"
+  link: "https://github.com/orgs/asyncapi/discussions/689"
+ 


### PR DESCRIPTION
- reflect current status of finance expenses
- one small fix on links in success stories - we should not have custom styles and always match tailwind. Just small stuff, other links are strange as well - while writing tests @vishvamsinh28 will probably need to do some refactor and have a dedicated link component for other sections of finance page


style of links 

before
![Screenshot 2023-12-20 at 17 36 07](https://github.com/asyncapi/website/assets/6995927/37c45635-2d29-4f81-978c-b926b41e58eb)


after
![Screenshot 2023-12-20 at 18 38 18](https://github.com/asyncapi/website/assets/6995927/7d28d685-325e-42bf-80cc-a71c90645976)
