### PR TITLE
fix: fixed text on the events page two buttons and linked it to the common.json file

### DIFF
--- a/components/buttons/GoogleCalendarButton.tsx
+++ b/components/buttons/GoogleCalendarButton.tsx
@@ -27,13 +27,13 @@ export default function GoogleCalendarButton({
 }: IGoogleCalendarButtonProps) {
   const { t } = useTranslation('common');
   
-// created a variable with name 'googleCalenderBtnText' to take the value from 'common.json' file to add text on the button
+// created a variable with name 'googleCalendarBtnText' to take the value from 'common.json' file to add text on the button
 
-let googleCalenderBtnText = details.googleCalendarBtn;
+let googleCalendarBtnText = details.googleCalendarBtn;
 
   return (
     <Button
-      text={t(googleCalenderBtnText)}
+      text={t(googleCalendarBtnText)}
       icon={<IconGoogleCalendar />}
       href={href}
       iconPosition={iconPosition}

--- a/components/buttons/GoogleCalendarButton.tsx
+++ b/components/buttons/GoogleCalendarButton.tsx
@@ -38,3 +38,4 @@ export default function GoogleCalendarButton({
     />
   );
 }
+

--- a/components/buttons/GoogleCalendarButton.tsx
+++ b/components/buttons/GoogleCalendarButton.tsx
@@ -19,7 +19,6 @@ interface IGoogleCalendarButtonProps extends IButtonDefaultProps {}
  * @param {string} props.className - The class name to be applied to the button.
  */
 export default function GoogleCalendarButton({
-  text,
   href,
   target = '_blank',
   iconPosition = ButtonIconPosition.LEFT,

--- a/components/buttons/GoogleCalendarButton.tsx
+++ b/components/buttons/GoogleCalendarButton.tsx
@@ -26,14 +26,10 @@ export default function GoogleCalendarButton({
   className
 }: IGoogleCalendarButtonProps) {
   const { t } = useTranslation('common');
-  
-// created a variable with name 'googleCalendarBtnText' to take the value from 'common.json' file to add text on the button
-
-let googleCalendarBtnText = details.googleCalendarBtn;
 
   return (
     <Button
-      text={t(googleCalendarBtnText)}
+      text={t(details.googleCalendarBtn)}
       icon={<IconGoogleCalendar />}
       href={href}
       iconPosition={iconPosition}

--- a/components/buttons/GoogleCalendarButton.tsx
+++ b/components/buttons/GoogleCalendarButton.tsx
@@ -19,7 +19,7 @@ interface IGoogleCalendarButtonProps extends IButtonDefaultProps {}
  * @param {string} props.className - The class name to be applied to the button.
  */
 export default function GoogleCalendarButton({
-  text = 'googleCalendarBtn',
+  text,
   href,
   target = '_blank',
   iconPosition = ButtonIconPosition.LEFT,

--- a/components/buttons/GoogleCalendarButton.tsx
+++ b/components/buttons/GoogleCalendarButton.tsx
@@ -6,6 +6,7 @@ import type { IButtonDefaultProps } from '../../types/components/buttons/types';
 import { useTranslation } from '../../utils/i18n';
 import IconGoogleCalendar from '../icons/GoogleCalendar';
 import Button from './Button';
+import details from '../../public/locales/en/common.json';
 
 interface IGoogleCalendarButtonProps extends IButtonDefaultProps {}
 
@@ -25,10 +26,14 @@ export default function GoogleCalendarButton({
   className
 }: IGoogleCalendarButtonProps) {
   const { t } = useTranslation('common');
+  
+// created a variable with name 'googleCalenderBtnText' to take the value from 'common.json' file to add text on the button
+
+let googleCalenderBtnText = details.googleCalendarBtn;
 
   return (
     <Button
-      text={t(text)}
+      text={t(googleCalenderBtnText)}
       icon={<IconGoogleCalendar />}
       href={href}
       iconPosition={iconPosition}

--- a/components/buttons/ICSFileButton.tsx
+++ b/components/buttons/ICSFileButton.tsx
@@ -38,3 +38,4 @@ export default function ICSFButton({
     />
   );
 }
+

--- a/components/buttons/ICSFileButton.tsx
+++ b/components/buttons/ICSFileButton.tsx
@@ -29,7 +29,7 @@ export default function ICSFButton({
 
   return (
     <Button
-      text={t(details.icsFileBtn;)}
+      text={t(details.icsFileBtn)}
       icon={<IconCalendar />}
       href={href}
       iconPosition={iconPosition}

--- a/components/buttons/ICSFileButton.tsx
+++ b/components/buttons/ICSFileButton.tsx
@@ -6,6 +6,7 @@ import type { IButtonDefaultProps } from '../../types/components/buttons/types';
 import { useTranslation } from '../../utils/i18n';
 import IconCalendar from '../icons/Calendar';
 import Button from './Button';
+import details from '../../public/locales/en/common.json';
 
 interface IICSFButtonProps extends IButtonDefaultProps {}
 
@@ -26,9 +27,13 @@ export default function ICSFButton({
 }: IICSFButtonProps) {
   const { t } = useTranslation('common');
 
+// created a variable with name 'icsFileBtnText' to take the value from 'common.json' file to add text on the button
+
+let icsFileBtnText = details.icsFileBtn;
+
   return (
     <Button
-      text={t(text)}
+      text={t(icsFileBtnText)}
       icon={<IconCalendar />}
       href={href}
       iconPosition={iconPosition}

--- a/components/buttons/ICSFileButton.tsx
+++ b/components/buttons/ICSFileButton.tsx
@@ -19,7 +19,7 @@ interface IICSFButtonProps extends IButtonDefaultProps {}
  * @param {string} props.className - The class name to be applied to the button.
  */
 export default function ICSFButton({
-  text = 'icsFileBtn',
+  text,
   href,
   target = '_blank',
   iconPosition = ButtonIconPosition.LEFT,
@@ -27,13 +27,9 @@ export default function ICSFButton({
 }: IICSFButtonProps) {
   const { t } = useTranslation('common');
 
-// created a variable with name 'icsFileBtnText' to take the value from 'common.json' file to add text on the button
-
-let icsFileBtnText = details.icsFileBtn;
-
   return (
     <Button
-      text={t(icsFileBtnText)}
+      text={t(details.icsFileBtn;)}
       icon={<IconCalendar />}
       href={href}
       iconPosition={iconPosition}

--- a/components/buttons/ICSFileButton.tsx
+++ b/components/buttons/ICSFileButton.tsx
@@ -19,7 +19,6 @@ interface IICSFButtonProps extends IButtonDefaultProps {}
  * @param {string} props.className - The class name to be applied to the button.
  */
 export default function ICSFButton({
-  text,
   href,
   target = '_blank',
   iconPosition = ButtonIconPosition.LEFT,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

-Screenshots

With Error

![Screenshot 2024-12-19 at 6 42 13 PM](https://github.com/user-attachments/assets/b7627087-73a3-4e46-b0f9-5e590d936ee7)

Fixed 

![Screenshot 2024-12-19 at 6 42 18 PM](https://github.com/user-attachments/assets/8a9f048b-901d-4375-94e6-6fec57dfd909)


-Description 

- Updated the text on two buttons on the events page under the community section in the navbar and linked those texts to the '[common.json](https://github.com/asyncapi/website/blob/master/public/locales/en/common.json)' file.


-Issue resolved

#3465 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced internationalization for the Google Calendar and ICS File buttons by sourcing button text from a localization JSON file.
- **Bug Fixes**
	- Updated button text retrieval logic to improve localization accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->