### PR TITLE
fix: resolved the links that were inactive on pressing the "edit-this-page" for view docs #3221

### DIFF
--- a/config/edit-page-config.json
+++ b/config/edit-page-config.json
@@ -1,15 +1,7 @@
 [
   {
-    "value": "/tools/generator",
-    "href": "https://github.com/asyncapi/generator/tree/master/docs"
-  },
-  {
     "value": "reference/specification/",
     "href": "https://github.com/asyncapi/spec/blob/master/spec/asyncapi.md"
-  },
-  {
-    "value": "/tools/cli",
-    "href": "https://github.com/asyncapi/cli/tree/master/docs"
   },
   {
     "value": "",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
- Fixed the links that were not working for the files of  docs/tools/generator and docs/tools/cli 
- There was an unnecessary json in the config/edit-page-config.json file,removed them  
- Resolved the issue where the "Edit this page on GitHub" link was not functioning correctly. It is now fixed and working as intended.

**Related issue(s)**
Fixes #3221 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated configuration by removing links to the AsyncAPI generator and CLI documentation.
- **Bug Fixes**
	- Cleaned up outdated references in the edit page configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->