### PR TITLE
fix: bump codecov from v4 to v5

### DIFF
--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -121,5 +121,4 @@ jobs:
         with:
           fail_ci_if_error: true
           files: ./coverage/lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -117,7 +117,7 @@ jobs:
 
       - if: steps.packagejson.outputs.exists == 'true'
         name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673
+        uses: codecov/codecov-action@7f8b4b4bde536c465e797be725718b88c5d95e0e
         with:
           fail_ci_if_error: true
           files: ./coverage/lcov.info

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -117,8 +117,9 @@ jobs:
 
       - if: steps.packagejson.outputs.exists == 'true'
         name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@7f8b4b4bde536c465e797be725718b88c5d95e0e
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           files: ./coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true


### PR DESCRIPTION
**Description**

- Changes as suggested in https://github.com/codecov/codecov-action/issues/1580
- and https://github.com/zigpy/workflows/pull/26

**Related issue(s)**
fixes https://github.com/asyncapi/website/issues/3469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the `codecov-action` version for improved coverage report uploads in the Node.js pull request testing workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->