### PR TITLE
fix: fixes gap between Github & View Docs Button on smaller screens (#3008)

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/pages/tools/generator.tsx
+++ b/pages/tools/generator.tsx
@@ -16,7 +16,7 @@ import Paragraph from '../../components/typography/Paragraph';
  */
 function renderButtons(): JSX.Element {
   return (
-    <div className='mt-8'>
+    <div className='mt-8 space-y-4 md:space-y-0'>
       {/* <Button
         text="Learn more"
         href="/docs/tools/generator"
@@ -32,7 +32,7 @@ function renderButtons(): JSX.Element {
       <Button
         text='View Docs'
         href='/docs/tools/generator'
-        className='ml-2 mt-2 block w-full sm:w-auto md:mt-0 md:inline-block'
+        className='md:ml-2 mt-2 block w-fit md:mt-0 md:inline-block'
       />
     </div>
   );


### PR DESCRIPTION
On smaller screens the buttons were not properly aligned and having spacing issues.

- Added Vertical Spacing
- Set `view docs` content width to fit. ( So that only occupies width as per the content )

**Before**
![image](https://github.com/user-attachments/assets/894eb773-d1cd-4b31-b171-522ada4b7882)


**After** ✅ 
![Screenshot 2024-09-23 100557](https://github.com/user-attachments/assets/faf5fb68-8d42-4642-96de-77c2586189ee)

Resolves: #3008 
