### PR TITLE
refactor: front page card correct alignment #2964

### DIFF
--- a/components/campaigns/AnnoucementHero.js
+++ b/components/campaigns/AnnoucementHero.js
@@ -98,12 +98,12 @@ export default function AnnouncementHero({ className = '', small = false, hideVi
 
   return (
     <Container as="section" padding='' className={`text-center`}>
-      <div className="relative flex flex-row justify-center items-center md:gap-4 overflow-x-hidden">
+      <div className="relative mt-2 flex flex-row justify-center items-center md:gap-4 overflow-x-hidden">
         {numberOfVisibleBanners > 1 && <div className="h-8 w-8 rounded-full bg-primary-500 hover:bg-primary-600 cursor-pointer mb-2 absolute left-0 z-10 top-1/2 transform -translate-y-1/2 opacity-50 md:opacity-100 flex justify-center items-center" onClick={goToPrevious}>
           <ArrowLeft className='w-4 text-white' />
         </div>}
-        <div className='relative w-5/6 pr-3 flex flex-col gap-2 justify-center items-center'>
-          <div className='relative w-full h-[18rem] lg:w-[38rem] lg:h-[17rem] overflow-hidden'>
+        <div className='relative  w-5/6 flex flex-col gap-2 justify-center items-center'>
+          <div className='relative flex justify-center items-center w-full h-[18rem] lg:w-[38rem] lg:h-[17rem] overflow-hidden'>
           {banners.map((banner, index) => (
             banner.show && (
               <Banner


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
refactor - The front page card is now aligned to the center of its parent div.
![image](https://github.com/asyncapi/website/assets/101279242/34926922-c985-4498-8f14-815726a9bc9f)


Resolved #2964 