### PR TITLE
Changed News to Contact us

### DIFF
--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -55,13 +55,13 @@ export default function Footer() {
               <div className='mb-5 px-14 sm:ml-10 sm:px-8 md:ml-5'>
                 <div className='py-2'>
                   <div className='text-white'>
-                    <Heading typeStyle={HeadingTypeStyle.smSemibold}>News</Heading>
+                    <Heading typeStyle={HeadingTypeStyle.smSemibold}>Contact Us</Heading>
                   </div>
                 </div>
                 <ul className='justify-center'>
                   <li className='py-2'>
                     <div className='text-base leading-6 text-cool-gray transition duration-300 ease-in-out hover:text-white'>
-                      <a href='mailto:press@asyncapi.io'>Email Us</a>
+                      <a href='mailto:press@asyncapi.io'>Email </a>
                     </div>
                   </li>
                 </ul>


### PR DESCRIPTION
Fix: Bug
**Before**
<img width="1470" alt="Screenshot 2025-03-09 at 22 16 40" src="https://github.com/user-attachments/assets/5ff5f1e5-2fa2-48a5-ac32-626f9e7fd7c8" />
**After**
<img width="1470" alt="Screenshot 2025-03-09 at 22 16 14" src="https://github.com/user-attachments/assets/0c929934-45d0-4697-bc01-e29f8e6bf51e" />

**Description**
-Changed News to Contact Us in footer

**Related issue(s)**
Fixes #3852 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the footer text for clearer communication by changing the heading from "News" to "Contact Us" and simplifying the email label from "Email Us" to "Email."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->