### PR TITLE
Update code to support @octokit/request v9 and @octokit/graphql v8

### DIFF
--- a/netlify/functions/github_discussions.ts
+++ b/netlify/functions/github_discussions.ts
@@ -1,5 +1,4 @@
 import type { Handler, HandlerEvent } from '@netlify/functions';
-import type { GraphQlQueryResponseData } from '@octokit/graphql';
 import { graphql } from '@octokit/graphql';
 
 const repositoryID: string =
@@ -25,22 +24,20 @@ const handler: Handler = async function (event: HandlerEvent) {
     const { title, feedback } = JSON.parse(event.body || '');
 
     try {
-      // eslint-disable-next-line function-paren-newline
-      const createDiscussion: GraphQlQueryResponseData = await graphql(
-        `mutation {
+      const createDiscussion = await graphql(
+        {
+          query: `mutation {
             createDiscussion(input:{repositoryId:"${repositoryID}", categoryId:"${categoryID}", title:"${title}", body:"${feedback}"}){
              discussion{
                url
              }
            }
         }`,
-        {
-          owner: 'asyncapi',
-          repo: 'community',
           headers: {
-            authorization: `token ${process.env.GITHUB_TOKEN_CREATE_DISCUSSION}`
+            authorization: `Bearer ${process.env.GITHUB_TOKEN_CREATE_DISCUSSION}`
           }
-        });
+        }
+      );
       const { url } = createDiscussion.createDiscussion.discussion;
 
       return {

--- a/netlify/functions/save-discussion-background/helpers.ts
+++ b/netlify/functions/save-discussion-background/helpers.ts
@@ -18,7 +18,7 @@ export function toTitleCase(title: string): string {
 export async function fetchGraphql(query: string): Promise<any> {
   const parameters = {
     headers: {
-      authorization: `token ${process.env.GITHUB_TOKEN}`,
+      authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
     },
   };
   return await graphql(query, parameters);


### PR DESCRIPTION
Fixes #3690

Update code to support `@octokit/request` v9.2.2 and `@octokit/graphql` v8.2.1.

* **netlify/functions/github_discussions.ts**
  - Remove unused import of `GraphQlQueryResponseData`.
  - Update `graphql` function call to use the new syntax.
  - Update authorization header to use the new token format.

* **netlify/functions/save-discussion-background/helpers.ts**
  - Update authorization header to use the new token format.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved API interactions by reformatting GraphQL queries.
	- Standardized the authentication method by updating to the "Bearer" token format for enhanced integration with external services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->