### PR TITLE
fix: fix Spec Explorer link in Docs

### DIFF
--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -31,7 +31,7 @@ export default function Calendar({ className = '', size }: ICalendarProps) {
   const eventsExist = eventsData.length > 0;
 
   return (
-    <div className={twMerge('overflow-hidden rounded-md border border-gray-200 bg-white p-4 h-full', className)}>
+    <div className={twMerge('overflow-hidden rounded-md border border-gray-200 bg-white p-4', className)}>
       <Heading level={HeadingLevel.h2} typeStyle={HeadingTypeStyle.mdSemibold}>
         {t('calendar.title')}
       </Heading>

--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -31,7 +31,7 @@ export default function Calendar({ className = '', size }: ICalendarProps) {
   const eventsExist = eventsData.length > 0;
 
   return (
-    <div className={twMerge('overflow-hidden rounded-md border border-gray-200 bg-white p-4', className)}>
+    <div className={twMerge('overflow-hidden rounded-md border border-gray-200 bg-white p-4 h-full', className)}>
       <Heading level={HeadingLevel.h2} typeStyle={HeadingTypeStyle.mdSemibold}>
         {t('calendar.title')}
       </Heading>

--- a/components/data/buckets.ts
+++ b/components/data/buckets.ts
@@ -93,7 +93,7 @@ export const buckets: Bucket[] = [
     name: 'Explorer',
     title: 'Specification Explorer',
     description: 'Simplifying our Specification JSON Schema like a pro.',
-    link: '/docs/reference/specification/v3.0.0-Explorer',
+    link: '/docs/reference/specification/v3.0.0-explorer',
     className: 'bg-teal-200',
     borderClassName: 'border-orange-200',
     icon: IconExplorer


### PR DESCRIPTION
The **browser requests** in
https://github.com/asyncapi/website/blob/master/components/data/buckets.ts#L96
'**E**xplorer,' but 
the **App Router** in
https://github.com/asyncapi/website/blob/master/components/layout/DocsLayout.tsx#L92
is looking for '**e**xplorer.' 
It does not find it and returns an HTTP 404 error in the local environment.

This PR fixes the inconsistency, ensuring the link returns the correct page after clicking on 'Docs / Specification Explorer'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the URL for the "Explorer" bucket in the documentation links to ensure proper case sensitivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->