### PR TITLE
fix(docs issue): undefined errors while rendering in docs/tools

### DIFF
--- a/markdown/docs/tools/cli/context.md
+++ b/markdown/docs/tools/cli/context.md
@@ -123,7 +123,7 @@ Map of filesystem paths to target AsyncAPI documents.
 
 Field Pattern | Type | Description
 ---|:---:|---
-{contextName} | `string` | An optional string value representing filesystem path to the target AsyncAPI document.
+\{contextName\} | `string` | An optional string value representing filesystem path to the target AsyncAPI document.
 
 ### <a name="minimalEmptyContextFile"></a>Minimal Empty Context File
 Raw JSON:

--- a/markdown/docs/tools/glee/bearerToken.md
+++ b/markdown/docs/tools/glee/bearerToken.md
@@ -81,7 +81,7 @@ export async clientAuth({ parsedAsyncAPI, serverName }) {
 }
 ```
 
-Glee will utilize the `token` for server authentication, employing it in the header with the format: Authorization: Bearer {token}.
+Glee will utilize the `token` for server authentication, employing it in the header with the format: Authorization: Bearer \{token\}.
 
 ### Server side
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Currently [this page](https://www.asyncapi.com/docs/tools/cli/context) and [this](https://www.asyncapi.com/docs/tools/glee/bearerToken) are throwing errors

1.
![image](https://github.com/user-attachments/assets/53e6351a-330f-45e8-9627-de47aece2488)

2.
![image](https://github.com/user-attachments/assets/00e7e9d8-7e6b-48f0-afcd-38de17c62f64)

The main issue was in docs `{token}` and `{contextName}` keywords are used as it and then being rendered which causes javascript to be identified it as a value (thus it is undefined)

Using escape character fixes this
![image](https://github.com/user-attachments/assets/f2c718ea-d08e-4d39-af9c-d01fa6eb5f4b)
![image](https://github.com/user-attachments/assets/cdb7f462-365c-4f66-9e4d-7f0e5f82b7ae)


**Related issue(s)**

Resolves #3115 