### PR TITLE
fix: add scrollable Community dropdown to display all content

### DIFF
--- a/components/navigation/FlyoutMenu.tsx
+++ b/components/navigation/FlyoutMenu.tsx
@@ -14,12 +14,12 @@ interface FlyoutProps {
 export default function Flyout({ items = [] }: FlyoutProps) {
   return (
     <div
-      className="absolute z-50 -ml-4 w-screen max-w-md pt-3 md:ml-12 md:-translate-x-1/2 lg:left-1/2 lg:max-w-3xl lg:-translate-x-1/2"
-      data-testid="Flyout-main"
+      className='absolute z-50 -ml-4 w-screen max-w-md pt-3 md:ml-12 md:-translate-x-1/2 lg:left-1/2 lg:max-w-3xl lg:-translate-x-1/2'
+      data-testid='Flyout-main'
     >
-      <div className="rounded-lg shadow-lg">
-        <div className="shadow-xs overflow-hidden rounded-lg">
-          <div className="scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-transparent relative z-20 grid max-h-96 min-h-40 gap-6 overflow-y-auto bg-white px-5 py-6 sm:gap-8 sm:p-8 lg:grid-cols-2">
+      <div className='rounded-lg shadow-lg'>
+        <div className='shadow-xs overflow-hidden rounded-lg'>
+          <div className='scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-transparent relative z-20 grid max-h-96 min-h-40 gap-6 overflow-y-auto bg-white px-5 py-6 sm:gap-8 sm:p-8 lg:grid-cols-2'>
             <MenuBlocks items={items} />
           </div>
         </div>

--- a/components/navigation/FlyoutMenu.tsx
+++ b/components/navigation/FlyoutMenu.tsx
@@ -14,12 +14,12 @@ interface FlyoutProps {
 export default function Flyout({ items = [] }: FlyoutProps) {
   return (
     <div
-      className="absolute z-50 -ml-4 w-screen max-w-md pt-3 md:ml-12 md:-translate-x-1/2 lg:left-1/2 lg:max-w-3xl lg:-translate-x-1/2"
-      data-testid="Flyout-main"
+      className='absolute z-50 -ml-4 w-screen max-w-md pt-3 md:ml-12 md:-translate-x-1/2 lg:left-1/2 lg:max-w-3xl lg:-translate-x-1/2'
+      data-testid='Flyout-main'
     >
-      <div className="rounded-lg shadow-lg">
-        <div className="shadow-xs overflow-hidden rounded-lg">
-          <div className="scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-transparent relative z-20 grid max-h-[calc(100vh-20px)] gap-6 overflow-y-auto bg-white px-5 py-6 sm:gap-8 sm:p-8 lg:grid-cols-2">
+      <div className='rounded-lg shadow-lg'>
+        <div className='shadow-xs overflow-hidden rounded-lg'>
+          <div className='scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-transparent relative z-20 grid max-h-[calc(100vh-20px)] gap-6 overflow-y-auto bg-white px-5 py-6 sm:gap-8 sm:p-8 lg:grid-cols-2'>
             <MenuBlocks items={items} />
           </div>
         </div>

--- a/components/navigation/FlyoutMenu.tsx
+++ b/components/navigation/FlyoutMenu.tsx
@@ -14,12 +14,12 @@ interface FlyoutProps {
 export default function Flyout({ items = [] }: FlyoutProps) {
   return (
     <div
-      className='absolute z-50 -ml-4 w-screen max-w-md pt-3 md:ml-12 md:-translate-x-1/2 lg:left-1/2 lg:max-w-3xl lg:-translate-x-1/2'
-      data-testid='Flyout-main'
+      className="absolute z-50 -ml-4 w-screen max-w-md pt-3 md:ml-12 md:-translate-x-1/2 lg:left-1/2 lg:max-w-3xl lg:-translate-x-1/2"
+      data-testid="Flyout-main"
     >
-      <div className='rounded-lg shadow-lg'>
-        <div className='shadow-xs overflow-hidden rounded-lg'>
-          <div className='scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-transparent relative z-20 grid max-h-96 min-h-40 gap-6 overflow-y-auto bg-white px-5 py-6 sm:gap-8 sm:p-8 lg:grid-cols-2'>
+      <div className="rounded-lg shadow-lg">
+        <div className="shadow-xs overflow-hidden rounded-lg">
+          <div className="scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-transparent relative z-20 grid max-h-[calc(100vh-20px)] gap-6 overflow-y-auto bg-white px-5 py-6 sm:gap-8 sm:p-8 lg:grid-cols-2">
             <MenuBlocks items={items} />
           </div>
         </div>

--- a/components/navigation/FlyoutMenu.tsx
+++ b/components/navigation/FlyoutMenu.tsx
@@ -19,7 +19,7 @@ export default function Flyout({ items = [] }: FlyoutProps) {
     >
       <div className="rounded-lg shadow-lg">
         <div className="shadow-xs overflow-hidden rounded-lg">
-          <div className="relative z-20 grid gap-6 bg-white px-5 py-6 sm:gap-8 sm:p-8 lg:grid-cols-2 max-h-96 min-h-40 overflow-y-auto scrollbar-thin scrollbar-thumb-white scrollbar-track-transparent">
+          <div className="scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-transparent relative z-20 grid max-h-96 min-h-40 gap-6 overflow-y-auto bg-white px-5 py-6 sm:gap-8 sm:p-8 lg:grid-cols-2">
             <MenuBlocks items={items} />
           </div>
         </div>

--- a/components/navigation/FlyoutMenu.tsx
+++ b/components/navigation/FlyoutMenu.tsx
@@ -14,12 +14,12 @@ interface FlyoutProps {
 export default function Flyout({ items = [] }: FlyoutProps) {
   return (
     <div
-      className='absolute z-50 -ml-4 w-screen max-w-md pt-3 md:ml-12 md:-translate-x-1/2 lg:left-1/2 lg:max-w-3xl lg:-translate-x-1/2'
-      data-testid='Flyout-main'
+      className="absolute z-50 -ml-4 w-screen max-w-md pt-3 md:ml-12 md:-translate-x-1/2 lg:left-1/2 lg:max-w-3xl lg:-translate-x-1/2"
+      data-testid="Flyout-main"
     >
-      <div className='rounded-lg shadow-lg'>
-        <div className='shadow-xs overflow-hidden rounded-lg'>
-          <div className='relative z-20 grid gap-6 bg-white px-5 py-6 sm:gap-8 sm:p-8 lg:grid-cols-2'>
+      <div className="rounded-lg shadow-lg">
+        <div className="shadow-xs overflow-hidden rounded-lg">
+          <div className="relative z-20 grid gap-6 bg-white px-5 py-6 sm:gap-8 sm:p-8 lg:grid-cols-2 max-h-96 min-h-40 overflow-y-auto scrollbar-thin scrollbar-thumb-white scrollbar-track-transparent">
             <MenuBlocks items={items} />
           </div>
         </div>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->
The "Community" dropdown should display all its content, even if the content exceeds the available space. A scrollbar should appear when the dropdown content is too large, allowing users to scroll through the options.

**#3549**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Enhanced flyout menu styling with new CSS classes for maximum height and vertical scrolling control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->