### PR TITLE
fix: restrict markdown tests to ubuntu runner

### DIFF
--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -2,7 +2,7 @@
 name: PR testing - if Node project
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
   push:
     branches: [master]
@@ -76,7 +76,7 @@ jobs:
         run: npm run generate:assets --if-present
 
       # Run the test:md script and capture output
-      - if: steps.packagejson.outputs.exists == 'true'
+      - if: ${{ steps.packagejson.outputs.exists == 'true' && matrix.os == 'ubuntu-latest' }}
         name: Run markdown checks
         id: markdown_check
         run: |
@@ -87,7 +87,7 @@ jobs:
 
       # Post a comment using sticky-pull-request-comment
       - name: Comment on PR with markdown issues
-        if: ${{ steps.markdown_check.outputs.markdown_output != '' }}
+        if: ${{ steps.markdown_check.outputs.markdown_output != '' && matrix.os == 'ubuntu-latest' }}
         uses: marocchino/sticky-pull-request-comment@3d60a5b2dae89d44e0c6ddc69dd7536aec2071cd
         with:
           header: markdown-check-error
@@ -102,7 +102,7 @@ jobs:
             ```
 
       # Delete the comment if there are no issues
-      - if: ${{ steps.markdown_check.outputs.markdown_output == '' }}
+      - if: ${{ steps.markdown_check.outputs.markdown_output == '' && matrix.os == 'ubuntu-latest' }}
         name: Delete markdown check comment
         uses: marocchino/sticky-pull-request-comment@3d60a5b2dae89d44e0c6ddc69dd7536aec2071cd
         with:

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -2,7 +2,7 @@
 name: PR testing - if Node project
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
   push:
     branches: [master]

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -42,6 +42,9 @@ jobs:
       - if: steps.should_run.outputs.shouldrun == 'true'
         name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
       - if: steps.should_run.outputs.shouldrun == 'true'
         name: Check if Node.js project and has package.json
         id: packagejson

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -2,7 +2,7 @@
 name: PR testing - if Node project
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
   push:
     branches: [master]


### PR DESCRIPTION
This PR restricts markdown tests to Ubuntu Runner since we cannot make use of commands like sed in Windows bash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated workflow configuration for pull request testing to improve control flow.
	- Implemented OS-specific conditions for executing markdown checks and commenting on PR issues.
	- Expanded job matrix to include macOS and Windows environments for broader testing coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->