### PR TITLE
docs: update docs to explain relationship between operations, Consumers, and Producers

### DIFF
--- a/markdown/docs/concepts/asyncapi-document/adding-operations.md
+++ b/markdown/docs/concepts/asyncapi-document/adding-operations.md
@@ -41,7 +41,7 @@ onUserSignUp:
   title: User sign up
   summary: React and process information about new user sign up.
   description: Process information about user sign up and update the information in the table that counts numbers of currently signed up users.
-  action: receive
+  action: receive (Consumer)
   channel:
     $ref: '#/channels/userSignup'
 ```
@@ -52,3 +52,11 @@ Some fields are missing from this example:
 - No `messages` field means that this operation processes any message coming from the `userSignup` channel.
 - No `security` field means that there are no special security measures related to this operation and that the security should be applied the same as for other operations. Essentially, the security from the server level should be respected.
 - No `reply` field means that after reacting to the user sign up, this application will not send any reply as a reaction.
+
+## Relationship between Operations, Consumers, and Producers
+
+Operations in AsyncAPI are closely related to the high-level concepts of Consumers and Producers. A Producer is an application that sends messages, while a Consumer is an application that receives messages. In the context of AsyncAPI operations:
+- An operation with the `action` set to `send` corresponds to a Producer.
+- An operation with the `action` set to `receive` corresponds to a Consumer.
+
+Understanding this relationship helps in designing and documenting the interactions between different components in an event-driven architecture. For more details on Consumers and Producers, refer to the [Consumer](/docs/concepts/consumer) and [Producer](/docs/concepts/producer) pages.

--- a/markdown/docs/concepts/consumer.md
+++ b/markdown/docs/concepts/consumer.md
@@ -31,3 +31,5 @@ The diagram above illustrates a sample flow of events from the `producer` to the
 <Remember>
 <b>Subscribers</b> can also be <a href="https://www.asyncapi.com/docs/concepts/producer">producers</a>.
 </Remember>
+
+For more details on how operations link to the high-level concepts of Consumers and Producers, refer to the [Adding operations](/docs/concepts/asyncapi-document/adding-operations) page.

--- a/markdown/docs/concepts/producer.md
+++ b/markdown/docs/concepts/producer.md
@@ -34,3 +34,5 @@ flowchart LR
 ```
 
 In the diagram above, there is a producer publishing messages to a specific channel and a consumer subscribing to messages from that channel. Also, there is a second producer publishing to one channel and subscribing to messages from another channel.
+
+For more details on how operations link to the high-level concepts of Consumers and Producers, refer to the [Adding operations](/docs/concepts/asyncapi-document/adding-operations) page.


### PR DESCRIPTION
Fixes #3450

Add explanation of the relationship between operations, Consumers, and Producers to the 'Adding operations' page.

* Update `markdown/docs/concepts/asyncapi-document/adding-operations.md` to include a section explaining the relationship between operations, Consumers, and Producers.
* Update the language in `operation.action` to reference "Consumers" and "Producers" alongside "receive" and "send".
* Add references to the 'Adding operations' page in `markdown/docs/concepts/consumer.md` and `markdown/docs/concepts/producer.md`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new section that explains how operations relate to message sending and receiving roles.
  - Updated examples to clearly denote the consumer role.
  - Enhanced related guides with additional references for further context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->