### PR TITLE
fix: update env variable names on Head

### DIFF
--- a/components/Head.js
+++ b/components/Head.js
@@ -1,5 +1,4 @@
 import { useContext, useEffect } from 'react';
-import Head from 'next/head';
 import AppContext from '../context/AppContext';
 import ReactGA from 'react-ga';
 import TagManager from 'react-gtm-module';
@@ -11,8 +10,7 @@ export default function HeadComponent({
   rssTitle = 'RSS Feed for AsyncAPI Initiative Blog',
   rssLink = '/rss.xml',
 }) {
-  // const url = process.env.NEXT_PUBLIC_DEPLOY_PRIME_URL || process.env.NEXT_PUBLIC_DEPLOY_URL || 'http://localhost:8888';
-  const url = 'https://asyncapi.com'
+  const url = process.env.NEXT_PUBLIC_DEPLOY_PRIME_URL || process.env.NEXT_PUBLIC_DEPLOY_URL || 'http://localhost:3000';
   const appContext = useContext(AppContext);
   const { path = '' } = appContext || {};
 
@@ -39,7 +37,7 @@ export default function HeadComponent({
 
 
   return (
-    <Head>
+      <>
       <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
       <meta httpEquiv="x-ua-compatible" content="ie=edge" />
       <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
@@ -76,6 +74,6 @@ export default function HeadComponent({
       <meta property="og:description" content={description} />
 
       <title>{title}</title>
-    </Head>
+      </>
   );
 }

--- a/components/Head.js
+++ b/components/Head.js
@@ -11,7 +11,7 @@ export default function HeadComponent({
   rssTitle = 'RSS Feed for AsyncAPI Initiative Blog',
   rssLink = '/rss.xml',
 }) {
-  const url = process.env.DEPLOY_PRIME_URL || process.env.DEPLOY_URL || 'http://localhost:3000';
+  const url = process.env.NEXT_PUBLIC_DEPLOY_PRIME_URL || process.env.NEXT_PUBLIC_DEPLOY_URL || 'http://localhost:3000';
   const appContext = useContext(AppContext);
   const { path = '' } = appContext || {};
 
@@ -31,7 +31,7 @@ export default function HeadComponent({
 
   //enable google analytics
   if (typeof window !== 'undefined' && window.location.hostname.includes('asyncapi.com')) {
-    TagManager.initialize({gtmId: 'GTM-T58BTVQ'})
+    TagManager.initialize({ gtmId: 'GTM-T58BTVQ' })
     ReactGA.initialize('UA-109278936-1')
     ReactGA.pageview(window.location.pathname + window.location.search)
   }

--- a/components/Head.js
+++ b/components/Head.js
@@ -10,7 +10,7 @@ export default function HeadComponent({
   rssTitle = 'RSS Feed for AsyncAPI Initiative Blog',
   rssLink = '/rss.xml',
 }) {
-  const url = process.env.NEXT_PUBLIC_DEPLOY_PRIME_URL || process.env.NEXT_PUBLIC_DEPLOY_URL || 'http://localhost:3000';
+  const url = process.env.DEPLOY_PRIME_URL || process.env.DEPLOY_URL || 'http://localhost:3000';
   const appContext = useContext(AppContext);
   const { path = '' } = appContext || {};
 

--- a/components/Head.js
+++ b/components/Head.js
@@ -11,7 +11,8 @@ export default function HeadComponent({
   rssTitle = 'RSS Feed for AsyncAPI Initiative Blog',
   rssLink = '/rss.xml',
 }) {
-  const url = process.env.NEXT_PUBLIC_DEPLOY_PRIME_URL || process.env.NEXT_PUBLIC_DEPLOY_URL || 'http://localhost:3000';
+  // const url = process.env.NEXT_PUBLIC_DEPLOY_PRIME_URL || process.env.NEXT_PUBLIC_DEPLOY_URL || 'http://localhost:8888';
+  const url = 'https://asyncapi.com'
   const appContext = useContext(AppContext);
   const { path = '' } = appContext || {};
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,4 +1,5 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
+import CustomHead from '../components/Head'
 
 class MyDocument extends Document {
   static async getInitialProps(ctx) {
@@ -9,7 +10,9 @@ class MyDocument extends Document {
   render() {
     return (
       <Html lang="en">
-        <Head />
+        <Head>
+          <CustomHead />
+        </Head>
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
## Description

Currently, Next app is not able to get environment variables from the Netlify, since Next js don't allow envs to get accessed directly on the client side. Only the variable names starting with `NEXT_APP` are allowed. 

References :-
- https://stackoverflow.com/questions/72589406/nextjs-meta-tag-details-not-appearing-on-social-media-post
- https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables

Since, env weren't accessible to the client components, this raised the issue of not configuring the `meta` tags for the website. With PR changes, it is required to add a `NEXT_PUBLIC_DEPLOY_URL` or `NEXT_PUBLIC_PRIME_DEPLOY_URL` inside the Netlify environment variables.
