### PR TITLE
feat: implemented email validation in the homepage newsletter 

### DIFF
--- a/components/NewsletterSubscribe.js
+++ b/components/NewsletterSubscribe.js
@@ -6,9 +6,6 @@ import Paragraph from "./typography/Paragraph";
 import Loader from "./Loader";
 import { useTranslation } from "../lib/i18n";
 import axios from "axios";
-import dotenv from "dotenv";
-
-require('dotenv').config();
 
 export default function NewsletterSubscribe({
   className = 'p-8 text-center',
@@ -27,7 +24,7 @@ export default function NewsletterSubscribe({
   const headTextColor = dark ? 'text-white' : ''
   const paragraphTextColor = dark ? 'text-gray-300' : ''
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = (e) => {
     setStatus("loading");
     e.preventDefault()
     const data = {

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -8,7 +8,9 @@
         "successTitle": "Thank you for subscribing!",
         "errorTitle": "Something went wrong",
         "errorSubtitle": "Subscription failed, please let us know about it by submitting a bug",
-        "errorLinkText": "here"
+        "errorLinkText": "here",
+        "invalidTitle": "Enter the Correct Email!",
+        "invalidSubtitle": "Please verify if you have entered the correct email address. If there's a mistake, kindly correct it."
     },
     "newsroomSection": {
         "title": "Latest news and blogs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "axios": "^1.6.0",
         "clsx": "^1.1.1",
         "cssnano": "^5.1.12",
-        "dotenv": "^8.2.0",
+        "dotenv": "^8.6.0",
         "fuse.js": "^6.6.2",
         "googleapis": "^100.0.0",
         "gray-matter": "^4.0.2",
@@ -5190,7 +5190,10 @@
     "node_modules/dotenv": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Add email validation to the Subscribe Newsletter homepage.
- Use [AbstractAPI Email Validation](https://app.abstractapi.com/api/email-validation), which provides 100 API requests per month.
- Generalize the code for all three newsletter statuses: `success`, `error`, and `invalid`.

**Related issue(s)**
Fixes #2125 

**Implementation**
![AsyncAPI Initiative for event-driven APIs](https://github.com/asyncapi/website/assets/99159580/a66f3d8c-9b43-4c47-a61d-f1163b74fb07)
