### PR TITLE
style: alignment on tools/cli and tools/generator

### DIFF
--- a/config/newsroom_videos.json
+++ b/config/newsroom_videos.json
@@ -1,7 +1,7 @@
 [
   {
     "image_url": "https://i.ytimg.com/vi/4t4nAmDekDA/hqdefault.jpg",
-    "title": "AACoT&#39;24 Community Meeting, Wednesday February 7th 2024",
+    "title": "AACoT'24 Community Meeting, Wednesday February 7th 2024",
     "description": "https://github.com/asyncapi/community/issues/1041.",
     "videoId": "4t4nAmDekDA"
   },

--- a/pages/[lang]/tools/cli.js
+++ b/pages/[lang]/tools/cli.js
@@ -72,7 +72,7 @@ export default function CliPage() {
                     className="block mt-2 md:mt-0 md:inline-block w-full sm:w-auto"
                     href="https://www.github.com/asyncapi/cli"
                 />
-                <Button text={t("cli.docsButton")} href="/docs/tools/cli" className="ml-2 block mt-2 md:mt-0 md:inline-block w-full sm:w-auto" />
+                <Button text={t("cli.docsButton")} href="/docs/tools/cli" className="md:ml-2 block mt-2 md:mt-0 md:inline-block w-full sm:w-auto" />
             </div>
         );
     }
@@ -156,7 +156,7 @@ export default function CliPage() {
                             </div>
 
                             <div>
-                                <Heading level="h3" typeStyle="heading-sm-semibold" className="text-center md:text-left">
+                                <Heading level="h3" typeStyle="heading-sm-semibold" className="mb-4 text-center md:text-left">
                                     {t("cli.exampleTitle")}
                                 </Heading>
                                 <div className="space-y-5">

--- a/pages/tools/generator.js
+++ b/pages/tools/generator.js
@@ -20,10 +20,10 @@ export default function GeneratorPage() {
           className="w-full mb-2 sm:w-auto sm:mb-0 sm:mr-2"
         /> */}
         <GithubButton
-          className="w-full sm:w-auto"
+          className="block mt-2 md:mt-0 md:inline-block w-full sm:w-auto"
           href="https://www.github.com/asyncapi/generator"
         />
-      <Button text="View Docs" href="/docs/tools/generator" className="ml-2 block mt-2 md:mt-0 md:inline-block w-full sm:w-auto"/>
+      <Button text="View Docs" href="/docs/tools/generator" className="md:ml-2 block mt-2 md:mt-0 md:inline-block w-full sm:w-auto"/>
       </div>
     );
   }


### PR DESCRIPTION
**Description**
This PR adds some style fixes for the tools/cli page which includes button and text margin changes.

### Before 
The button has `ml-2` class for all screen sizes, ideally it should only be added for `<md` devices. and the Example heading should have the `mb-4` class same as the above Installation heading.

![image](https://github.com/asyncapi/website/assets/71088429/8d843beb-6f0a-453a-a0e9-9ad9301d140a)
<img width="158" alt="image" src="https://github.com/asyncapi/website/assets/71088429/2141030c-43f3-41ea-8c57-f0e2d41046cd">


### After
![image](https://github.com/asyncapi/website/assets/71088429/23e6810c-f4cc-4cdb-b1aa-abe0e6e25bae)
![image](https://github.com/asyncapi/website/assets/71088429/262ee6ea-2bc2-41a3-bfbd-1c9adcdeb62c)

