### PR TITLE
feat: add-all-generator-templates-manually

### DIFF
--- a/config/tools-manual.json
+++ b/config/tools-manual.json
@@ -29,7 +29,93 @@
     },
     "AsyncAPI Generator Templates": {
         "description": "The following is a list of templates compatible with AsyncAPI Generator. You can use them to generate apps, clients or documentation from your AsyncAPI documents.",
-        "toolsList": []
+        "toolsList": [
+            {
+                "title": "Go Watermill Template",
+                "description": "Generates Go client using Watermill",
+                "links": {
+                    "repoUrl": "https://github.com/asyncapi/go-watermill-template"
+                },
+                "filters": {
+                    "language": "Go",
+                    "technology": ["Watermill"],
+                    "categories": ["generator-template"]
+                }
+            },
+            {
+                "title": "Node.js Template",
+                "description": "Generates Node.js client and server code",
+                "links": {
+                    "repoUrl": "https://github.com/asyncapi/nodejs-template"
+                },
+                "filters": {
+                    "language": "JavaScript",
+                    "technology": ["Node.js"],
+                    "categories": ["generator-template"]
+                }
+            },
+            {
+                "title": "Markdown Template",
+                "description": "Generates documentation in Markdown format",
+                "links": {
+                    "repoUrl": "https://github.com/asyncapi/markdown-template"
+                },
+                "filters": {
+                    "language": "Markdown",
+                    "technology": [],
+                    "categories": ["generator-template"]
+                }
+            },
+            {
+                "title": "Python Paho Template",
+                "description": "Generates Python client using Paho MQTT",
+                "links": {
+                    "repoUrl": "https://github.com/asyncapi/python-paho-template"
+                },
+                "filters": {
+                    "language": "Python",
+                    "technology": ["Paho"],
+                    "categories": ["generator-template"]
+                }
+            },
+            {
+                "title": "Dotnet RabbitMQ Template",
+                "description": "Generates .NET client using RabbitMQ",
+                "links": {
+                    "repoUrl": "https://github.com/asyncapi/dotnet-rabbitmq-template"
+                },
+                "filters": {
+                    "language": ".NET",
+                    "technology": ["RabbitMQ"],
+                    "categories": ["generator-template"]
+                }
+            },
+            {
+                "title": "Node.js WebSocket Template",
+                "description": "Generates Node.js client and server code using WebSocket",
+                "links": {
+                    "repoUrl": "https://github.com/asyncapi/nodejs-ws-template"
+                },
+                "filters": {
+                    "language": "JavaScript",
+                    "technology": ["WebSocket"],
+                    "categories": ["generator-template"]
+                }
+            },
+            {
+                "title": "TypeScript NATS Template",
+                "description": "Generates TypeScript client using NATS",
+                "links": {
+                    "repoUrl": "https://github.com/asyncapi/ts-nats-template"
+                },
+                "filters": {
+                    "language": "TypeScript",
+                    "technology": ["NATS"],
+                    "categories": ["generator-template"]
+                }
+            }
+
+        ]
     },
     "Code-first tools": {
         "description": "The following is a list of tools that generate AsyncAPI documents from your code.",


### PR DESCRIPTION


<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- To solve Stale issue https://github.com/asyncapi/generator/issues/921 from generator project  
- I was asked to resolve it by following  steps https://github.com/asyncapi/generator/issues/921#issuecomment-2590638495
- I have added the generator related templates in `tools-manual.json`, but as for now, the changes are not getting reflected on [Tools Page ](https://www.asyncapi.com/tools) locally. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added 7 new AsyncAPI generator templates for various programming languages and technologies
	- Expanded template options for Go, Node.js, Markdown, Python, .NET, WebSocket, and TypeScript
	- Enhanced code generation and documentation capabilities for AsyncAPI users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->