### PR TITLE
fix: fixed typo and added relevant links to components of Expense Breakdown section in Finance Page 

### DIFF
--- a/components/FinancialSummary/ExpenseBreakdown.js
+++ b/components/FinancialSummary/ExpenseBreakdown.js
@@ -19,63 +19,75 @@ export default function ExpenseBreakdown() {
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-10 mt-8 mx-3">
 
                         <div className="bg-white rounded-md shadow-md p-4 flex flex-col items-center">
-                            <div className="text-darkGunMetal">
-                                <div className="flex flex-col items-center">
-                                    <img src="/img/illustrations/MentorshipProgram.webp" alt="Mentorship Program" className="w-1/5 h-auto object-cover rounded-md m-1" />
-                                    <h2 className="text-2xl font-semibold my-2 text-center text-darkGunMetal">Mentorship Program</h2>
+                            <a href="https://www.asyncapi.com/blog/beyond-boundaries" target="_blank">
+                                <div className="text-darkGunMetal">
+                                    <div className="flex flex-col items-center">
+                                        <img src="/img/illustrations/MentorshipProgram.webp" alt="Mentorship Program" className="w-1/5 h-auto object-cover rounded-md m-1" />
+                                        <h2 className="text-2xl font-semibold my-2 text-center text-darkGunMetal">Mentorship Program</h2>
+                                    </div>
+                                    <p className="text-base text-center text-darkGunMetal">Our AsyncAPI Mentorship program offers paid guidance to develop valuable features, investing in tools and motivated individuals for community benefit.</p>
                                 </div>
-                                <p className="text-base text-center text-darkGunMetal">Our AsyncAPI Mentorship program offers paid guidance to develop valuable features, investing in tools and motivated individuals for community benefit.</p>
-                            </div>
+                            </a>
                         </div>
 
                         <div className="bg-white rounded-md shadow-md p-4 flex flex-col items-center">
-                            <div className="text-darkGunMetal">
-                                <div className="flex flex-col items-center">
-                                    <img src="/img/illustrations/BountyProgram.webp" alt="Bounty Program" className="w-1/5 h-auto object-cover rounded-md m-1" />
-                                    <h2 className="text-2xl text-center font-semibold my-2 text-darkGunMetal">Bounty Program</h2>
+                            <a href="https://github.com/orgs/asyncapi/discussions/541" target="_blank">
+                                <div className="text-darkGunMetal">
+                                    <div className="flex flex-col items-center">
+                                        <img src="/img/illustrations/BountyProgram.webp" alt="Bounty Program" className="w-1/5 h-auto object-cover rounded-md m-1" />
+                                        <h2 className="text-2xl text-center font-semibold my-2 text-darkGunMetal">Bounty Program</h2>
+                                    </div>
+                                    <p className="text-base text-center text-darkGunMetal">Rewarding contributors regardless of affiliation or volunteer status. Free mentoring and support for newcomers to build portfolios and unlock tech prospects.</p>
                                 </div>
-                                <p className="text-base text-center text-darkGunMetal">Rewarding contributors regardless of affiliation or volunteer status. Free mentoring and support for newcomers to build portfolios and unlock tech prospects.</p>
-                            </div>
+                            </a>
                         </div>
 
                         <div className="bg-white rounded-md shadow-md p-4 flex flex-col items-center">
-                            <div className="text-darkGunMetal">
-                                <div className="flex flex-col items-center">
-                                    <img src="/img/illustrations/Events.webp" alt="Events" className="w-1/5 h-auto object-cover rounded-md m-1" />
-                                    <h2 className="text-2xl text-center font-semibold my-2 text-darkGunMetal">Events</h2>
+                            <a href="https://www.asyncapi.com/community/events" target="_blank">
+                                <div className="text-darkGunMetal">
+                                    <div className="flex flex-col items-center">
+                                        <img src="/img/illustrations/Events.webp" alt="Events" className="w-1/5 h-auto object-cover rounded-md m-1" />
+                                        <h2 className="text-2xl text-center font-semibold my-2 text-darkGunMetal">Events</h2>
+                                    </div>
+                                    <p className="text-base text-center text-darkGunMetal">Supporting AsyncAPI conferences incurs costs for services and travel arrangements. Your contributions facilitate event hosting and community growth.</p>
                                 </div>
-                                <p className="text-base text-center text-darkGunMetal">Supporting AsyncAPI conferences incurs costs for services and travel arrangements. Your contributions facilitate event hosting and community growth.</p>
-                            </div>
+                            </a>
                         </div>
 
                         <div className="bg-white rounded-md shadow-md p-4 flex flex-col items-center">
-                            <div className="text-darkGunMetal">
-                                <div className="flex flex-col items-center">
-                                    <img src="/img/illustrations/SwagStore.webp" alt="Swag Store" className="w-1/5 h-auto object-cover rounded-md m-1" />
-                                    <h2 className="text-2xl font-semibold my-2 text-center text-darkGunMetal">Swag Store</h2>
+                            <a href="https://www.store.asyncapi.com/collections/all-productsy" target="_blank">
+                                <div className="text-darkGunMetal">
+                                    <div className="flex flex-col items-center">
+                                        <img src="/img/illustrations/SwagStore.webp" alt="Swag Store" className="w-1/5 h-auto object-cover rounded-md m-1" />
+                                        <h2 className="text-2xl font-semibold my-2 text-center text-darkGunMetal">Swag Store</h2>
+                                    </div>
+                                    <p className="text-base text-center text-darkGunMetal">Creating a swag store for seamless distribution to contributors, mentees, ambassadors, and community members. Store profits can fund complimentary swag expenses.</p>
                                 </div>
-                                <p className="text-base text-center text-darkGunMetal">Creating a swag store for seamless distribution to contributors, mentees, ambassadors, and community members. Store profits can fund complimentary swag expenses.</p>
-                            </div>
+                            </a>
                         </div>
 
                         <div className="bg-white rounded-md shadow-md p-4 flex flex-col items-center">
-                            <div className="text-darkGunMetal">
-                                <div className="flex flex-col items-center">
-                                    <img src="/img/illustrations/Hiring.webp" alt="Hiring" className="w-1/5 h-auto object-cover rounded-md m-1" />
-                                    <h2 className="text-2xl font-semibold my-2 text-center text-darkGunMetal">Hiring</h2>
+                            <a href="https://opencollective.com" target="_blank">
+                                <div className="text-darkGunMetal">
+                                    <div className="flex flex-col items-center">
+                                        <img src="/img/illustrations/Hiring.webp" alt="Hiring" className="w-1/5 h-auto object-cover rounded-md m-1" />
+                                        <h2 className="text-2xl font-semibold my-2 text-center text-darkGunMetal">Hiring</h2>
+                                    </div>
+                                    <p className="text-base text-center text-darkGunMetal">To support our community, we require full time commitment. Open Collective helps us hire for AsyncAPI. <a style={{ textDecoration: "underline" }} href="https://www.linkedin.com/in/v-thulisile-sibanda/" target='_blank'>Thulie</a> joins as community manager, with plans to expand our team.</p>
                                 </div>
-                                <p className="text-base text-center text-darkGunMetal">To support our community, we require full time commitment. Open Collective helps us hire for AsyncAPI. <a style={{ textDecoration: "underline" }} href="https://www.linkedin.com/in/v-thulisile-sibanda/" target='_blank'>Thulie</a> joins as community manager, with plans to expand the team. our team</p>
-                            </div>
+                            </a>
                         </div>
 
                         <div className="bg-white rounded-md shadow-md p-4 flex flex-col items-center">
-                            <div className="text-darkGunMetal">
-                                <div className="flex flex-col items-center">
-                                    <img src="/img/illustrations/Services.webp" alt="Services" className="w-1/5 h-auto object-cover rounded-md m-1" />
-                                    <h2 className="text-2xl font-semibold my-2 text-center text-darkGunMetal">Services</h2>
+                            <a href="https://zoom.us/pricing" target="_blank">
+                                <div className="text-darkGunMetal">
+                                    <div className="flex flex-col items-center">
+                                        <img src="/img/illustrations/Services.webp" alt="Services" className="w-1/5 h-auto object-cover rounded-md m-1" />
+                                        <h2 className="text-2xl font-semibold my-2 text-center text-darkGunMetal">Services</h2>
+                                    </div>
+                                    <p className="text-base text-center text-darkGunMetal">Occasionally, we must pay for services such as Zoom or Descript, as they are not available through specific Open Source support programs.</p>
                                 </div>
-                                <p className="text-base text-center text-darkGunMetal">Occasionally, we must pay for services such as Zoom or Descript, as they are not available through specific Open Source support programs.</p>
-                            </div>
+                            </a>
                         </div>
 
                     </div>


### PR DESCRIPTION
Fixes #2482 
Before : 
![before](https://github.com/asyncapi/website/assets/95705739/cf37a4ba-ca92-46f9-aab7-bb5ba91f968d)

After: 
![after](https://github.com/asyncapi/website/assets/95705739/3a8632cb-f319-4dbe-a26c-afe7296312eb)


Links to Components : 

mentorship program 
https://www.asyncapi.com/blog/beyond-boundaries

bounty program 
https://github.com/orgs/asyncapi/discussions/541

events
https://www.asyncapi.com/community/events

swag store 
https://www.store.asyncapi.com/collections/all-productsy

hiring
https://opencollective.com/

services
https://zoom.us/pricing
