### PR TITLE
fix: added translation for testimonial data of Homepage

### DIFF
--- a/locales/de/landing-page.json
+++ b/locales/de/landing-page.json
@@ -69,6 +69,29 @@
         "supportedByPosttext": " für weitere Informationen."
     },
     "testimonials": {
-        "title": "Was die Experten sagen"
+        "title": "Was die Experten sagen",
+        "data": [
+            {
+                "authorName": "Matt McLarty",
+                "authorDescription": "Globaler Leiter der API-Strategy bei MuleSoft",
+                "text":"Microservices unterstreichen die Notwendigkeit einer ereignisgesteuerten Kommunikation in verteilten Architekturen. AsyncAPI bringt die Vielfalt des REST-API-Ökosystems in asynchrone APIs."
+            },
+            {
+                "authorName":"Bill Doerrfeld",
+                "authorDescription":"Chefredakteur bei Nordic APIs",
+                "text":"Auch ereignisgesteuerte APIs verdienen Aufmerksamkeit! AsyncAPI bringt die zahlreichen Vorteile einer maschinen- und menschenlesbaren Spezifikation für diese nuancierten Ansätze mit sich."
+            },
+            {
+                "authorName":"Jonathan Schabowsky",
+                "authorDescription":"Senior-Architekt im Büro des CTO bei Solace",
+                "text":"Entwickler müssen in der Lage sein, schnell und konsistent ereignisgesteuerte Anwendungen zu erstellen, die einen Mehrwert für das Geschäft bieten und in Echtzeit auf Kundenbedürfnisse reagieren. Ich kann nicht zählen, wie oft ich von Entwicklern gehört habe, die nach OpenAPI/Swagger-ähnlichen Werkzeugen für die asynchrone und ereignisgesteuerte Welt gefragt haben, und genau das ist es, was die AsyncAPI-Initiative verwirklicht."
+            },
+            {
+                "authorName":"Eric Horesnyi",
+                "authorDescription":"Geschäftsführer bei Streamdata.io",
+                "text":"Wir konzentrieren uns seit 2014 auf ereignisgesteuerte APIs und danken den Mitwirkenden von AsyncAPI jeden Tag dafür, dass sie die Community auf gemeinsame Standards hin lenken."
+            }
+    
+            ]
     }
 }

--- a/locales/en/landing-page.json
+++ b/locales/en/landing-page.json
@@ -69,6 +69,29 @@
         "supportedByPosttext": " for more info."
     },
     "testimonials": {
-        "title": "What the experts are saying"
+        "title": "What the experts are saying",
+        "data": {
+        "0":{
+            "authorName": "Matt McLarty",
+            "authorDescription": "Global Leader of API Strategy at MuleSoft",
+            "text":"Microservices underline the need for event-based communication in distributed architectures. AsyncAPI brings the richness of the REST API ecosystem to asynchronous APIs."
+        },
+        "1":{
+            "authorName":"Bill Doerrfeld",
+            "authorDescription":"Editor in Chief at Nordic APIs",
+            "text":"Event-driven APIs need love too! AsyncAPI brings the many benefits of a machine/human-readable specification to these nuanced approaches."
+        },
+        "2":{
+            "authorName":"Jonathan Schabowsky",
+            "authorDescription":"Sr. Architect, Office of the CTO at Solace",
+            "text":"Developers need to be able to quickly and consistently create event-driven applications that provide business value and react to customer needs in realtime. I can't count how many times I've heard developers ask for OpenAPI/Swagger style tools for the asynchronous and event-driven world, and that is exactly what the AsyncAPI initiative is making a reality."
+        },
+        "3":{
+            "authorName":"Eric Horesnyi",
+            "authorDescription":"CEO at Streamdata.io",
+            "text":"We’ve been focusing on event-driven APIs since 2014 and thank the AsyncAPI contributors every day for driving the community towards common standards."
+        }
+
+    }
     }
 }

--- a/pages/[lang]/index.js
+++ b/pages/[lang]/index.js
@@ -216,31 +216,31 @@ function HomePage() {
           <ul className="max-w-screen-xl mx-auto md:grid md:grid-cols-2 md:px-6 lg:px-8">
             <Testimonial
               className="md:pr-10 lg:pr-16"
-              text="Microservices underline the need for event-based communication in distributed architectures. AsyncAPI brings the richness of the REST API ecosystem to asynchronous APIs."
+              text={t('testimonials.data.0.text')}
               authorAvatar="/img/testimonials/matt-mclarty.jpg"
-              authorName="Matt McLarty"
-              authorDescription="Global Leader of API Strategy at MuleSoft"
+              authorName={t('testimonials.data.0.authorName')}
+              authorDescription={t('testimonials.data.0.authorDescription')}
             />
             <Testimonial
               className="md:pl-10 lg:pl-16"
-              text="Event-driven APIs need love too! AsyncAPI brings the many benefits of a machine/human-readable specification to these nuanced approaches."
+              text={t('testimonials.data.1.text')}
               authorAvatar="/img/testimonials/bill-doerrfeld.jpg"
-              authorName="Bill Doerrfeld"
-              authorDescription="Editor in Chief at Nordic APIs"
+              authorName={t('testimonials.data.1.authorName')}
+              authorDescription={t('testimonials.data.1.authorDescription')}
             />
             <Testimonial
               className="md:pr-10 lg:pr-16"
-              text="Developers need to be able to quickly and consistently create event-driven applications that provide business value and react to customer needs in realtime. I can't count how many times I've heard developers ask for OpenAPI/Swagger style tools for the asynchronous and event-driven world, and that is exactly what the AsyncAPI initiative is making a reality."
+              text={t('testimonials.data.2.text')}
               authorAvatar="/img/testimonials/jonathan-schabowsky.jpg"
-              authorName="Jonathan Schabowsky"
-              authorDescription="Sr. Architect, Office of the CTO at Solace"
+              authorName={t('testimonials.data.2.authorName')}
+              authorDescription={t('testimonials.data.2.authorDescription')}
             />
             <Testimonial
               className="md:pl-10 lg:pl-16"
-              text="We’ve been focusing on event-driven APIs since 2014 and thank the AsyncAPI contributors every day for driving the community towards common standards."
+              text={t('testimonials.data.3.text')}
               authorAvatar="/img/testimonials/eric-horesnyi.jpg"
-              authorName="Eric Horesnyi"
-              authorDescription="CEO at Streamdata.io"
+              authorName={t('testimonials.data.3.authorName')}
+              authorDescription={t('testimonials.data.3.authorDescription')}
             />
           </ul>
         </Container>


### PR DESCRIPTION

**Description**

- The testimonial data of Homepage was not getting translated earlier.
- I have added the translation text to respective landing-page.json files for both the languages.
- Instead of directly using the text I have fetched the text from .json files for the testimonial section.

**Related issue(s)**
 Resolves Issue #2039 

**Before**
![Screenshot from 2024-03-03 03-03-20](https://github.com/asyncapi/website/assets/96368921/d78617a8-cb45-44ec-bdba-093582dae260)
![Screenshot from 2024-03-03 03-03-36](https://github.com/asyncapi/website/assets/96368921/48d2839d-2fa9-4de4-9640-3b76a7f89d39)

**After**
![Screenshot from 2024-03-03 02-46-38](https://github.com/asyncapi/website/assets/96368921/9b7e7df1-e05e-4c10-8fb6-965e246e3708)
![Screenshot from 2024-03-03 02-47-05](https://github.com/asyncapi/website/assets/96368921/708de749-40d2-473e-9755-9b4ba126bd18)