### PR TITLE
fix: fixed the routes for casestudy

### DIFF
--- a/components/CaseStudyCard.tsx
+++ b/components/CaseStudyCard.tsx
@@ -19,7 +19,7 @@ export default function CaseStudyCard({ studies = [] }: ICaseStudyCardProps) {
   return (
     <div className='flex flex-wrap pt-10 lg:grid lg:grid-cols-3 lg:gap-8 lg:text-center'>
       {studies.map((study, index) => (
-        <a key={index} href={`${study.id}`}>
+        <a key={index} href={`casestudies/${study.id}`}>
           <div
             className='max-w-sm overflow-hidden rounded-md border border-gray-200 bg-white p-4'
             data-testid='CaseStudyCard-main'


### PR DESCRIPTION
**Description**

The case study card was pointing to '/[id]' instead of the correct path 'casestudies/[id]' .


Resolves #3231