### PR TITLE
fix: make the edit page on github point to correct resource

### DIFF
--- a/config/edit-page-config.json
+++ b/config/edit-page-config.json
@@ -13,7 +13,7 @@
   },
   {
     "value": "",
-    "href": "https://github.com/asyncapi/website/blob/master/pages"
+    "href": "https://github.com/asyncapi/website/blob/master/markdown"
   },
   {
     "value": "reference/extensions/",


### PR DESCRIPTION
**Description**
- The older link was pointing to a wrong resource.
- Involved finding where the correct resource exists.
- Changed the link to now open the correct markdown files
- Previous error page on clicking the link:

![image](https://github.com/user-attachments/assets/ae668445-4cfb-4ef9-8abc-a859de5cbcdc)

- Current working after updating:

![image](https://github.com/user-attachments/assets/d1562eb2-2c97-4831-93da-b54447c0002b)



**Related issue(s)**
Fixes #3300