### PR TITLE
fix: refactor the 'Edit this page on GitHub' workflow (#3221)

### DIFF
--- a/components/layout/DocsLayout.tsx
+++ b/components/layout/DocsLayout.tsx
@@ -60,7 +60,7 @@ function generateEditLink(post: IPost) {
   if (isHrefToFile) last = '';
 
   return (
-    <a target='_blank' rel='noopener noreferrer' href={`${target?.href}/${last}`} className='ml-1 underline'>
+    <a target='_blank' rel='noopener noreferrer' href={`${target?.href}/${last.slice(0, -1)}`} className='ml-1 underline'>
       {EditPage}
     </a>
   );

--- a/components/layout/DocsLayout.tsx
+++ b/components/layout/DocsLayout.tsx
@@ -60,7 +60,12 @@ function generateEditLink(post: IPost) {
   if (isHrefToFile) last = '';
 
   return (
-    <a target='_blank' rel='noopener noreferrer' href={`${target?.href}/${last.slice(0, -1)}`} className='ml-1 underline'>
+    <a
+      target='_blank'
+      rel='noopener noreferrer'
+      href={`${target?.href}/${last.slice(0, -1)}`}
+      className='ml-1 underline'
+    >
       {EditPage}
     </a>
   );

--- a/config/edit-page-config.json
+++ b/config/edit-page-config.json
@@ -1,7 +1,7 @@
 [
   {
     "value": "/tools/generator",
-    "href": "https://github.com/asyncapi/generator/tree/master/docs"
+    "href": "https://github.com/asyncapi/generator/blob/master/apps/generator/docs"
   },
   {
     "value": "reference/specification/",
@@ -9,7 +9,7 @@
   },
   {
     "value": "/tools/cli",
-    "href": "https://github.com/asyncapi/cli/tree/master/docs"
+    "href": "https://github.com/asyncapi/cli/blob/master/docs"
   },
   {
     "value": "",
@@ -17,6 +17,6 @@
   },
   {
     "value": "reference/extensions/",
-    "href": "https://github.com/asyncapi/extensions-catalog/tree/master/extensions"
+    "href": "https://github.com/asyncapi/extensions-catalog/blob/master/extensions"
   }
 ]


### PR DESCRIPTION
### Description

This Pull Request addresses the broken or incorrect “Edit this page on GitHub” links by modifying two key files:

1. **`config/edit-page-config.json`**  
   - Changed `tree/master` references to `blob/master`.  
   - Updated paths for `/tools/generator`, `/tools/cli`, and other sections:
     ```diff
     - "https://github.com/asyncapi/generator/tree/master/docs"
     + "https://github.com/asyncapi/generator/blob/master/apps/generator/docs"

     - "https://github.com/asyncapi/cli/tree/master/docs"
     + "https://github.com/asyncapi/cli/blob/master/docs"

     - "https://github.com/asyncapi/extensions-catalog/tree/master/extensions"
     + "https://github.com/asyncapi/extensions-catalog/blob/master/extensions"

     (etc.)
     ```

2. **`components/layout/DocsLayout.tsx`**  
   - Modified the link logic to remove the trailing slash via `last.slice(0, -1)`:
     ```diff
     - <a target="_blank" rel="noopener noreferrer" href={`${target?.href}/${last}`} className="ml-1 underline">
     + <a target="_blank" rel="noopener noreferrer" href={`${target?.href}/${last.slice(0, -1)}`} className="ml-1 underline">
     ```

These changes ensure the “Edit this page” link directs contributors to the correct markdown files on GitHub.

### Related Issue
Closes [#3221](https://github.com/asyncapi/website/issues/3221).

### Additional Notes
https://github.com/user-attachments/assets/c2b89b32-69f5-4d5a-9ce3-01017962693d


### Checklist
- [x] [Issue #3221](https://github.com/asyncapi/website/issues/3221) is linked and will close automatically on merge.
- [x] All commits are signed or follow the commit message guidelines.

@sambhavgupta0705 @anshgoyalevil @akshatnema 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected GitHub documentation links for AsyncAPI generator, CLI, and extensions catalog to point directly to specific files.
  - Fixed edit page link generation to ensure accurate URL construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->