### PR TITLE
fix: remove extra symbols from fragment URLs

### DIFF
--- a/components/TOC.tsx
+++ b/components/TOC.tsx
@@ -39,7 +39,7 @@ export default function TOC({ className, cssBreakingPoint = 'xl', toc, contentSe
       // a-namedefinitionsapplicationaapplication slugWithATag contains transformed heading name that is later used
       // for scroll spy identification
       slugWithATag: item.content
-        .replace(/[<>?!:`'."\\/=,]/gi, '')
+        .replace(/[<>?!:`'."\\/=@#$%^&*()\[\]{}+,;]/gi, '')
         .replace(/\s/gi, '-')
         .toLowerCase()
     }));

--- a/components/TOC.tsx
+++ b/components/TOC.tsx
@@ -39,7 +39,7 @@ export default function TOC({ className, cssBreakingPoint = 'xl', toc, contentSe
       // a-namedefinitionsapplicationaapplication slugWithATag contains transformed heading name that is later used
       // for scroll spy identification
       slugWithATag: item.content
-        .replace(/[<>?!:`'."\\/=]/gi, '')
+        .replace(/[<>?!:`'."\\/=,]/gi, '')        
         .replace(/\s/gi, '-')
         .toLowerCase()
     }));

--- a/components/TOC.tsx
+++ b/components/TOC.tsx
@@ -39,7 +39,7 @@ export default function TOC({ className, cssBreakingPoint = 'xl', toc, contentSe
       // a-namedefinitionsapplicationaapplication slugWithATag contains transformed heading name that is later used
       // for scroll spy identification
       slugWithATag: item.content
-        .replace(/[<>?!:`'."\\/=@#$%^&*()\[\]{}+,;]/gi, '')
+        .replace(/[<>?!:`'."\\/=@#$%^&*()[\]{}+,;]/gi, '')
         .replace(/\s/gi, '-')
         .toLowerCase()
     }));

--- a/components/TOC.tsx
+++ b/components/TOC.tsx
@@ -39,7 +39,7 @@ export default function TOC({ className, cssBreakingPoint = 'xl', toc, contentSe
       // a-namedefinitionsapplicationaapplication slugWithATag contains transformed heading name that is later used
       // for scroll spy identification
       slugWithATag: item.content
-        .replace(/[<>?!:`'."\\/=,]/gi, '')        
+        .replace(/[<>?!:`'."\\/=,]/gi, '')
         .replace(/\s/gi, '-')
         .toLowerCase()
     }));

--- a/components/navigation/Filter.tsx
+++ b/components/navigation/Filter.tsx
@@ -66,6 +66,8 @@ export default function Filter({ data, onFilter, checks, className }: FilterProp
 
           if (e) {
             newQuery[check.name] = e;
+          } else {
+            delete newQuery[check.name]; // Remove filter if deselected
           }
           if (newQuery) {
             const queryParams = new URLSearchParams(newQuery as { [key: string]: string }).toString();


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
This PR fixes an issue where commas (,) in fragment URLs cause broken links.  

https://github.com/user-attachments/assets/82bdf952-092c-468e-a8f5-a870596d2616


**Related issue(s)**
fixes #3633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Style**
	- Updated table of contents slug generation to remove additional special characters during processing, enhancing the cleanliness of slugs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->