### PR TITLE
fix: navigates user to the relevant category when URL is provided

### DIFF
--- a/components/tools/ToolDashboard.js
+++ b/components/tools/ToolDashboard.js
@@ -61,6 +61,22 @@ export default function ToolDashboard() {
     };
   });
 
+  // Navigates the user to the specific categories on providing the URL
+  useEffect(() => {
+    if (!loading) {
+        const urlPath = router.asPath;
+        const elementIndex = urlPath.lastIndexOf('#');
+        if (elementIndex !== -1) {
+          const element = urlPath.substring(elementIndex + 1).replace(/%20/g, ' ');
+            const DOMElement = document.getElementById(element);
+            if (DOMElement) {
+              DOMElement.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' });
+            }            
+        }
+    }
+  }, [loading]);
+
+
   // Function to update the list of tools according to the current filters applied
   const updateToolsList = () => {
     let tempToolsList = {};

--- a/components/tools/ToolsList.js
+++ b/components/tools/ToolsList.js
@@ -6,7 +6,7 @@ export default function toolsList({ toolsData }) {
     <div className="" data-testid="ToolsList-main" >
       {Object.keys(toolsData).map((categoryName, index) => {
         if(toolsData[categoryName].toolsList.length > 0) return (
-        <div className='my-8' key={index} id={categoryName}>
+        <div className='my-8 scroll-m-96 scroll-mb-96' key={index} id={categoryName}>
           <Heading typeStyle='heading-md-semibold' className='my-2' >
             {categoryName}
           </Heading>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
On entering the URL on the search bar, the user correctly gets navigated to the relevant category.

**After the fix**

https://github.com/asyncapi/website/assets/100564488/37442130-c755-4ff2-a8aa-d96c0291baa3


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fixes #2181 