### PR TITLE
Added loading state and adjusted tweet height in TwitterTimelineEmbed

### DIFF
--- a/components/newsroom/Newsroom.tsx
+++ b/components/newsroom/Newsroom.tsx
@@ -5,6 +5,7 @@ import { TwitterTimelineEmbed } from 'react-twitter-embed';
 import { HeadingLevel, HeadingTypeStyle } from '@/types/typography/Heading';
 import { ParagraphTypeStyle } from '@/types/typography/Paragraph';
 
+import Loader from '../Loader';
 import ArrowRight from '../icons/ArrowRight';
 import Heading from '../typography/Heading';
 import Paragraph from '../typography/Paragraph';
@@ -19,7 +20,7 @@ import NewsroomYoutube from './NewsroomYoutube';
  */
 export default function Newsroom() {
 
-  const [isLoaded, setIsLoaded] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   return (
     <>
@@ -83,13 +84,20 @@ export default function Newsroom() {
             </div>
           </div>
           <div className='w-full px-2 md:w-1/2 md:pl-4 md:pr-0'>
-            <div className='mx-auto mt-8 w-full rounded-xl shadow-md md:mt-0' data-testid='Newsroom-Twitter'>
-            {!isLoaded && <p> Loading Tweets... </p>}
+            <div className='mx-auto mt-8 w-full rounded-xl shadow-md md:mt-0' style={{ height: '500px' }} data-testid='Newsroom-Twitter'>
+            {loading && (
+                <Loader
+                  loaderText="Loading Twitter feed..."
+                  className="h-full"
+                  pulsating={true}
+                  dark={false} 
+                />
+              )}
               <TwitterTimelineEmbed
-                sourceType='profile'
-                screenName='AsyncAPISpec'
-                options={{ height: '400' }}
-                onLoad={() => setIsLoaded(true)}
+                sourceType="profile"
+                screenName="AsyncAPISpec"
+                options={{ tweetLimit: '2', height: '500' }} 
+                onLoad={() => setLoading(false)} 
               />
             </div>
           </div>

--- a/components/newsroom/Newsroom.tsx
+++ b/components/newsroom/Newsroom.tsx
@@ -1,3 +1,5 @@
+import React, { useState } from 'react';
+
 import { TwitterTimelineEmbed } from 'react-twitter-embed';
 
 import { HeadingLevel, HeadingTypeStyle } from '@/types/typography/Heading';
@@ -11,10 +13,14 @@ import NewsroomArticle from './NewsroomArticle';
 import NewsroomBlogPosts from './NewsroomBlogPosts';
 import NewsroomYoutube from './NewsroomYoutube';
 
+
 /**
  * @description This component displays the latest updates, blog posts, news, and videos.
  */
 export default function Newsroom() {
+
+  const [isLoaded, setIsLoaded] = useState(false);
+
   return (
     <>
       <div className='mt-12 text-center' data-testid='Newsroom-main'>
@@ -78,7 +84,13 @@ export default function Newsroom() {
           </div>
           <div className='w-full px-2 md:w-1/2 md:pl-4 md:pr-0'>
             <div className='mx-auto mt-8 w-full rounded-xl shadow-md md:mt-0' data-testid='Newsroom-Twitter'>
-              <TwitterTimelineEmbed sourceType='profile' screenName='AsyncAPISpec' options={{ tweetLimit: '2' }} />
+            {!isLoaded && <p> Loading Tweets... </p>}
+              <TwitterTimelineEmbed
+                sourceType='profile'
+                screenName='AsyncAPISpec'
+                options={{ height: '400' }}
+                onLoad={() => setIsLoaded(true)}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
Description

Implemented a loading state for the Twitter embed to improve user experience by showing a "Loading Tweets..." message while the tweets are being fetched.

Adjusted the height of the embedded Twitter timeline to 400px for better display control and to limit the space taken up by the tweets.

Ensured that only a limited number of tweets are displayed by utilizing the tweetLimit option.

 <!-- Resolves #3132  -->