### PR TITLE
docs: highlight <code/>, correct typos and servers.md <CodeBlock/>

### DIFF
--- a/pages/docs/tutorials/getting-started/asyncapi-documents.md
+++ b/pages/docs/tutorials/getting-started/asyncapi-documents.md
@@ -9,7 +9,7 @@ weight: 101
 
 An AsyncAPI document is a file that defines and annotates the different components of **a specific Event-Driven API**.
 
-The file format must be JSON or YAML; however, only the subset of YAML that matches the JSON capabilities is allowed.
+The file format must be [JSON](https://www.json.org/json-en.html) or [YAML](https://yaml.org/); however, only the subset of YAML that matches the JSON capabilities is allowed. Below we have an example AsyncAPI document in YAML file format.
 
 <CodeBlock>
 {`asyncapi: 3.0.0

--- a/pages/docs/tutorials/getting-started/hello-world.md
+++ b/pages/docs/tutorials/getting-started/hello-world.md
@@ -25,7 +25,7 @@ operations:
       $ref: '#/channels/hello'`}
 </CodeBlock>
 
-Let's get into the details of this sample AsyncAPI document:
+Let's get into the details of this sample [AsyncAPI document](../../concepts/asyncapi-document):
 
 <CodeBlock highlightedLines={[1]}>
 {`asyncapi: 3.0.0

--- a/pages/docs/tutorials/getting-started/request-reply.md
+++ b/pages/docs/tutorials/getting-started/request-reply.md
@@ -3,7 +3,7 @@ title: Request/reply pattern
 weight: 40
 ---
 
-In this tutorial, you'll learn how to implement the request/reply pattern in an AsyncAPI document using a straightforward pong-pong example.
+In this tutorial, you'll learn how to implement the request/reply pattern in an AsyncAPI document using a straightforward ping-pong example.
 
 Before we begin, it would be beneficial for you to have a basic understanding of AsyncAPI and Event-Driven Architectures (EDA). If you need a refresher, refer to our [Event-Driven Architecture](/docs/tutorials/getting-started/event-driven-architectures) document.
 

--- a/pages/docs/tutorials/getting-started/servers.md
+++ b/pages/docs/tutorials/getting-started/servers.md
@@ -11,7 +11,7 @@ In the previous lesson, you learned how to create the definition of a simple [He
 
 In this tutorial, you'll learn how to add `servers` to your AsyncAPI document. Adding and defining servers is useful because it specifies where and how to connect. The connection facilitates where to send and receive messages.
 
-<CodeBlock highlightedLines={[6,7,8,9,10]}>
+<CodeBlock highlightedLines={[5,6,7,8,9]}>
 {`asyncapi: 3.0.0
 info:
   title: Hello world application

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -341,3 +341,7 @@ abbr[title] {
 .meeting-card:hover > div:nth-child(2) > p  {
   color: white;
 }
+
+code{
+  font-weight: bold;
+}


### PR DESCRIPTION

**Description**

-  __Enhancement:__ The code tags should appear bold everywhere in the docs
-  __Typo:__ Found some typos in tutorials + missing of proper redirects.
-  __Fix:__ The Codeblock in servers.md in not hightlighted correctly.

**Related issue(s)**
Fixes #2522 