### PR TITLE
fix: fixed /docs/concepts/consumer page 

### DIFF
--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -4,7 +4,7 @@ const path = require('path');
 const SRC_DIR = 'markdown';
 const TARGET_DIR = 'pages';
 
-const whiteListTags = ['a', 'br', 'div'];
+const whiteListTags = ['a', 'br', 'div', 'b', 'i'];
 
 // Check if target directory doesn't exist then create it
 if (!fs.existsSync(TARGET_DIR)) {


### PR DESCRIPTION
**Description**

This PR targets whitelisting more tags for the `build-pages` script so that we don't encounter any build errors on these pages.
