### PR TITLE
fix: file write errors for tools and newsroom video

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "clsx": "^2.1.0",
         "cssnano": "^6.0.3",
         "dotenv": "^16.4.4",
+        "fs-extra": "^11.2.0",
         "fuse.js": "^7.0.0",
         "googleapis": "^133.0.0",
         "gray-matter": "^4.0.3",
@@ -4697,20 +4698,6 @@
         "unstorage": "1.9.0"
       }
     },
-    "node_modules/@netlify/ipx/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/@netlify/ipx/node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -4785,6 +4772,21 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@netlify/plugin-nextjs/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@netlify/plugin-nextjs/node_modules/node-fetch": {
@@ -6253,20 +6255,6 @@
         "storybook": "^8.2.9"
       }
     },
-    "node_modules/@storybook/addon-docs/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/@storybook/addon-essentials": {
       "version": "8.2.9",
       "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-8.2.9.tgz",
@@ -6524,20 +6512,6 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@storybook/builder-webpack5/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/@storybook/codemod": {
@@ -6829,20 +6803,6 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/@storybook/nextjs/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/@storybook/preset-react-webpack": {
       "version": "8.2.9",
       "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-8.2.9.tgz",
@@ -6888,20 +6848,6 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@storybook/preset-react-webpack/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/@storybook/preview-api": {
@@ -14227,6 +14173,21 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -14339,17 +14300,17 @@
       "dev": true
     },
     "node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.14"
       }
     },
     "node_modules/fs-minipass": {
@@ -27095,19 +27056,6 @@
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/storybook/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/storybook/node_modules/globby": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "clsx": "^2.1.0",
     "cssnano": "^6.0.3",
     "dotenv": "^16.4.4",
+    "fs-extra": "^11.2.0",
     "fuse.js": "^7.0.0",
     "googleapis": "^133.0.0",
     "gray-matter": "^4.0.3",

--- a/scripts/build-newsroom-videos.js
+++ b/scripts/build-newsroom-videos.js
@@ -1,9 +1,13 @@
-const { writeFileSync } = require('fs');
-const { resolve } = require('path');
+const { writeFileSync, mkdirSync, existsSync } = require('fs');
+const { resolve, dirname } = require('path');
 const fetch = require('node-fetch-2');
 
 async function buildNewsroomVideos(writePath) {
     try {
+        const dir = dirname(writePath);
+        if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true });
+        }
         const response = await fetch('https://youtube.googleapis.com/youtube/v3/search?' + new URLSearchParams({
             key: process.env.YOUTUBE_TOKEN,
             part: 'snippet',

--- a/scripts/build-tools.js
+++ b/scripts/build-tools.js
@@ -14,16 +14,31 @@ const buildTools = async (automatedToolsPath, manualToolsPath, toolsPath, tagsPa
     if (!fs.existsSync(automatedDir)) {
       fs.mkdirSync(automatedDir, { recursive: true });
     }
-    fs.writeFileSync(
-      automatedToolsPath,
-      JSON.stringify(automatedTools, null, '  ')
-    );
+
+    await retryWriteFile(automatedToolsPath, JSON.stringify(automatedTools, null, '  '));
 
     await combineTools(automatedTools, require(manualToolsPath), toolsPath, tagsPath);
   } catch (err) {
     throw new Error(`An error occurred while building tools: ${err.message}`);
   }
 };
+
+async function retryWriteFile(filePath, data, retries = 3, delay = 1000) {
+  for (let attempt = 0; attempt < retries; attempt++) {
+    try {
+      fs.writeFileSync(filePath, data);
+      console.log(`File written successfully to ${filePath}`);
+      break;
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        console.error(`ENOENT error on attempt ${attempt + 1}. Retrying in ${delay}ms...`);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      } else {
+        throw err;
+      }
+    }
+  }
+}
 
 /* istanbul ignore next */
 if (require.main === module) {

--- a/scripts/build-tools.js
+++ b/scripts/build-tools.js
@@ -2,13 +2,18 @@ const { getData } = require('./tools/extract-tools-github');
 const { convertTools } = require('./tools/tools-object');
 const { combineTools } = require('./tools/combine-tools');
 const fs = require('fs');
-const path = require('path');
+const { resolve, dirname } = require('path');
 
 const buildTools = async (automatedToolsPath, manualToolsPath, toolsPath, tagsPath) => {
   try {
     let githubExtractData = await getData();
     let automatedTools = await convertTools(githubExtractData);
+    
+    const automatedDir = dirname(automatedToolsPath);
 
+    if (!fs.existsSync(automatedDir)) {
+      fs.mkdirSync(automatedDir, { recursive: true });
+    }
     fs.writeFileSync(
       automatedToolsPath,
       JSON.stringify(automatedTools, null, '  ')
@@ -22,10 +27,10 @@ const buildTools = async (automatedToolsPath, manualToolsPath, toolsPath, tagsPa
 
 /* istanbul ignore next */
 if (require.main === module) {
-  const automatedToolsPath = path.join(__dirname, '../config', 'tools-automated.json');
-  const manualToolsPath = path.join(__dirname, '../config', 'tools-manual.json');
-  const toolsPath = path.join(__dirname, '../config', 'tools.json');
-  const tagsPath = path.join(__dirname, '../config', 'all-tags.json');
+  const automatedToolsPath = resolve(__dirname, '../config', 'tools-automated.json');
+  const manualToolsPath = resolve(__dirname, '../config', 'tools-manual.json');
+  const toolsPath = resolve(__dirname, '../config', 'tools.json');
+  const tagsPath = resolve(__dirname, '../config', 'all-tags.json');
 
   buildTools(automatedToolsPath, manualToolsPath, toolsPath, tagsPath);
 }

--- a/scripts/build-tools.js
+++ b/scripts/build-tools.js
@@ -2,7 +2,7 @@ const { getData } = require('./tools/extract-tools-github');
 const { convertTools } = require('./tools/tools-object');
 const { combineTools } = require('./tools/combine-tools');
 const fs = require('fs');
-const { resolve } = require('path');
+const path = require('path');
 
 const buildTools = async (automatedToolsPath, manualToolsPath, toolsPath, tagsPath) => {
   try {
@@ -22,10 +22,10 @@ const buildTools = async (automatedToolsPath, manualToolsPath, toolsPath, tagsPa
 
 /* istanbul ignore next */
 if (require.main === module) {
-  const automatedToolsPath = resolve(__dirname, '../config', 'tools-automated.json');
-  const manualToolsPath = resolve(__dirname, '../config', 'tools-manual.json');
-  const toolsPath = resolve(__dirname, '../config', 'tools.json');
-  const tagsPath = resolve(__dirname, '../config', 'all-tags.json');
+  const automatedToolsPath = path.join(__dirname, '../config', 'tools-automated.json');
+  const manualToolsPath = path.join(__dirname, '../config', 'tools-manual.json');
+  const toolsPath = path.join(__dirname, '../config', 'tools.json');
+  const tagsPath = path.join(__dirname, '../config', 'all-tags.json');
 
   buildTools(automatedToolsPath, manualToolsPath, toolsPath, tagsPath);
 }

--- a/scripts/build-tools.js
+++ b/scripts/build-tools.js
@@ -1,44 +1,21 @@
 const { getData } = require('./tools/extract-tools-github');
 const { convertTools } = require('./tools/tools-object');
 const { combineTools } = require('./tools/combine-tools');
-const fs = require('fs');
-const { resolve, dirname } = require('path');
+const fs = require('fs-extra');
+const { resolve } = require('path');
 
 const buildTools = async (automatedToolsPath, manualToolsPath, toolsPath, tagsPath) => {
   try {
     let githubExtractData = await getData();
     let automatedTools = await convertTools(githubExtractData);
-    
-    const automatedDir = dirname(automatedToolsPath);
 
-    if (!fs.existsSync(automatedDir)) {
-      fs.mkdirSync(automatedDir, { recursive: true });
-    }
-
-    await retryWriteFile(automatedToolsPath, JSON.stringify(automatedTools, null, '  '));
+    await fs.writeFile(automatedToolsPath, JSON.stringify(automatedTools, null, '  '));
 
     await combineTools(automatedTools, require(manualToolsPath), toolsPath, tagsPath);
   } catch (err) {
     throw new Error(`An error occurred while building tools: ${err.message}`);
   }
 };
-
-async function retryWriteFile(filePath, data, retries = 3, delay = 1000) {
-  for (let attempt = 0; attempt < retries; attempt++) {
-    try {
-      fs.writeFileSync(filePath, data);
-      console.log(`File written successfully to ${filePath}`);
-      break;
-    } catch (err) {
-      if (err.code === 'ENOENT') {
-        console.error(`ENOENT error on attempt ${attempt + 1}. Retrying in ${delay}ms...`);
-        await new Promise((resolve) => setTimeout(resolve, delay));
-      } else {
-        throw err;
-      }
-    }
-  }
-}
 
 /* istanbul ignore next */
 if (require.main === module) {

--- a/tests/build-newsroom-videos.test.js
+++ b/tests/build-newsroom-videos.test.js
@@ -1,4 +1,4 @@
-const { readFileSync, rmSync, mkdirSync, existsSync } = require('fs');
+const { readFileSync, removeSync, mkdirpSync } = require('fs-extra');
 const { resolve } = require('path');
 const { buildNewsroomVideos } = require('../scripts/build-newsroom-videos');
 const { mockApiResponse, expectedResult } = require('./fixtures/newsroomData');
@@ -11,19 +11,15 @@ describe('buildNewsroomVideos', () => {
     const testFilePath = resolve(testDir, 'newsroom_videos.json');
 
     beforeAll(() => {
+        mkdirpSync(testDir);
         process.env.YOUTUBE_TOKEN = 'testkey';
     });
 
     afterAll(() => {
-        if (existsSync(testDir)) {
-            rmSync(testDir, { recursive: true, force: true });
-        }
+        removeSync(testDir);
     });
 
     beforeEach(() => {
-        if (!existsSync(testDir)) {
-            mkdirSync(testDir, { recursive: true });
-        }
         fetch.mockClear();
     });
 
@@ -32,10 +28,6 @@ describe('buildNewsroomVideos', () => {
             ok: true,
             json: jest.fn().mockResolvedValue(mockApiResponse),
         });
-
-        if (!existsSync(testDir)) {
-            mkdirSync(testDir, { recursive: true });
-        }
 
         const result = await buildNewsroomVideos(testFilePath);
 
@@ -49,7 +41,6 @@ describe('buildNewsroomVideos', () => {
         expectedUrl.searchParams.set('maxResults', '5');
 
         expect(fetch).toHaveBeenCalledWith(expectedUrl.toString());
-
         const response = readFileSync(testFilePath, 'utf8');
         expect(response).toEqual(expectedResult);
         expect(result).toEqual(expectedResult);

--- a/tests/build-newsroom-videos.test.js
+++ b/tests/build-newsroom-videos.test.js
@@ -1,13 +1,14 @@
 const { readFileSync, removeSync, mkdirpSync } = require('fs-extra');
-const { resolve } = require('path');
+const { resolve, join } = require('path');
 const { buildNewsroomVideos } = require('../scripts/build-newsroom-videos');
 const { mockApiResponse, expectedResult } = require('./fixtures/newsroomData');
 const fetch = require('node-fetch-2');
+const os = require('os');
 
 jest.mock('node-fetch-2', () => jest.fn());
 
 describe('buildNewsroomVideos', () => {
-    const testDir = resolve(__dirname, 'test_config');
+    const testDir = join(os.tmpdir(), 'test_config');
     const testFilePath = resolve(testDir, 'newsroom_videos.json');
 
     beforeAll(() => {
@@ -89,7 +90,7 @@ describe('buildNewsroomVideos', () => {
             json: jest.fn().mockResolvedValue(mockApiResponse),
         });
 
-        const invalidPath = '/invalid_dir/newsroom_videos.json';
+        const invalidPath = resolve(os.tmpdir(), 'invalid_dir', 'newsroom_videos.json');
 
         try {
             await buildNewsroomVideos(invalidPath);

--- a/tests/build-tools.test.js
+++ b/tests/build-tools.test.js
@@ -3,6 +3,8 @@ const { resolve } = require('path');
 const { buildTools } = require('../scripts/build-tools');
 const { tagsData, manualTools, mockConvertedData, mockExtractData } = require('../tests/fixtures/buildToolsData');
 const fs = require('fs-extra');
+const os = require('os');
+const path = require('path');
 
 jest.mock('axios');
 jest.mock('../scripts/tools/categorylist', () => ({
@@ -24,7 +26,7 @@ jest.mock('../scripts/tools/tags-color', () => ({
 }));
 
 describe('buildTools', () => {
-    const testDir = resolve(__dirname, 'test_config');
+    const testDir = path.join(os.tmpdir(), 'test_config');
     const toolsPath = resolve(testDir, 'tools.json');
     const tagsPath = resolve(testDir, 'all-tags.json');
     const automatedToolsPath = resolve(testDir, 'tools-automated.json');
@@ -33,7 +35,6 @@ describe('buildTools', () => {
 
     beforeAll(() => {
         consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => {});
-
         fs.ensureDirSync(testDir);
         fs.outputFileSync(manualToolsPath, JSON.stringify(manualTools));
     });
@@ -81,7 +82,7 @@ describe('buildTools', () => {
     it('should handle file write errors', async () => {
         axios.get.mockResolvedValue({ data: mockExtractData });
 
-        const invalidPath = '/invalid_dir/tools.json';
+        const invalidPath = path.resolve(os.tmpdir(), 'invalid_dir', 'tools.json');
 
         try {
             await buildTools(invalidPath, manualToolsPath, toolsPath, tagsPath);

--- a/tests/build-tools.test.js
+++ b/tests/build-tools.test.js
@@ -1,5 +1,5 @@
 const axios = require('axios');
-const { resolve } = require('path');
+const path = require('path');
 const { buildTools } = require('../scripts/build-tools');
 const { tagsData, manualTools, mockConvertedData, mockExtractData } = require('../tests/fixtures/buildToolsData');
 const fs = require('fs');
@@ -24,11 +24,11 @@ jest.mock('../scripts/tools/tags-color', () => ({
 }));
 
 describe('buildTools', () => {
-    const testDir = resolve(__dirname, 'test_config');
-    const toolsPath = resolve(testDir, 'tools.json');
-    const tagsPath = resolve(testDir, 'all-tags.json');
-    const automatedToolsPath = resolve(testDir, 'tools-automated.json');
-    const manualToolsPath = resolve(testDir, 'tools-manual.json');
+    const testDir = path.join(__dirname, 'test_config');
+    const toolsPath = path.join(testDir, 'tools.json');
+    const tagsPath = path.join(testDir, 'all-tags.json');
+    const automatedToolsPath = path.join(testDir, 'tools-automated.json');
+    const manualToolsPath = path.join(testDir, 'tools-manual.json');
 
     beforeAll(() => {
         fs.mkdirSync(testDir, { recursive: true });
@@ -78,7 +78,7 @@ describe('buildTools', () => {
     it('should handle file write errors', async () => {
         axios.get.mockResolvedValue({ data: mockExtractData });
 
-        const invalidPath = '/invalid_dir/tools.json';
+        const invalidPath = path.join('/invalid_dir', 'tools.json');
 
         try {
             await buildTools(invalidPath, manualToolsPath, toolsPath, tagsPath);


### PR DESCRIPTION
This PR replaces resolve with path.join for paths in build-tools script and its test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced error handling and directory management in build tools and tests.
	- Updated file handling to utilize `fs-extra` for improved file system operations.
	- Modified test setup to ensure directories are created and cleaned up correctly, preventing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->