### PR TITLE
fix: broken link to generator github actions

### DIFF
--- a/markdown/blog/asyncapi-github-actions.md
+++ b/markdown/blog/asyncapi-github-actions.md
@@ -16,7 +16,7 @@ excerpt: AsyncAPI community got rich with two GitHub Actions that you can use fo
 ---
 
 > tl;dr
-> AsyncAPI community got rich with two GitHub Actions that you can use for [validation](https://github.com/marketplace/actions/asyncapi-github-action) and [generation](https://github.com/marketplace/actions/generator-for-asyncapi-documents).
+> AsyncAPI community got rich with two GitHub Actions that you can use for [validation](https://github.com/marketplace/actions/asyncapi-github-action) and [generation](https://github.com/marketplace/actions/generator-validator-converter-and-others-all-in-one-for-your-asyncapi-docs).
 
 GitHub organized a [hackathon for GitHub Actions](https://githubhackathon.com/#hackathon). There is no better reason to work on a solution if there is a bag of swags waiting for you <img className="inline-block w-5 h-5 ml-1" src="https://emojipedia-us.s3.amazonaws.com:443/content/2020/04/05/trollface-github-emojipedia.png"/>
 
@@ -25,7 +25,7 @@ The hackathon was only a trigger, the right moment to decide that we should enga
 Two AsyncAPI related actions we crafted in March are:
 
 - Our community member, [Waleed Ashraf](https://twitter.com/WaleedAshraf01/) created [an action](https://github.com/marketplace/actions/asyncapi-github-action) to validate AsyncAPI documents with our [parser](https://github.com/asyncapi/parser-js/)
-- We also created [official AsyncAPI action](https://github.com/marketplace/actions/generator-for-asyncapi-documents) for our [generator](https://github.com/asyncapi/generator/).
+- We also created [official AsyncAPI action](https://github.com/marketplace/actions/generator-validator-converter-and-others-all-in-one-for-your-asyncapi-docs) for our [generator](https://github.com/asyncapi/generator/).
 
 ## Writing a GitHub Action
 

--- a/markdown/blog/status-update-47-20.md
+++ b/markdown/blog/status-update-47-20.md
@@ -39,7 +39,7 @@ Try out the project by following :point_down: instructions:
 
 ### Generator GitHub Action 1.0
 
-Yes, our official [GitHub Action for Generator](https://github.com/marketplace/actions/generator-for-asyncapi-documents) already uses the latest Generator and is released under v1. 
+Yes, our official [GitHub Action for Generator](https://github.com/marketplace/actions/generator-validator-converter-and-others-all-in-one-for-your-asyncapi-docs) already uses the latest Generator and is released under v1. 
 
 ```yaml
 - name: Generating HTML from my AsyncAPI document

--- a/markdown/docs/tools/generator/installation-guide.md
+++ b/markdown/docs/tools/generator/installation-guide.md
@@ -73,7 +73,7 @@ To uninstall the generator, use the following command:
 npm uninstall @asyncapi/cli -g
 ``` 
 
-> :memo: **Note:**  To use the generator in your CI/CD pipeline to automate whatever you generate for your event-driven architecture apps, install the AsyncAPI CLI in your pipeline. If you are using GitHub Actions, use [Github Actions for Generator](https://github.com/marketplace/actions/generator-for-asyncapi-documents).
+> :memo: **Note:**  To use the generator in your CI/CD pipeline to automate whatever you generate for your event-driven architecture apps, install the AsyncAPI CLI in your pipeline. If you are using GitHub Actions, use [Github Actions for Generator](https://github.com/marketplace/actions/generator-validator-converter-and-others-all-in-one-for-your-asyncapi-docs).
 
 ## Generator library in Node.js apps
 Use the generator library in your Node.js projects by installing it via the following command: `npm install @asyncapi/generator`.


### PR DESCRIPTION
**Description**
There is a broken link in the **AsyncAPI Generator Installation Guide** (https://www.asyncapi.com/docs/tools/generator/installation-guide#uninstall-asyncapi-cli) that needs to be updated.

**Current Link**: https://github.com/marketplace/actions/generator-for-asyncapi-documents

**Correct Link**: https://github.com/marketplace/actions/generator-validator-converter-and-others-all-in-one-for-your-asyncapi-docs

**Related issue(s)** Resolve https://github.com/asyncapi/website/issues/3190