### PR TITLE
feat: add social sharing buttons to blog posts

### DIFF
--- a/components/layout/BlogLayout.tsx
+++ b/components/layout/BlogLayout.tsx
@@ -8,6 +8,8 @@ import type { IPosts } from '@/types/post';
 
 import BlogContext from '../../context/BlogContext';
 import AuthorAvatars from '../AuthorAvatars';
+import IconTwitter from '../icons/Twitter';
+import IconLinkedIn from '../icons/LinkedIn';
 // import AnnouncementHero from '../campaigns/AnnoucementHero';
 import Head from '../Head';
 import TOC from '../TOC';
@@ -38,6 +40,9 @@ export default function BlogLayout({
   if (!router.isFallback && !post?.slug) {
     return <ErrorPage statusCode={404} />;
   }
+
+  const twitterShareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(post.title)}&url=${encodeURIComponent(`https://www.asyncapi.com${post.slug}`)}`;
+  const linkedInShareUrl = `https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(`https://www.asyncapi.com${post.slug}`)}&title=${encodeURIComponent(post.title)}`;
 
   return (
     <BlogContext.Provider value={{ post }}>
@@ -82,6 +87,14 @@ export default function BlogLayout({
                   <span>{post.readingTime} min read</span>
                 </div>
               </div>
+            </div>
+            <div className='mt-4 flex space-x-4'>
+              <a href={twitterShareUrl} target='_blank' rel='noopener noreferrer' aria-label='Share on Twitter'>
+                <IconTwitter className='h-6 w-6 text-blue-500 hover:text-blue-700' />
+              </a>
+              <a href={linkedInShareUrl} target='_blank' rel='noopener noreferrer' aria-label='Share on LinkedIn'>
+                <IconLinkedIn className='h-6 w-6 text-blue-500 hover:text-blue-700' />
+              </a>
             </div>
           </header>
           <article className='mb-32'>

--- a/components/navigation/BlogPostItem.tsx
+++ b/components/navigation/BlogPostItem.tsx
@@ -12,6 +12,8 @@ import { ParagraphTypeStyle } from '@/types/typography/Paragraph';
 import AuthorAvatars from '../AuthorAvatars';
 import Heading from '../typography/Heading';
 import Paragraph from '../typography/Paragraph';
+import IconTwitter from '../icons/Twitter';
+import IconLinkedIn from '../icons/LinkedIn';
 
 interface BlogPostItemProps {
   // eslint-disable-next-line prettier/prettier
@@ -50,6 +52,9 @@ export default forwardRef(function BlogPostItem(
       break;
     default:
   }
+
+  const twitterShareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(post.title)}&url=${encodeURIComponent(`https://www.asyncapi.com${post.slug}`)}`;
+  const linkedInShareUrl = `https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(`https://www.asyncapi.com${post.slug}`)}&title=${encodeURIComponent(post.title)}`;
 
   return (
     <li className={`list-none rounded-lg ${className}`} ref={ref} id={id}>
@@ -126,6 +131,14 @@ export default forwardRef(function BlogPostItem(
                     <span>{post.readingTime} min read</span>
                   </Paragraph>
                 </div>
+              </div>
+              <div className='mt-4 flex space-x-4'>
+                <a href={twitterShareUrl} target='_blank' rel='noopener noreferrer' aria-label='Share on Twitter'>
+                  <IconTwitter className='h-6 w-6 text-blue-500 hover:text-blue-700' />
+                </a>
+                <a href={linkedInShareUrl} target='_blank' rel='noopener noreferrer' aria-label='Share on LinkedIn'>
+                  <IconLinkedIn className='h-6 w-6 text-blue-500 hover:text-blue-700' />
+                </a>
               </div>
             </div>
           </span>

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -13,6 +13,8 @@ import BlogContext from '@/context/BlogContext';
 import type { IBlogPost } from '@/types/post';
 import { HeadingLevel, HeadingTypeStyle } from '@/types/typography/Heading';
 import { ParagraphTypeStyle } from '@/types/typography/Paragraph';
+import IconTwitter from '@/components/icons/Twitter';
+import IconLinkedIn from '@/components/icons/LinkedIn';
 
 /**
  * @description The BlogIndexPage is the blog index page of the website.


### PR DESCRIPTION
Fixes #3649

Add social sharing buttons for Twitter and LinkedIn to blog posts.

* **BlogLayout.tsx**
  - Import `IconTwitter` and `IconLinkedIn` components.
  - Add social sharing buttons for Twitter and LinkedIn at the top of each blog post.
  - Generate pre-filled sharing links including the blog post title and URL.

* **BlogPostItem.tsx**
  - Import `IconTwitter` and `IconLinkedIn` components.
  - Add social sharing buttons for Twitter and LinkedIn to each blog post item.
  - Generate pre-filled sharing links including the blog post title and URL.

* **index.tsx**
  - Import `IconTwitter` and `IconLinkedIn` components.



