### PR TITLE
docs: add docs triagers to codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@
 * @derberg @akshatnema @magicmatatjahu @mayaleeeee @asyncapi-bot-eve
 
 # All .md files
-*.md @alequetzalli @asyncapi-bot-eve
+*.md @alequetzalli @octonawish-akcodes @BhaswatiRoy @TRohit20 @VaishnaviNandakumar @Arya-Gupta @J0SAL @asyncapi-bot-eve 
 
 pages/blog/*.md @thulieblack @alequetzalli
 pages/community/*.md @thulieblack @alequetzalli


### PR DESCRIPTION
I'm excited and proud to nominate the following docs contributors to be granted triager rights:
https://github.com/asyncapi/website/issues/2586#issuecomment-1909124598 
