### PR TITLE
docs: update CODEOWNERS file with new Docs Committer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,11 +8,11 @@
 * @derberg @akshatnema @magicmatatjahu @anshgoyalevil @mayaleeeee @asyncapi-bot-eve
 
 # All .md files
-*.md @quetzalliwrites @asyncapi-bot-eve
+*.md @quetzalliwrites @TRohit20 @asyncapi-bot-eve
 
-markdown/blog/*.md @thulieblack @quetzalliwrites
-markdown/community/*.md @thulieblack @quetzalliwrites
+markdown/blog/*.md @thulieblack @quetzalliwrites @TRohit20
+markdown/community/*.md @thulieblack @quetzalliwrites @TRohit20
 
-README.md @quetzalliwrites @derberg @akshatnema @magicmatatjahu @mayaleeeee @asyncapi-bot-eve
-#docTriagers: TRohit20 BhaswatiRoy VaishnaviNandakumar J0SAL
+README.md @quetzalliwrites @derberg @akshatnema @magicmatatjahu @TRohit20 @mayaleeeee @asyncapi-bot-eve
+#docTriagers: BhaswatiRoy VaishnaviNandakumar J0SAL
 #codeTriagers: sambhavgupta0705 devilkiller-ag


### PR DESCRIPTION
**Description**
The PR is intended to update the `CODEOWNERS` file, specifically to move @TRohit20 (myself) from Docs Triager maintainer level to Docs 'Committer' level. 

This change will allow me carry out community work in the same capacity as @quetzalliwrites does at the moment, which includes reviewing, approving and merging required documents. 

CC @derberg @quetzalliwrites Kindly have a look and do the needful. Thank you !

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal review processes for documentation files to enhance team collaboration and ensure efficient content oversight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->