### PR TITLE
Fix: after animation demo conflicting input and output on landing page

### DIFF
--- a/components/DemoAnimation.js
+++ b/components/DemoAnimation.js
@@ -248,7 +248,7 @@ export default function DemoAnimation({ className = '' }) {
             <OpenInStudioButton />
           </div>
           <MacWindow
-            className={`bg-gray-50 border-gray-200 border shadow-lg min-h-full transition-all duration-500 ease-in-out ${showControls ? 'transform -translate-x-full h-0 opacity-0 lg:h-auto lg:opacity-100 lg:-translate-x-3/4' : ''}`}
+            className={`bg-gray-50 border-gray-200 border shadow-lg min-h-full transition-all duration-500 ease-in-out ${showControls ? 'transform -translate-x-full h-0 opacity-0 lg:h-auto  lg:-translate-x-3/4' : ''}`}
             contentClassName="text-left h-full text-gray-800 text-sm font-medium transition-all duration-500 ease-in-out"
             title="Account Service Documentation"
           >


### PR DESCRIPTION
 Issue #2879 
Close #2879 

**Description**
remove opacity for large screen or after 1024px 


![Screenshot 2024-04-18 111317](https://github.com/asyncapi/website/assets/125847751/d94524e6-0e4b-4d3e-ada2-c37cdf8f3b9f)
