### PR TITLE
fix: fixed typo in the MAINTAINERS.json file

### DIFF
--- a/config/MAINTAINERS.json
+++ b/config/MAINTAINERS.json
@@ -700,7 +700,7 @@
     },
     {
         "name": "Sambhav Gupta",
-        "g705ithub": "sambhavgupta0705",
+        "github": "sambhavgupta0705",
         "linkedin": "sambhavgupta0705",
         "twitter": "sambhavgupta75",
         "slack": "U04630DU3N3",


### PR DESCRIPTION
Fixes #2633 

fixed typo in the MAINTAINERS.json file that was causing Flaky pages/community/tsc.cy.js test failure on some cypress-runs.