### PR TITLE
style: button and heading margin on tools/cli

### DIFF
--- a/pages/[lang]/tools/cli.js
+++ b/pages/[lang]/tools/cli.js
@@ -72,7 +72,7 @@ export default function CliPage() {
                     className="block mt-2 md:mt-0 md:inline-block w-full sm:w-auto"
                     href="https://www.github.com/asyncapi/cli"
                 />
-                <Button text={t("cli.docsButton")} href="/docs/tools/cli" className="ml-2 block mt-2 md:mt-0 md:inline-block w-full sm:w-auto" />
+                <Button text={t("cli.docsButton")} href="/docs/tools/cli" className="md:ml-2 block mt-2 md:mt-0 md:inline-block w-full sm:w-auto" />
             </div>
         );
     }
@@ -156,7 +156,7 @@ export default function CliPage() {
                             </div>
 
                             <div>
-                                <Heading level="h3" typeStyle="heading-sm-semibold" className="text-center md:text-left">
+                                <Heading level="h3" typeStyle="heading-sm-semibold" className="mb-4 text-center md:text-left">
                                     {t("cli.exampleTitle")}
                                 </Heading>
                                 <div className="space-y-5">


### PR DESCRIPTION
**Description**
This PR fixes the button and heading margin on `tools/cli` page for mobile screen size. #2718 fixed the tools/generator buttons but this page issues still persist.


![image](https://github.com/asyncapi/website/assets/71088429/8d843beb-6f0a-453a-a0e9-9ad9301d140a)
<img width="158" alt="image" src="https://github.com/asyncapi/website/assets/71088429/2141030c-43f3-41ea-8c57-f0e2d41046cd">


### After
![image](https://github.com/asyncapi/website/assets/71088429/23e6810c-f4cc-4cdb-b1aa-abe0e6e25bae)
![image](https://github.com/asyncapi/website/assets/71088429/262ee6ea-2bc2-41a3-bfbd-1c9adcdeb62c)

