### PR TITLE
fix: edge function should not operate if not targeting definition files

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,12 +166,11 @@ This is possible thanks to the following:
   Please find a flowchart explaining the flow this edge function should accomplish:
   ```mermaid
   flowchart TD
-    Request(Request) -->legitimate{Is it legitimate?}
-    legitimate -->|No| req_no_legitimate[Let the original request go through]
-    req_no_legitimate --> Response(Response)
-    
-    legitimate -->|Yes| req_legitimate[Fetch from GitHub]
-    req_legitimate-->req_json{Was requesting a .json file?}
+    Request(Request) -->schema-related{Is it requesting Schemas?}
+    schema-related -->|No| req_no_schemas[Let the original request go through]
+    req_no_schemas --> Response(Response)
+    schema-related -->|Yes| req_schemas[Fetch from GitHub]
+    req_schemas-->req_json{Was requesting a .json file?}
     
     req_json -->|No| Response(Response)
     req_json -->|Yes| response_status{Response Status?}

--- a/netlify/edge-functions/serve-definitions.ts
+++ b/netlify/edge-functions/serve-definitions.ts
@@ -7,21 +7,21 @@ const NR_METRICS_ENDPOINT = Deno.env.get("NR_METRICS_ENDPOINT") || "https://metr
 const URL_DEST_SCHEMAS = "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/master/schemas";
 const URL_DEST_DEFINITIONS = "https://raw.githubusercontent.com/asyncapi/spec-json-schemas/master/definitions";
 
-// Legitimate request:
+// Schemas-related request:
 //   Patterns: /<source> OR /<source>/<file> OR /<source>/<version>/<file>
 //   Examples: /definitions OR /schema-store/2.5.0-without-$id.json OR /definitions/2.4.0/info.json
-// Non-legitimate request:
+// Schemas-unrelated request:
 //   Patterns: /<source>/<randompath>/*
 //   Examples: /definitions/asyncapi.yaml OR /schema-store/2.4.0.JSON (uppercase)
 //
-// Non-legitimate requests should not use our GitHub Token and affect the rate limit. Those shouldn't send metrics to NR either as they just add noise.
-const legitimateRequestRegex = /^\/[\w\-]*\/?(?:([\w\-\.]*\/)?([\w\-$%\.]*\.json))?$/
+// Schemas-unrelated requests should not use our GitHub Token and affect the rate limit. Those shouldn't send metrics to NR either as they just add noise.
+const SchemasRelatedRequestRegex = /^\/[\w\-]*\/?(?:([\w\-\.]*\/)?([\w\-$%\.]*\.json))?$/
 
 export default async (request: Request, context: Context) => {
   let rewriteRequest = buildRewrite(request);
   let response: Response;
   if (rewriteRequest === null) {
-    // This is not a legitimate request, let it go through.
+    // This is a Schema-unrelated request. Let it go through and do not intercept it.
     return await context.next();
   }
 
@@ -68,7 +68,7 @@ export default async (request: Request, context: Context) => {
 };
 
 function buildRewrite(originalRequest: Request): (Request | null) {
-  const extractResult = legitimateRequestRegex.exec(new URL(originalRequest.url).pathname);
+  const extractResult = SchemasRelatedRequestRegex.exec(new URL(originalRequest.url).pathname);
   if (extractResult === null) {
     return null;
   }

--- a/netlify/edge-functions/serve-definitions.ts
+++ b/netlify/edge-functions/serve-definitions.ts
@@ -21,13 +21,12 @@ export default async (request: Request, context: Context) => {
   let rewriteRequest = buildRewrite(request);
   let response: Response;
   if (rewriteRequest === null) {
-    rewriteRequest = request;
-
-    response = await context.next();
-  } else {
-    // Fetching the definition file
-    response = await fetch(rewriteRequest);
+    // This is not a legitimate request, let it go through.
+    return await context.next();
   }
+
+  // Fetching the definition file
+  response = await fetch(rewriteRequest);
 
   const isRequestingAFile = request.url.endsWith('.json');
   if (isRequestingAFile) {
@@ -56,6 +55,7 @@ export default async (request: Request, context: Context) => {
         default:
           // Notifying NR of the error.
           metricName = "asyncapi.jsonschema.download.error";
+          console.log("Error downloading JSON Schema file: " + response.status + " " + response.statusText);
           break;
       }
     }


### PR DESCRIPTION
**Description**

This PR fixes the Netlify edge-function we use for serving JSON Schema files through our website. See [this README section](https://github.com/asyncapi/website?tab=readme-ov-file#json-schema-definitions).
The main logic of this edge-function was being executed for non-legitimate requests (requests that should just pass through).

Additionally, I'm adding a mermaid flowchart documenting the flow this edge-function should accomplish. 

**Related issue(s)**
https://github.com/asyncapi/website/pull/2493