### PR TITLE
fix: v3 specification reference section not loading during dev mode

### DIFF
--- a/components/layout/DocsLayout.tsx
+++ b/components/layout/DocsLayout.tsx
@@ -172,16 +172,15 @@ export default function DocsLayout({ post, navItems = {}, children }: IDocsLayou
                         <span className='font-sans text-sm text-gray-800 antialiased'>
                           {`What is new in v${post.title}? Have a look at the `}
                         </span>
-                        <Link href={post.releaseNoteLink} passHref legacyBehavior>
-                          <a
-                            target='_blank'
-                            rel='noopener noreferrer'
-                            className={
-                              'cursor-pointer font-body text-sm font-medium leading-6 text-secondary-500 underline transition duration-150 ease-in-out hover:text-secondary-600 focus:text-gray-900 focus:outline-none'
-                            }
-                          >
-                            release notes
-                          </a>
+                        <Link
+                          href={post.releaseNoteLink}
+                          target='_blank'
+                          rel='noopener noreferrer'
+                          className={
+                            'cursor-pointer font-body text-sm font-medium leading-6 text-secondary-500 underline transition duration-150 ease-in-out hover:text-secondary-600 focus:text-gray-900 focus:outline-none'
+                          }
+                        >
+                          release notes
                         </Link>
                         .
                       </div>
@@ -191,16 +190,15 @@ export default function DocsLayout({ post, navItems = {}, children }: IDocsLayou
                         </span>
                         <span className='font-sans text-sm text-gray-800 antialiased'>
                           Check&nbsp;
-                          <Link href='https://www.asyncapi.com/blog?tags=Release+Notes' passHref legacyBehavior>
-                            <a
-                              target='_blank'
-                              rel='noopener noreferrer'
-                              className={
-                                'cursor-pointer font-body text-sm font-medium leading-6 text-secondary-500 underline transition duration-150 ease-in-out hover:text-secondary-600 focus:text-gray-900 focus:outline-none'
-                              }
-                            >
-                              list of release notes
-                            </a>
+                          <Link
+                            href='https://www.asyncapi.com/blog?tags=Release+Notes'
+                            target='_blank'
+                            rel='noopener noreferrer'
+                            className={
+                              'cursor-pointer font-body text-sm font-medium leading-6 text-secondary-500 underline transition duration-150 ease-in-out hover:text-secondary-600 focus:text-gray-900 focus:outline-none'
+                            }
+                          >
+                            list of release notes
                           </Link>
                           .
                         </span>

--- a/components/layout/DocsLayout.tsx
+++ b/components/layout/DocsLayout.tsx
@@ -48,10 +48,10 @@ function generateEditLink(post: IPost) {
   if (target?.value === '') {
     return (
       <a
-        target="_blank"
-        rel="noopener noreferrer"
+        target='_blank'
+        rel='noopener noreferrer'
         href={`${target.href}${post.isIndex ? `${post.slug}/index` : post.slug}.md`}
-        className="ml-1 underline"
+        className='ml-1 underline'
       >
         {EditPage}
       </a>
@@ -60,12 +60,7 @@ function generateEditLink(post: IPost) {
   if (isHrefToFile) last = '';
 
   return (
-    <a
-      target="_blank"
-      rel="noopener noreferrer"
-      href={`${target?.href}/${last}`}
-      className="ml-1 underline"
-    >
+    <a target='_blank' rel='noopener noreferrer' href={`${target?.href}/${last}`} className='ml-1 underline'>
       {EditPage}
     </a>
   );
@@ -77,11 +72,7 @@ function generateEditLink(post: IPost) {
  * @param {NavigationItems} props.navItems Navigation items for the post
  * @param {React.ReactNode} props.children The children to render in the layout
  */
-export default function DocsLayout({
-  post,
-  navItems = {},
-  children,
-}: IDocsLayoutProps) {
+export default function DocsLayout({ post, navItems = {}, children }: IDocsLayoutProps) {
   const posts = getAllPosts();
   const router = useRouter();
   const [showMenu, setShowMenu] = useState(false);
@@ -97,33 +88,24 @@ export default function DocsLayout({
 
   return (
     <DocsContext.Provider value={{ post, navItems }}>
-      <div className="w-full bg-white px-4 sm:px-6 lg:px-8 xl:mx-auto xl:max-w-7xl">
-        {showMenu && (
-          <DocsMobileMenu
-            onClickClose={() => setShowMenu(false)}
-            post={post}
-            navigation={navigation}
-          />
-        )}
-        <div className="flex flex-row" id="main-content">
+      <div className='w-full bg-white px-4 sm:px-6 lg:px-8 xl:mx-auto xl:max-w-7xl'>
+        {showMenu && <DocsMobileMenu onClickClose={() => setShowMenu(false)} post={post} navigation={navigation} />}
+        <div className='flex flex-row' id='main-content'>
           {/* <!-- Static sidebar for desktop --> */}
-          <div
-            className="hidden lg:flex lg:shrink-0"
-            data-testid="DocsLayout-main"
-          >
-            <div className="flex w-72 flex-col border-r border-gray-200 bg-white py-2">
-              <div className="flex flex-1 flex-col md:sticky md:top-20 md:max-h-(screen-14) md:overflow-y-auto">
+          <div className='hidden lg:flex lg:shrink-0' data-testid='DocsLayout-main'>
+            <div className='flex w-72 flex-col border-r border-gray-200 bg-white py-2'>
+              <div className='flex flex-1 flex-col md:sticky md:top-20 md:max-h-(screen-14) md:overflow-y-auto'>
                 <SearchButton
-                  className="mb-4 mr-2 mt-8 flex items-center space-x-3 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-left text-sm text-gray-700 shadow-sm transition-all duration-500 ease-in-out hover:border-secondary-500 hover:bg-secondary-100 hover:text-secondary-500"
+                  className='mb-4 mr-2 mt-8 flex items-center space-x-3 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-left text-sm text-gray-700 shadow-sm transition-all duration-500 ease-in-out hover:border-secondary-500 hover:bg-secondary-100 hover:text-secondary-500'
                   indexName={DOCS_INDEX_NAME}
                 >
                   {({ actionKey }) => (
                     <>
                       <IconLoupe />
-                      <span className="flex-auto">Search docs...</span>
+                      <span className='flex-auto'>Search docs...</span>
                       {actionKey && (
-                        <kbd className="font-sans font-semibold">
-                          <abbr title={actionKey.key} className="no-underline">
+                        <kbd className='font-sans font-semibold'>
+                          <abbr title={actionKey.key} className='no-underline'>
                             {actionKey.shortKey}
                           </abbr>{' '}
                           K
@@ -133,7 +115,7 @@ export default function DocsLayout({
                   )}
                 </SearchButton>
 
-                <nav className="flex-1 bg-white">
+                <nav className='flex-1 bg-white'>
                   <ul>
                     {Object.values(navigation).map((navItem) => (
                       <DocsNav
@@ -148,20 +130,17 @@ export default function DocsLayout({
               </div>
             </div>
           </div>
-          <div className="flex w-0 max-w-full flex-1 flex-col lg:max-w-(screen-16)">
-            <main
-              className="relative z-0 pb-6 pt-2 focus:outline-none md:py-6"
-              tabIndex={0}
-            >
+          <div className='flex w-0 max-w-full flex-1 flex-col lg:max-w-(screen-16)'>
+            <main className='relative z-0 pb-6 pt-2 focus:outline-none md:py-6' tabIndex={0}>
               {!showMenu && (
-                <div className="lg:hidden">
+                <div className='lg:hidden'>
                   <button
                     onClick={() => setShowMenu(true)}
-                    className="flex px-4 text-gray-500 hover:text-gray-900 focus:outline-none sm:px-6 md:px-8"
-                    aria-label="Open sidebar"
+                    className='flex px-4 text-gray-500 hover:text-gray-900 focus:outline-none sm:px-6 md:px-8'
+                    aria-label='Open sidebar'
                   >
                     <span>{post.sectionTitle}</span>
-                    <ArrowRight className="size-5 rotate-90 pl-1" />
+                    <ArrowRight className='size-5 rotate-90 pl-1' />
                   </button>
                 </div>
               )}
@@ -169,23 +148,18 @@ export default function DocsLayout({
               {/* @TODO Will uncomment the component once it is in use */}
               {/* <AnnouncementHero className='ml-6' hideVideo={true} /> */}
 
-              <div
-                className={`xl:flex ${post.toc && post.toc.length ? 'xl:flex-row-reverse' : ''}`}
-              >
+              <div className={`xl:flex ${post.toc && post.toc.length ? 'xl:flex-row-reverse' : ''}`}>
                 <TOC
                   toc={post.toc}
                   depth={3}
-                  className="sticky top-20 mt-4 max-h-screen overflow-y-auto bg-blue-100 p-4 xl:mt-0 xl:w-72 xl:bg-transparent xl:pb-8"
+                  className='sticky top-20 mt-4 max-h-screen overflow-y-auto bg-blue-100 p-4 xl:mt-0 xl:w-72 xl:bg-transparent xl:pb-8'
                 />
-                <div className="px-4 sm:px-6 xl:max-w-184 xl:flex-1 xl:px-8">
-                  <Heading
-                    level={HeadingLevel.h1}
-                    typeStyle={HeadingTypeStyle.lg}
-                  >
+                <div className='px-4 sm:px-6 xl:max-w-184 xl:flex-1 xl:px-8'>
+                  <Heading level={HeadingLevel.h1} typeStyle={HeadingTypeStyle.lg}>
                     {post.title}
                   </Heading>
                   <div>
-                    <p className="font-normal font-sans text-sm text-gray-600 antialiased">
+                    <p className='font-normal font-sans text-sm text-gray-600 antialiased'>
                       Found an error? Have a suggestion?
                       {generateEditLink(post)}
                     </p>
@@ -193,19 +167,15 @@ export default function DocsLayout({
                   {post.releaseNoteLink && (
                     // show only when it is related to specification (/docs/reference/specification) AND is not a pre-release
                     // for example, if the post's title is "3.0.0 (Pre-release)", which will not have RN, so do not render this section.
-                    <div className="mt-5 w-full rounded-lg bg-secondary-100 px-2 py-3 text-center">
+                    <div className='mt-5 w-full rounded-lg bg-secondary-100 px-2 py-3 text-center'>
                       <div>
-                        <span className="font-sans text-sm text-gray-800 antialiased">
+                        <span className='font-sans text-sm text-gray-800 antialiased'>
                           {`What is new in v${post.title}? Have a look at the `}
                         </span>
-                        <Link
-                          href={post.releaseNoteLink}
-                          passHref
-                          legacyBehavior
-                        >
+                        <Link href={post.releaseNoteLink} passHref legacyBehavior>
                           <a
-                            target="_blank"
-                            rel="noopener noreferrer"
+                            target='_blank'
+                            rel='noopener noreferrer'
                             className={
                               'cursor-pointer font-body text-sm font-medium leading-6 text-secondary-500 underline transition duration-150 ease-in-out hover:text-secondary-600 focus:text-gray-900 focus:outline-none'
                             }
@@ -216,20 +186,15 @@ export default function DocsLayout({
                         .
                       </div>
                       <div>
-                        <span className="font-sans text-sm text-gray-800 antialiased">
-                          Interested in release notes of other versions of the
-                          specification?&nbsp;
+                        <span className='font-sans text-sm text-gray-800 antialiased'>
+                          Interested in release notes of other versions of the specification?&nbsp;
                         </span>
-                        <span className="font-sans text-sm text-gray-800 antialiased">
+                        <span className='font-sans text-sm text-gray-800 antialiased'>
                           Check&nbsp;
-                          <Link
-                            href="https://www.asyncapi.com/blog?tags=Release+Notes"
-                            passHref
-                            legacyBehavior
-                          >
+                          <Link href='https://www.asyncapi.com/blog?tags=Release+Notes' passHref legacyBehavior>
                             <a
-                              target="_blank"
-                              rel="noopener noreferrer"
+                              target='_blank'
+                              rel='noopener noreferrer'
                               className={
                                 'cursor-pointer font-body text-sm font-medium leading-6 text-secondary-500 underline transition duration-150 ease-in-out hover:text-secondary-600 focus:text-gray-900 focus:outline-none'
                               }
@@ -242,18 +207,14 @@ export default function DocsLayout({
                       </div>
                     </div>
                   )}
-                  <article className="my-12">
-                    <Head
-                      title={post.title}
-                      description={post.excerpt}
-                      image={post.cover}
-                    />
+                  <article className='my-12'>
+                    <Head title={post.title} description={post.excerpt} image={post.cover} />
                     {children}
                   </article>
                   <div>
                     <DocsButton post={post} />
                   </div>
-                  <div className="">
+                  <div className=''>
                     <Feedback />
                   </div>
                 </div>

--- a/components/layout/DocsLayout.tsx
+++ b/components/layout/DocsLayout.tsx
@@ -48,10 +48,10 @@ function generateEditLink(post: IPost) {
   if (target?.value === '') {
     return (
       <a
-        target='_blank'
-        rel='noopener noreferrer'
+        target="_blank"
+        rel="noopener noreferrer"
         href={`${target.href}${post.isIndex ? `${post.slug}/index` : post.slug}.md`}
-        className='ml-1 underline'
+        className="ml-1 underline"
       >
         {EditPage}
       </a>
@@ -60,7 +60,12 @@ function generateEditLink(post: IPost) {
   if (isHrefToFile) last = '';
 
   return (
-    <a target='_blank' rel='noopener noreferrer' href={`${target?.href}/${last}`} className='ml-1 underline'>
+    <a
+      target="_blank"
+      rel="noopener noreferrer"
+      href={`${target?.href}/${last}`}
+      className="ml-1 underline"
+    >
       {EditPage}
     </a>
   );
@@ -72,7 +77,11 @@ function generateEditLink(post: IPost) {
  * @param {NavigationItems} props.navItems Navigation items for the post
  * @param {React.ReactNode} props.children The children to render in the layout
  */
-export default function DocsLayout({ post, navItems = {}, children }: IDocsLayoutProps) {
+export default function DocsLayout({
+  post,
+  navItems = {},
+  children,
+}: IDocsLayoutProps) {
   const posts = getAllPosts();
   const router = useRouter();
   const [showMenu, setShowMenu] = useState(false);
@@ -88,24 +97,33 @@ export default function DocsLayout({ post, navItems = {}, children }: IDocsLayou
 
   return (
     <DocsContext.Provider value={{ post, navItems }}>
-      <div className='w-full bg-white px-4 sm:px-6 lg:px-8 xl:mx-auto xl:max-w-7xl'>
-        {showMenu && <DocsMobileMenu onClickClose={() => setShowMenu(false)} post={post} navigation={navigation} />}
-        <div className='flex flex-row' id='main-content'>
+      <div className="w-full bg-white px-4 sm:px-6 lg:px-8 xl:mx-auto xl:max-w-7xl">
+        {showMenu && (
+          <DocsMobileMenu
+            onClickClose={() => setShowMenu(false)}
+            post={post}
+            navigation={navigation}
+          />
+        )}
+        <div className="flex flex-row" id="main-content">
           {/* <!-- Static sidebar for desktop --> */}
-          <div className='hidden lg:flex lg:shrink-0' data-testid='DocsLayout-main'>
-            <div className='flex w-72 flex-col border-r border-gray-200 bg-white py-2'>
-              <div className='flex flex-1 flex-col md:sticky md:top-20 md:max-h-(screen-14) md:overflow-y-auto'>
+          <div
+            className="hidden lg:flex lg:shrink-0"
+            data-testid="DocsLayout-main"
+          >
+            <div className="flex w-72 flex-col border-r border-gray-200 bg-white py-2">
+              <div className="flex flex-1 flex-col md:sticky md:top-20 md:max-h-(screen-14) md:overflow-y-auto">
                 <SearchButton
-                  className='mb-4 mr-2 mt-8 flex items-center space-x-3 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-left text-sm text-gray-700 shadow-sm transition-all duration-500 ease-in-out hover:border-secondary-500 hover:bg-secondary-100 hover:text-secondary-500'
+                  className="mb-4 mr-2 mt-8 flex items-center space-x-3 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-left text-sm text-gray-700 shadow-sm transition-all duration-500 ease-in-out hover:border-secondary-500 hover:bg-secondary-100 hover:text-secondary-500"
                   indexName={DOCS_INDEX_NAME}
                 >
                   {({ actionKey }) => (
                     <>
                       <IconLoupe />
-                      <span className='flex-auto'>Search docs...</span>
+                      <span className="flex-auto">Search docs...</span>
                       {actionKey && (
-                        <kbd className='font-sans font-semibold'>
-                          <abbr title={actionKey.key} className='no-underline'>
+                        <kbd className="font-sans font-semibold">
+                          <abbr title={actionKey.key} className="no-underline">
                             {actionKey.shortKey}
                           </abbr>{' '}
                           K
@@ -115,7 +133,7 @@ export default function DocsLayout({ post, navItems = {}, children }: IDocsLayou
                   )}
                 </SearchButton>
 
-                <nav className='flex-1 bg-white'>
+                <nav className="flex-1 bg-white">
                   <ul>
                     {Object.values(navigation).map((navItem) => (
                       <DocsNav
@@ -130,17 +148,20 @@ export default function DocsLayout({ post, navItems = {}, children }: IDocsLayou
               </div>
             </div>
           </div>
-          <div className='flex w-0 max-w-full flex-1 flex-col lg:max-w-(screen-16)'>
-            <main className='relative z-0 pb-6 pt-2 focus:outline-none md:py-6' tabIndex={0}>
+          <div className="flex w-0 max-w-full flex-1 flex-col lg:max-w-(screen-16)">
+            <main
+              className="relative z-0 pb-6 pt-2 focus:outline-none md:py-6"
+              tabIndex={0}
+            >
               {!showMenu && (
-                <div className='lg:hidden'>
+                <div className="lg:hidden">
                   <button
                     onClick={() => setShowMenu(true)}
-                    className='flex px-4 text-gray-500 hover:text-gray-900 focus:outline-none sm:px-6 md:px-8'
-                    aria-label='Open sidebar'
+                    className="flex px-4 text-gray-500 hover:text-gray-900 focus:outline-none sm:px-6 md:px-8"
+                    aria-label="Open sidebar"
                   >
                     <span>{post.sectionTitle}</span>
-                    <ArrowRight className='size-5 rotate-90 pl-1' />
+                    <ArrowRight className="size-5 rotate-90 pl-1" />
                   </button>
                 </div>
               )}
@@ -148,18 +169,23 @@ export default function DocsLayout({ post, navItems = {}, children }: IDocsLayou
               {/* @TODO Will uncomment the component once it is in use */}
               {/* <AnnouncementHero className='ml-6' hideVideo={true} /> */}
 
-              <div className={`xl:flex ${post.toc && post.toc.length ? 'xl:flex-row-reverse' : ''}`}>
+              <div
+                className={`xl:flex ${post.toc && post.toc.length ? 'xl:flex-row-reverse' : ''}`}
+              >
                 <TOC
                   toc={post.toc}
                   depth={3}
-                  className='sticky top-20 mt-4 max-h-screen overflow-y-auto bg-blue-100 p-4 xl:mt-0 xl:w-72 xl:bg-transparent xl:pb-8'
+                  className="sticky top-20 mt-4 max-h-screen overflow-y-auto bg-blue-100 p-4 xl:mt-0 xl:w-72 xl:bg-transparent xl:pb-8"
                 />
-                <div className='px-4 sm:px-6 xl:max-w-184 xl:flex-1 xl:px-8'>
-                  <Heading level={HeadingLevel.h1} typeStyle={HeadingTypeStyle.lg}>
+                <div className="px-4 sm:px-6 xl:max-w-184 xl:flex-1 xl:px-8">
+                  <Heading
+                    level={HeadingLevel.h1}
+                    typeStyle={HeadingTypeStyle.lg}
+                  >
                     {post.title}
                   </Heading>
                   <div>
-                    <p className='font-normal font-sans text-sm text-gray-600 antialiased'>
+                    <p className="font-normal font-sans text-sm text-gray-600 antialiased">
                       Found an error? Have a suggestion?
                       {generateEditLink(post)}
                     </p>
@@ -167,15 +193,19 @@ export default function DocsLayout({ post, navItems = {}, children }: IDocsLayou
                   {post.releaseNoteLink && (
                     // show only when it is related to specification (/docs/reference/specification) AND is not a pre-release
                     // for example, if the post's title is "3.0.0 (Pre-release)", which will not have RN, so do not render this section.
-                    <div className='mt-5 w-full rounded-lg bg-secondary-100 px-2 py-3 text-center'>
+                    <div className="mt-5 w-full rounded-lg bg-secondary-100 px-2 py-3 text-center">
                       <div>
-                        <span className='font-sans text-sm text-gray-800 antialiased'>
+                        <span className="font-sans text-sm text-gray-800 antialiased">
                           {`What is new in v${post.title}? Have a look at the `}
                         </span>
-                        <Link href={post.releaseNoteLink}>
+                        <Link
+                          href={post.releaseNoteLink}
+                          passHref
+                          legacyBehavior
+                        >
                           <a
-                            target='_blank'
-                            rel='noopener noreferrer'
+                            target="_blank"
+                            rel="noopener noreferrer"
                             className={
                               'cursor-pointer font-body text-sm font-medium leading-6 text-secondary-500 underline transition duration-150 ease-in-out hover:text-secondary-600 focus:text-gray-900 focus:outline-none'
                             }
@@ -186,15 +216,20 @@ export default function DocsLayout({ post, navItems = {}, children }: IDocsLayou
                         .
                       </div>
                       <div>
-                        <span className='font-sans text-sm text-gray-800 antialiased'>
-                          Interested in release notes of other versions of the specification?&nbsp;
+                        <span className="font-sans text-sm text-gray-800 antialiased">
+                          Interested in release notes of other versions of the
+                          specification?&nbsp;
                         </span>
-                        <span className='font-sans text-sm text-gray-800 antialiased'>
+                        <span className="font-sans text-sm text-gray-800 antialiased">
                           Check&nbsp;
-                          <Link href='https://www.asyncapi.com/blog?tags=Release+Notes'>
+                          <Link
+                            href="https://www.asyncapi.com/blog?tags=Release+Notes"
+                            passHref
+                            legacyBehavior
+                          >
                             <a
-                              target='_blank'
-                              rel='noopener noreferrer'
+                              target="_blank"
+                              rel="noopener noreferrer"
                               className={
                                 'cursor-pointer font-body text-sm font-medium leading-6 text-secondary-500 underline transition duration-150 ease-in-out hover:text-secondary-600 focus:text-gray-900 focus:outline-none'
                               }
@@ -207,14 +242,18 @@ export default function DocsLayout({ post, navItems = {}, children }: IDocsLayou
                       </div>
                     </div>
                   )}
-                  <article className='my-12'>
-                    <Head title={post.title} description={post.excerpt} image={post.cover} />
+                  <article className="my-12">
+                    <Head
+                      title={post.title}
+                      description={post.excerpt}
+                      image={post.cover}
+                    />
                     {children}
                   </article>
                   <div>
                     <DocsButton post={post} />
                   </div>
-                  <div className=''>
+                  <div className="">
                     <Feedback />
                   </div>
                 </div>


### PR DESCRIPTION
**Description**
These breaking changes are part of NextJS 13. If the Link Components have a tag it should wrap [passHref](https://nextjs.org/docs/app/api-reference/components/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag) and should put [legacyBehavior](https://nextjs.org/docs/pages/building-your-application/upgrading/version-13). Another alternative is to use [codemods](https://nextjs.org/docs/pages/building-your-application/upgrading/codemods#new-link).

**Related issue(s)**
Fixes #3002 

![Screenshot 2024-05-30 122801](https://github.com/asyncapi/website/assets/54782057/5294170f-72bc-407f-a699-cdc926918f95)