### PR TITLE
fix: form clear after bug

### DIFF
--- a/components/NewsletterSubscribe.tsx
+++ b/components/NewsletterSubscribe.tsx
@@ -59,6 +59,10 @@ export default function NewsletterSubscribe({
 
   const setFormStatus = (formResponse: FormStatus) => {
     setStatus(formResponse);
+    if (formResponse === FormStatus.ERROR) {
+      setEmail('');
+      setName('');
+    }
     setTimeout(() => {
       setStatus(FormStatus.NORMAL);
     }, 10000);


### PR DESCRIPTION
**Description**

When the newsletter subscription fails, the form used to display the incorrect data after 10 seconds when it reloads. I have fixed this issue by clearing the input fields (email and name) after an error.

**Related issue(s)**

Fixes #3622 

**After Solved** 

https://github.com/user-attachments/assets/7fb33020-95fb-4bac-8046-a816ebebe02e





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling in newsletter subscription form by clearing input fields when a submission error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->