### PR TITLE
fix: incorrect URL for social handles in Ambassadors section

### DIFF
--- a/config/AMBASSADORS_MEMBERS.json
+++ b/config/AMBASSADORS_MEMBERS.json
@@ -54,7 +54,7 @@
     "bio": "Daniel has been part of the codecentric team since October 2016. Since the beginning of 2022 he works as Senior Solution Architect at the Dortmund branch. Starting as a consultant with a focus on application lifecycle management, his focus shifted more and more towards APIs. In addition to numerous customer projects and his involvement in the open source world around APIs, our Head of API Experience & Operations is also a frequent speaker at conferences.",
     "title": "Senior Solution Architect / Head of API Experience and Operations",
     "github": "danielkocot",
-    "twitter": "dk_1977",
+    "twitter": "dankocot",
     "linkedin": "danielkocot",
     "company": "Codecentric AG",
     "country": "🇩🇪",


### PR DESCRIPTION
Fixes #3798

Update the Twitter handle for Daniel Kocot in the Ambassadors section.

* Change the Twitter handle for Daniel Kocot from "dk_1977" to "dankocot" in `config/AMBASSADORS_MEMBERS.json`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated an ambassador's Twitter handle so his profile correctly links to his official social media account, ensuring improved accuracy.
  - Strengthened the reliability of profile information, allowing users to trust the displayed social media details.
  - This change helps maintain consistency and supports our commitment to quality by keeping ambassador profiles up-to-date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->