### PR TITLE
fix: add specification explorer to mobile view and fix spelling inconsistency

### DIFF
--- a/components/navigation/learningItems.tsx
+++ b/components/navigation/learningItems.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 
+import IconExplorer from '../icons/Explorer';
 import IconGradCap from '../icons/GradCap';
 import IconGuide from '../icons/Guide';
 import IconMigration from '../icons/Migration';
@@ -56,7 +57,7 @@ const learningItems: LearningItem[] = [
     href: '/docs/migration',
     icon: IconMigration,
     className: 'bg-blue-400',
-    title: 'Migrations',
+    title: 'Migration',
     description: 'Our migration guides on how to upgrade to newer AsyncAPI versions.'
   },
   {
@@ -65,6 +66,13 @@ const learningItems: LearningItem[] = [
     className: 'bg-red-200',
     title: 'Community',
     description: 'Our Community section documents the community guidelines and resources.'
+  },
+  {
+    href: '/docs/reference/specification/v3.0.0-explorer',
+    icon: IconExplorer,
+    className: 'bg-teal-200',
+    title: 'Specification Explorer',
+    description: 'Simplifying our Specification JSON Schema like a pro.'
   }
 ];
 


### PR DESCRIPTION
This PR fixes two issues:

1. The "Specification Explorer" tab was missing in the mobile view but was visible in the desktop view.
2. The spelling of "Migration" was inconsistent. It appeared as "Migrations" in the mobile view.

These issues are now resolved to ensure a consistent navigation experience across devices.

Before:-

![imageedit_4_8739910269](https://github.com/user-attachments/assets/06451470-9f2a-45ca-93dd-113139b7de69)



After:-

![imageedit_2_9083419206](https://github.com/user-attachments/assets/4f0d0093-50b4-4940-872d-ae4592c3b864)

Fixes #3727 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new navigation item, "Specification Explorer," featuring its own icon, background styling, and a descriptive summary.

- **Refactor**
  - Updated the label of an existing learning item from "Migrations" to "Migration" for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->