### PR TITLE
fix: add Specification Explorer to mobile dropdown and unify Migration spelling (#3727)

### DIFF
--- a/components/navigation/learningItems.tsx
+++ b/components/navigation/learningItems.tsx
@@ -7,6 +7,7 @@ import IconPaper from '../icons/Paper';
 import IconPlant from '../icons/Plant';
 import IconRocket from '../icons/Rocket';
 import IconUsers from '../icons/Users';
+import IconExplorer from '../icons/Explorer';
 
 interface LearningItem {
   href: string;
@@ -56,7 +57,7 @@ const learningItems: LearningItem[] = [
     href: '/docs/migration',
     icon: IconMigration,
     className: 'bg-blue-400',
-    title: 'Migrations',
+    title: 'Migration',
     description: 'Our migration guides on how to upgrade to newer AsyncAPI versions.'
   },
   {
@@ -65,6 +66,13 @@ const learningItems: LearningItem[] = [
     className: 'bg-red-200',
     title: 'Community',
     description: 'Our Community section documents the community guidelines and resources.'
+  },
+  {
+    href: '/docs/reference/specification/v3.0.0-explorer',
+    icon: IconExplorer,
+    className: 'bg-teal-200',
+    title: 'Specification Explorer',
+    description: 'Simplifying our Specification JSON Schema like a pro.',
   }
 ];
 

--- a/components/navigation/learningItems.tsx
+++ b/components/navigation/learningItems.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 
+import IconExplorer from '../icons/Explorer';
 import IconGradCap from '../icons/GradCap';
 import IconGuide from '../icons/Guide';
 import IconMigration from '../icons/Migration';
@@ -7,7 +8,6 @@ import IconPaper from '../icons/Paper';
 import IconPlant from '../icons/Plant';
 import IconRocket from '../icons/Rocket';
 import IconUsers from '../icons/Users';
-import IconExplorer from '../icons/Explorer';
 
 interface LearningItem {
   href: string;
@@ -72,7 +72,7 @@ const learningItems: LearningItem[] = [
     icon: IconExplorer,
     className: 'bg-teal-200',
     title: 'Specification Explorer',
-    description: 'Simplifying our Specification JSON Schema like a pro.',
+    description: 'Simplifying our Specification JSON Schema like a pro.'
   }
 ];
 


### PR DESCRIPTION
**Related issue(s)**
Fixes #3727

**Description**

- Added "Specification Explorer" to the mobile dropdown.
- Unified the spelling of "Migration" across all views (removed extra 's').
- Fixed inconsistencies in navigation between desktop and mobile views.

**Screenshots**
Desktop:
![Screenshot 2025-02-24 215023](https://github.com/user-attachments/assets/04b5e663-a8cf-4d4c-bd14-e81d4bf3b7ca)

Mobile:
![Screenshot 2025-02-24 215504](https://github.com/user-attachments/assets/7ab18383-2081-4aae-8241-44df0f47c022)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "Specification Explorer" navigation item with a distinctive style and description to help users access specification documentation more easily.
  
- **Refactor**
  - Updated the title of an existing navigation item from "Migrations" to "Migration" for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->