### PR TITLE
docs: add Rohit as core docs maintainer and Prince as docs triager

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,11 +8,11 @@
 * @derberg @akshatnema @magicmatatjahu @anshgoyalevil @mayaleeeee @asyncapi-bot-eve
 
 # All .md files
-*.md @quetzalliwrites @asyncapi-bot-eve
+*.md @quetzalliwrites @TRohit20 @asyncapi-bot-eve
 
-markdown/blog/*.md @thulieblack @quetzalliwrites
-markdown/community/*.md @thulieblack @quetzalliwrites
+markdown/blog/*.md @thulieblack @quetzalliwrites @TRohit20
+markdown/community/*.md @thulieblack @quetzalliwrites @TRohit20 
 
 README.md @quetzalliwrites @derberg @akshatnema @magicmatatjahu @mayaleeeee @asyncapi-bot-eve
-#docTriagers: TRohit20 BhaswatiRoy VaishnaviNandakumar J0SAL
+#docTriagers: VaishnaviNandakumar Aahil13
 #codeTriagers: sambhavgupta0705 devilkiller-ag

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,6 +13,6 @@
 markdown/blog/*.md @thulieblack @quetzalliwrites @TRohit20
 markdown/community/*.md @thulieblack @quetzalliwrites @TRohit20 
 
-README.md @quetzalliwrites @derberg @akshatnema @magicmatatjahu @mayaleeeee @TRohit20 @asyncapi-bot-eve
+README.md @quetzalliwrites @derberg @akshatnema @mayaleeeee @TRohit20 @asyncapi-bot-eve
 #docTriagers: VaishnaviNandakumar Aahil13
 #codeTriagers: sambhavgupta0705 devilkiller-ag

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
-* @derberg @akshatnema @magicmatatjahu @anshgoyalevil @mayaleeeee @asyncapi-bot-eve
+* @derberg @akshatnema @anshgoyalevil @mayaleeeee @asyncapi-bot-eve
 
 # All .md files
 *.md @quetzalliwrites @TRohit20 @asyncapi-bot-eve
@@ -13,6 +13,6 @@
 markdown/blog/*.md @thulieblack @quetzalliwrites @TRohit20
 markdown/community/*.md @thulieblack @quetzalliwrites @TRohit20 
 
-README.md @quetzalliwrites @derberg @akshatnema @magicmatatjahu @mayaleeeee @asyncapi-bot-eve
+README.md @quetzalliwrites @derberg @akshatnema @magicmatatjahu @mayaleeeee @TRohit20 @asyncapi-bot-eve
 #docTriagers: VaishnaviNandakumar Aahil13
 #codeTriagers: sambhavgupta0705 devilkiller-ag


### PR DESCRIPTION
I would like to propose we add Rohit as another docs core maintainer, with the same permission level as mine. (It's time we have more than 1 core docs person!)

I also propose we add Prince testing how he does as a docs triager. 

Both folks have confirmed offline they are excited to contribute more :) 

p.s. also removing some docs maintainers from file who aren't still active

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Revised contributor assignments for documentation-related content to better align oversight responsibilities with current team roles.
  - Updated ownership for various markdown files and directories to reflect current contributors.
  - Modified comments regarding documentation triagers for clarity.

These improvements enhance our internal workflows and set the stage for smoother future updates without directly impacting your user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->