### PR TITLE
refactor: removed the unnecessary useState() hook and onMouseEnter() …

### DIFF
--- a/pages/community/tsc.tsx
+++ b/pages/community/tsc.tsx
@@ -1,5 +1,5 @@
 import { sortBy } from 'lodash';
-import React, { useState } from 'react';
+import React from 'react';
 
 import type { Tsc } from '@/types/pages/community/Community';
 
@@ -66,11 +66,9 @@ function addAdditionalUserInfo(user: Tsc) {
  * @returns The Twitter SVG component.
  */
 function TwitterSVG() {
-  const [isHovered, setIsHovered] = useState(false);
-
   return (
-    <div className='size-5' onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
-      <IconTwitter className={isHovered ? 'hover:fill-black' : ''} />
+    <div className='size-5'>
+      <IconTwitter className='hover:fill-black' />
     </div>
   );
 }
@@ -81,11 +79,9 @@ function TwitterSVG() {
  * @returns The GitHub SVG component.
  */
 function GitHubSVG() {
-  const [isHovered, setIsHovered] = useState(false);
-
   return (
-    <div className='size-5' onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
-      <IconGithub className={isHovered ? 'hover:fill-black' : ''} />
+    <div className='size-5'>
+      <IconGithub className='hover:fill-black' />
     </div>
   );
 }
@@ -96,12 +92,10 @@ function GitHubSVG() {
  * @returns The LinkedIn SVG component.
  */
 function LinkedInSVG() {
-  const [isHovered, setIsHovered] = useState(false);
-
   return (
-    <div className='size-5' onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+    <div className='size-5'>
       {/* Use the imported SVG icon component */}
-      <IconLinkedIn className={isHovered ? 'hover:fill-linkedin' : ''} />
+      <IconLinkedIn className='hover:fill-linkedin' />
     </div>
   );
 }

--- a/pages/community/tsc.tsx
+++ b/pages/community/tsc.tsx
@@ -1,5 +1,4 @@
 import { sortBy } from 'lodash';
-import React from 'react';
 
 import type { Tsc } from '@/types/pages/community/Community';
 


### PR DESCRIPTION
**Description**
Removed redundant useState() hook and event handlers for hover effects.

Fixes #3413 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Simplified hover effects for social media icons by removing local state management and utilizing CSS classes instead.
	- Updated import statements to reflect the removal of unused state management functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->