### PR TITLE
fix: added language selector for mobile nav

### DIFF
--- a/components/navigation/MobileNavMenu.js
+++ b/components/navigation/MobileNavMenu.js
@@ -9,7 +9,7 @@ import Link from 'next/link';
 import NavItemDropdown from '../icons/NavItemDropdown';
 import { useState } from 'react';
 
-export default function MobileNavMenu({ onClickClose = () => {} }) {
+export default function MobileNavMenu({ onClickClose = () => {},LanguageSelector }) {
   const [open, setOpen] = useState();
   function showMenu(menu) {
     if (open === menu) {
@@ -30,6 +30,7 @@ export default function MobileNavMenu({ onClickClose = () => {} }) {
                 </a>
               </Link>
               <div className="flex flex-row items-center justify-content -mr-2" data-testid="MobileNav-button">
+                {LanguageSelector}
                 <SearchButton
                   className="flex items-center text-left space-x-2 p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out"
                   aria-label="Open Search"

--- a/components/navigation/NavBar.js
+++ b/components/navigation/NavBar.js
@@ -129,6 +129,18 @@ export default function NavBar({
     setOpen(null);
   }, [asPath]);
 
+  const LanguageSelector = (
+    <LanguageSelect
+      options={uniqueLangs}
+      onChange={(value) => {
+        changeLanguage(value.toLowerCase(), true);
+      }}
+      className=""
+      selected={i18n.language ? i18n.language.toUpperCase() : "EN"}
+    />
+  );
+  
+
   return (
     <div className={`bg-white ${className} z-50`}>
       {/* <a href="#main-content" className="block md:inline-block absolute transform -translate-y-20 focus:translate-y-0 bg-gray-100 text-gray-700 p-5 text-md font-semibold" alt="Skip to main content">Skip to main content</a> */}
@@ -146,6 +158,7 @@ export default function NavBar({
         )}
 
         <div className="flex flex-row items-center justify-center -mr-2 -my-2 lg:hidden" data-testid="Navbar-search">
+          {LanguageSelector}
           <SearchButton
             className="flex items-center text-left space-x-2 p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out"
             aria-label="Open Search"
@@ -207,14 +220,7 @@ export default function NavBar({
             </SearchButton>
 
             {/* // Language Picker Component */}
-            <LanguageSelect
-              options={uniqueLangs}
-              onChange={(value) => {
-                changeLanguage(value.toLowerCase(), true);
-              }}
-              className=""
-              selected={i18n.language ? i18n.language.toUpperCase() : "EN"}
-            />
+            {LanguageSelector}
 
             <GithubButton text="Star on GitHub" href="https://github.com/asyncapi/spec" className="py-2 ml-2" inNav="true" />
           </div>
@@ -223,7 +229,7 @@ export default function NavBar({
       </div>
 
       {/* Mobile menu, show/hide based on mobile menu state. */}
-      {mobileMenuOpen && <MobileNavMenu onClickClose={() => setMobileMenuOpen(false)} />}
+      {mobileMenuOpen && <MobileNavMenu LanguageSelector={LanguageSelector} onClickClose={() => setMobileMenuOpen(false)} />}
 
     </div>
   )


### PR DESCRIPTION
![Screenshot (30)](https://github.com/asyncapi/website/assets/122370781/fc84b7da-d6d3-4ef4-a8fe-8ce97025c95a)
This PR resolves the issue #2845 , which reported the missing language selector in the mobile navigation. The fix involves adding the language selector to the mobile navigation menu, ensuring users on all devices have access to language options. Screenshots have been updated to reflect the changes.