### PR TITLE
fix: remove nested <a> tags from MobileNavMenu and resolve react-i18next issue

### DIFF
--- a/components/navigation/MobileNavMenu.tsx
+++ b/components/navigation/MobileNavMenu.tsx
@@ -85,11 +85,9 @@ export default function MobileNavMenu({
           <div className='space-y-2 px-5 py-2' onClick={() => showMenu('learning')} data-testid='MobileNav-docs'>
             <h4 className='flex justify-between font-medium text-gray-800'>
               {' '}
-              <a className='cursor-pointer'>
-                <Link href='/docs' className='flex'>
+                <Link href='/docs' className='flex cursor-pointer'>
                   Docs
                 </Link>
-              </a>
               <NavItemDropdown />
             </h4>
             {open === 'learning' && <MenuBlocks items={learningItems} />}
@@ -97,22 +95,18 @@ export default function MobileNavMenu({
           <div className='space-y-2 px-5 py-2' onClick={() => showMenu('tooling')} data-testid='MobileNav-tools'>
             <h4 className='flex justify-between font-medium text-gray-800'>
               {' '}
-              <a className='cursor-pointer'>
-                <Link href='/tools' className='flex'>
+                <Link href='/tools' className='flex cursor-pointer'>
                   Tools
                 </Link>
-              </a>
               <NavItemDropdown />
             </h4>
             {open === 'tooling' && <MenuBlocks items={toolingItems} />}
           </div>
           <div className='space-y-2 px-5 py-2' onClick={() => showMenu('community')} data-testid='MobileNav-community'>
             <h4 className='flex justify-between font-medium text-gray-800'>
-              <a className='cursor-pointer'>
-                <Link href='/community' className='flex'>
+                <Link href='/community' className='flex cursor-pointer'>
                   Community
                 </Link>
-              </a>
               <NavItemDropdown />
             </h4>
             {open === 'community' && <MenuBlocks items={communityItems} />}

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "react-dom": "^18",
         "react-ga": "^3.3.1",
         "react-gtm-module": "^2.0.11",
+        "react-i18next": "^15.4.1",
         "react-scrollspy": "^3.4.3",
         "react-syntax-highlighter": "^15.5.0",
         "react-text-truncate": "^0.19.0",
@@ -2323,9 +2324,10 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
-      "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
+      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -15190,7 +15192,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
       "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
-      "peer": true,
       "dependencies": {
         "void-elements": "3.1.0"
       }
@@ -24713,12 +24714,12 @@
       "integrity": "sha512-8gyj4TTxeP7eEyc2QKawEuQoAZdjKvMY4pgWfycGmqGByhs17fR+zEBs0JUDq4US/l+vbTl+6zvUIx27iDo/Vw=="
     },
     "node_modules/react-i18next": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-14.1.2.tgz",
-      "integrity": "sha512-FSIcJy6oauJbGEXfhUgVeLzvWBhIBIS+/9c6Lj4niwKZyGaGb4V4vUbATXSlsHJDXXB+ociNxqFNiFuV1gmoqg==",
-      "peer": true,
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.4.1.tgz",
+      "integrity": "sha512-ahGab+IaSgZmNPYXdV1n+OYky95TGpFwnKRflX/16dY04DsYYKHtVLjeny7sBSCREEcoMbAgSkFiGLF5g5Oofw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
+        "@babel/runtime": "^7.25.0",
         "html-parse-stringify": "^3.0.1"
       },
       "peerDependencies": {
@@ -29981,7 +29982,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
       "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "react-dom": "^18",
     "react-ga": "^3.3.1",
     "react-gtm-module": "^2.0.11",
+    "react-i18next": "^15.4.1",
     "react-scrollspy": "^3.4.3",
     "react-syntax-highlighter": "^15.5.0",
     "react-text-truncate": "^0.19.0",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

fix: remove nested \<a> tags from MobileNavMenu and resolve react-i18next issue

**Description**  
- Removed all \<a> tags from MobileNavMenu to fix the nesting issue.  
- Resolved installation problem related to react-i18next.  
- Ensured proper navigation structure without invalid nesting. 

**Related issue(s)**
`Resolves #3766`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the mobile navigation menu for a more consistent and efficient experience across key sections.
  
- **Chores**
  - Laid the groundwork for upcoming multi-language support by integrating an internationalization library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->