### PR TITLE
fix: fixed conference blog

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,8 +10,8 @@
 # All .md files
 *.md @alequetzalli @asyncapi-bot-eve
 
-pages/blog/*.md @thulieblack @alequetzalli
-pages/community/*.md @thulieblack @alequetzalli
+markdown/blog/*.md @thulieblack @alequetzalli
+markdown/community/*.md @thulieblack @alequetzalli
 
 README.md @alequetzalli @derberg @akshatnema @magicmatatjahu @mayaleeeee @asyncapi-bot-eve
 #docTriagers: TRohit20 BhaswatiRoy VaishnaviNandakumar J0SAL

--- a/markdown/blog/conference-2023.md
+++ b/markdown/blog/conference-2023.md
@@ -104,7 +104,7 @@ You can also catch up on the live recording from [AACoT'23 Madrid](https://www.y
 I want to express my gratitude to these individuals and many others for their unwavering dedication in assisting with AACoT'23 behind the scenes. 
 They contributed to the design of website prototypes, conference design implementation, creating promotional videos, reviewing Call for Papers (CfPs), editing conference recordings, and providing constant communication and support. I am genuinely thankful for their hard work and commitment.
 
-<Profile profiles={[
+<Profiles profiles={[
 {
     name: 'Aishat Muibudeen',
     avatar: 'https://avatars.githubusercontent.com/Mayaleeeee',


### PR DESCRIPTION
### Description

- Fixed `/blog/conference-2023` page by correcting `Profiles` in the blog.
- Updated CODEOWNERS file for new folder