### PR TITLE
fix: fix broken link in the tools section

### DIFF
--- a/components/tools/ToolsCard.tsx
+++ b/components/tools/ToolsCard.tsx
@@ -168,7 +168,7 @@ export default function ToolsCard({ toolData }: ToolsCardProp) {
           </div>
         )}
       </div>
-      {(toolData?.links?.repoUrl || toolData?.links?.websiteUrl || toolData?.links?.docsUrl) && (
+      {(toolData?.links?.repoUrl || toolData?.links?.docsUrl) && (
         <>
           <hr className='' />
           <div className='flex'>
@@ -200,20 +200,6 @@ export default function ToolsCard({ toolData }: ToolsCardProp) {
                   </a>
                 )}
               </>
-            )}
-            {toolData.links.websiteUrl && (
-              <a
-                className='w-full cursor-pointer border-x border-gray-200 px-1 py-6 text-center hover:bg-gray-200'
-                href={toolData.links.websiteUrl}
-                target='_blank'
-                rel='noreferrer'
-                data-testid='ToolsCard-websiteUrl'
-              >
-                <div className='m-auto flex w-fit gap-2'>
-                  <img src='/img/illustrations/icons/share.svg' alt='Share' className='w-5' />
-                  <div className='text-sm text-gray-700'>Visit Website</div>
-                </div>
-              </a>
             )}
             {toolData.links.docsUrl && (
               <a


### PR DESCRIPTION
Fixes #3797

Remove the `View Website` button from the `AsyncAPI Server API` card in the `components/tools/ToolsCard.tsx` file.

* Update the condition to check for `toolData.links.repoUrl` or `toolData.links.docsUrl` instead of `toolData.links.repoUrl` or `toolData.links.websiteUrl` or `toolData.links.docsUrl`.
* Remove the code block that renders the `View Website` button for `toolData.links.websiteUrl`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the tool display by removing the website link option, so now only repository and documentation links are shown when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->