### PR TITLE
fix: center filter alignment on large screen

### DIFF
--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -96,7 +96,7 @@ export default function BlogIndexPage() {
               <TextLink href='/rss.xml'> RSS Feed</TextLink>, too!
             </Paragraph>
           </div>
-          <div className='mx:64 mt-12 md:flex md:justify-center lg:justify-start'>
+          <div className='mx:64 mt-12 md:flex md:justify-center lg:justify-center'>
             <Filter
               data={navItems || []}
               onFilter={onFilter}

--- a/pages/community/index.tsx
+++ b/pages/community/index.tsx
@@ -181,7 +181,7 @@ export default function CommunityIndexPage() {
         />
       </div>
       <div className='mt-10 flex justify-center'>
-        <div className='m-5 p-8 bg-gray-100 rounded-lg shadow-md w-full max-w-6xl'>
+        <div className='m-5 w-full max-w-6xl rounded-lg bg-gray-100 p-8 shadow-md'>
           <div className='w-full'>
             <Card
               type={CardType.SMALL}


### PR DESCRIPTION
## Problem
- The filter component was aligned to the left on large screens (lg:justify-start).

## Solution
- Changed lg:justify-start to lg:justify-center to properly center it.

## Issue Link
- fixes #3626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated filter section layout in Blog page to center-align on large screens
	- Reordered CSS classes in Community page's main container div for consistent styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->