### PR TITLE
fix: file not found issue fixed for build tools and newsroom video script

### DIFF
--- a/tests/build-newsroom-videos.test.js
+++ b/tests/build-newsroom-videos.test.js
@@ -1,4 +1,4 @@
-const { readFileSync, removeSync, mkdirpSync } = require('fs-extra');
+const { readFileSync, removeSync, mkdirpSync, outputFileSync } = require('fs-extra');
 const { resolve, join } = require('path');
 const { buildNewsroomVideos } = require('../scripts/build-newsroom-videos');
 const { mockApiResponse, expectedResult } = require('./fixtures/newsroomData');
@@ -13,6 +13,7 @@ describe('buildNewsroomVideos', () => {
 
     beforeAll(() => {
         mkdirpSync(testDir);
+        outputFileSync(testFilePath, JSON.stringify({}));
         process.env.YOUTUBE_TOKEN = 'testkey';
     });
 

--- a/tests/build-tools.test.js
+++ b/tests/build-tools.test.js
@@ -37,6 +37,9 @@ describe('buildTools', () => {
         consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => {});
         fs.ensureDirSync(testDir);
         fs.outputFileSync(manualToolsPath, JSON.stringify(manualTools));
+        fs.outputFileSync(automatedToolsPath, JSON.stringify({}));
+        fs.outputFileSync(toolsPath, JSON.stringify({}));
+        fs.outputFileSync(tagsPath, JSON.stringify({}));
     });
 
     afterAll(() => {


### PR DESCRIPTION
This PR fixes the file not found issue for tests of build-tools and newsroom video script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced test setup by adding file creation for necessary JSON files, ensuring they exist before tests run.
	- Maintained error handling tests to cover various failure scenarios related to file access and data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->