### PR TITLE
fix: <description>Slack link not working (#3855)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Issues and pull requests without activity from the triager or committer within 1
 
 ### Issues
 
-[Open an issue](https://github.com/asyncapi/asyncapi/issues/new) **only** if you want to report a bug or a feature. Don't open issues for questions or support; join our [AsyncAPI Slack workspace](https://www.asyncapi.com/slack-invite) and post your queries on the relevant channels. Don't forget to follow our [Slack Etiquette](https://github.com/asyncapi/community/blob/master/slack-etiquette.md) while interacting with community members! It's more likely you'll get help, and much faster!
+[Open an issue](https://github.com/asyncapi/asyncapi/issues/new) **only** if you want to report a bug or a feature. Don't open issues for questions or support; join our [AsyncAPI Slack workspace](https://asyncapi.slack.com/) and post your queries on the relevant channels. Don't forget to follow our [Slack Etiquette](https://github.com/asyncapi/community/blob/master/slack-etiquette.md) while interacting with community members! It's more likely you'll get help, and much faster!
 
 ### Bug Reports and Feature Requests
 
@@ -80,7 +80,7 @@ Happy contributing! :heart:
 
 ## License
 
-When you submit changes, your submissions are understood to be under the same [Apache 2.0 License](https://github.com/asyncapi/asyncapi/blob/master/LICENSE) that covers the project. Feel free to [contact the maintainers](https://www.asyncapi.com/slack-invite) if that's a concern.
+When you submit changes, your submissions are understood to be under the same [Apache 2.0 License](https://github.com/asyncapi/asyncapi/blob/master/LICENSE) that covers the project. Feel free to [contact the maintainers](https://asyncapi.slack.com/) if that's a concern.
 
 ## Contribution recognition
 

--- a/components/navigation/communityItems.tsx
+++ b/components/navigation/communityItems.tsx
@@ -28,7 +28,7 @@ const communityItems: CommunityItem[] = [
   {
     icon: IconSlack,
     title: 'Slack Workspace',
-    href: 'https://asyncapi.com/slack-invite',
+    href: 'https://asyncapi.slack.com/',
     target: '_blank',
     description: "Need help? Want to share something? Join our Slack workspace. We're nice people :)"
   },

--- a/markdown/about/index.md
+++ b/markdown/about/index.md
@@ -40,7 +40,7 @@ You can see the list of maintainers who also form part of the [AsyncAPI TSC here
 
 We do our best to recognize every contribution to the project. We do it individually in every repository from [AsyncAPI GitHub organization](https://github.com/asyncapi/). There should always be a **Contributors** section in the readme, like [this one](https://github.com/asyncapi/asyncapi/blob/master/README.md#contributors). We use [All Contributors](https://allcontributors.org/docs/en/specification) specification to handle recognitions. 
 
-We apologize in advance if we failed to recognize your work. Feel free to contact us on [Slack](https://www.asyncapi.com/slack-invite/), and we will fix it immediately, or just talk to our [All Contributors bot](https://allcontributors.org).
+We apologize in advance if we failed to recognize your work. Feel free to contact us on [Slack](https://asyncapi.slack.com//), and we will fix it immediately, or just talk to our [All Contributors bot](https://allcontributors.org).
 
 ## AsyncAPI, in numbers
 Interested to know more about our growth? Feel free to check our annual summary report: 
@@ -56,7 +56,7 @@ This is the list of companies that either provide a significant financial suppor
 
 Would you like to get on the list and support us financially? Check out all [AsyncAPI sponsoring options](https://opencollective.com/asyncapi).
 
-Would you like to help us with the maintenance? Contact us on [AsyncAPI Slack](https://www.asyncapi.com/slack-invite/).
+Would you like to help us with the maintenance? Contact us on [AsyncAPI Slack](https://asyncapi.slack.com//).
 
 ## Brands and companies using AsyncAPI
 The total number of companies and projects using AsyncAPI as well as their identity is impossible to know. So far, we are aware that the following ones operate with it.
@@ -90,7 +90,7 @@ All the information about the project's economy, the amount of the donations, th
 - Press & communications info:
 [**press@asyncapi.io**](mailto:press@asyncapi.io).
 - [**Twitter**](https://twitter.com/asyncapispec?lang=es): It's used for disseminating all news and information regarding the project, resolving user queries, and sharing the latest updates within AsyncAPI.
-- [**Slack workspace**](https://www.asyncapi.com/slack-invite): The main place of encounter for the whole community of AsyncAPI.
+- [**Slack workspace**](https://asyncapi.slack.com/): The main place of encounter for the whole community of AsyncAPI.
 - [**Newsletter**](https://www.asyncapi.com/newsletter): To learn about the status of the project, news, actualizations, recorded events, and meetings.
 - [**Blog**](https://www.asyncapi.com/blog): It’s used to disseminate information related to the project. It's also open to collaborations.
 - [**LinkedIn**](https://es.linkedin.com/company/asyncapi): It's used to publish news related to the project or its environment. It’s also used as a source of information.

--- a/markdown/blog/2020-summary.md
+++ b/markdown/blog/2020-summary.md
@@ -37,7 +37,7 @@ All those moments lead us to the most important one: the [partnership with Postm
 
 ## Slack
 
-tl;dr AsyncAPI community activity on [our Slack workspace](https://www.asyncapi.com/slack-invite/) doubled!
+tl;dr AsyncAPI community activity on [our Slack workspace](https://asyncapi.slack.com//) doubled!
 
 <Figure
   src="/img/posts/2020-summary/active-members.webp"

--- a/markdown/blog/2023-mentorship-summary.md
+++ b/markdown/blog/2023-mentorship-summary.md
@@ -93,7 +93,7 @@ Firstly, we'd like to thank everyone who made this program possible, and we are 
 
 ## How To Connect With Us
 
-- Join [our AsyncAPI Slack workspace](https://www.asyncapi.com/slack-invite). Be sure to follow our [Slack etiquette](https://github.com/asyncapi/.github/blob/master/slack-etiquette.md) and [our code of conduct](https://github.com/asyncapi/.github/blob/master/CODE_OF_CONDUCT.md).
+- Join [our AsyncAPI Slack workspace](https://asyncapi.slack.com/). Be sure to follow our [Slack etiquette](https://github.com/asyncapi/.github/blob/master/slack-etiquette.md) and [our code of conduct](https://github.com/asyncapi/.github/blob/master/CODE_OF_CONDUCT.md).
 - Join the dedicated Mentorship channel `#09_mentorships` for all mentorship discussions. All mentees and mentors are there.
 
 > Photo by <a href="https://unsplash.com/@spacex?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">SpaceX</a> on <a href="https://unsplash.com/photos/gray-spacecraft-taking-off-during-daytime-OHOU-5UVIYQ?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Unsplash</a>

--- a/markdown/blog/2024-Q1-docs-report.md
+++ b/markdown/blog/2024-Q1-docs-report.md
@@ -65,7 +65,7 @@ Here are the top 15 queries:
 ## 2024 Google Season of Docs: Application
 Our documentation lacks a persona-driven journey for diverse roles, such as documentation contributors, code contributors, ambassadors, maintainers, etc. Consequently, the AsyncAPI onboarding experience is not as efficient as it could be for new contributors, often resulting in onboarding calls being perceived as bottlenecks. To address this issue, [AsyncAPI has submitted an application for 2024 Google Season of Docs](https://github.com/orgs/asyncapi/discussions/1136) that proposes two projects: `Onboarding Contributor Guides` and `Expand Community Docs`. 
 
-We have also created a new [AsyncAPI Slack channel named `#temp-gsod-2024`](https://www.asyncapi.com/slack-invite) that anyone can join for:
+We have also created a new [AsyncAPI Slack channel named `#temp-gsod-2024`](https://asyncapi.slack.com/) that anyone can join for:
 - Mentees identification
 - Mentors identification
 - Ideas identification

--- a/markdown/blog/april-2021-at-asyncapi.md
+++ b/markdown/blog/april-2021-at-asyncapi.md
@@ -32,7 +32,7 @@ I'm super happy to share that we removed the last roadblock for the next AsyncAP
 
 I hope you noticed a pattern. We do not want to do releases during the summer holidays and stay away from December :smiley:.
 
-In June 2021, we will release 2.1.0 version of the specification. It is going to be the first release under [open governance model](https://github.com/asyncapi/community/blob/master/CHARTER.md), under Linux Foundation and new [contribution guide](https://github.com/asyncapi/spec/blob/master/CONTRIBUTING.md). So many new things, a lot to organize around. It means we probably won't accept too many changes as logistics will consume a lot of time. We welcome any help. Join our [Slack](https://www.asyncapi.com/slack-invite/) for more details. 
+In June 2021, we will release 2.1.0 version of the specification. It is going to be the first release under [open governance model](https://github.com/asyncapi/community/blob/master/CHARTER.md), under Linux Foundation and new [contribution guide](https://github.com/asyncapi/spec/blob/master/CONTRIBUTING.md). So many new things, a lot to organize around. It means we probably won't accept too many changes as logistics will consume a lot of time. We welcome any help. Join our [Slack](https://asyncapi.slack.com//) for more details. 
 
 ## AsyncAPI use case at eBay
 
@@ -108,7 +108,7 @@ If you do not like feed readers, just like me, then use some service like [Blogt
 
 More and more people learn about AsyncAPI. We need to make sure there are good learning materials for anyone. More important, we need a solution that is easy to scale.
 
-Our new initiative is to work on training materials that can be used for in-class workshops with trainers, but on the other hand, they need to be available on a platform that offers self-learning training. All discussions happen [here](https://github.com/asyncapi/training/discussions), and you can also join the #training channel in our [Slack](https://www.asyncapi.com/slack-invite/).
+Our new initiative is to work on training materials that can be used for in-class workshops with trainers, but on the other hand, they need to be available on a platform that offers self-learning training. All discussions happen [here](https://github.com/asyncapi/training/discussions), and you can also join the #training channel in our [Slack](https://asyncapi.slack.com//).
 
 We need people that want to become trainers, trainees or help to work preparing training materials. All hands aboard :muscle:.
 

--- a/markdown/blog/async_standards_compare.md
+++ b/markdown/blog/async_standards_compare.md
@@ -94,4 +94,4 @@ Once completed, OpenTelemetry helps to answer the classic event-driven question 
 
 It’s a great time for event-driven architecture. Challenges that used to be overcome in different ways in every implementation are now being addressed by standard, open-source solutions. While OpenTelemetry, AsyncAPI and CloudEvents do have overlapping capabilities, they are distinct enough to all warrant a place in your DevOps processes.
 
-If you have more questions or want to share your experience with these standards, you can let us know in the [AsyncAPI Slack](https://www.asyncapi.com/slack-invite) or the [Solace Community Forum](http://solace.community/). 
+If you have more questions or want to share your experience with these standards, you can let us know in the [AsyncAPI Slack](https://asyncapi.slack.com/) or the [Solace Community Forum](http://solace.community/). 

--- a/markdown/blog/asyncapi-discovery-intro.md
+++ b/markdown/blog/asyncapi-discovery-intro.md
@@ -78,4 +78,4 @@ As the spec matures, the tooling will hopefully be close behind.
 
 In the meantime, the AsyncAPI Discovery Tool can be a huge help to enterprises that are new to AsyncAPI but experienced with event-driven architecture and messaging. The AsyncAPI Discovery Tool can start you down the road from a tangled event mess to a well-organized, fully documented, tightly governed architecture.
 
-If you have more questions or want to share your experience with these standards, you can let us know in the [AsyncAPI Slack](https://www.asyncapi.com/slack-invite) or the [Solace Community Forum](http://solace.community/).
+If you have more questions or want to share your experience with these standards, you can let us know in the [AsyncAPI Slack](https://asyncapi.slack.com/) or the [Solace Community Forum](http://solace.community/).

--- a/markdown/blog/automated-releases-part-two.md
+++ b/markdown/blog/automated-releases-part-two.md
@@ -229,6 +229,6 @@ I don't think I can ever understand this "hate" towards JavaScript. I think, tho
 
 ![pr info about release](/img/posts/pr-indicator.webp)
 
-In case you want to have more explanation on the release automation subject, I recommend reading [the first part of the automation story](/blog/automated-releases/). You can also [join our Slack](https://www.asyncapi.com/slack-invite/) for further discussion.
+In case you want to have more explanation on the release automation subject, I recommend reading [the first part of the automation story](/blog/automated-releases/). You can also [join our Slack](https://asyncapi.slack.com//) for further discussion.
 
 _* Cover photo by [Rock'n Roll Monkey](https://unsplash.com/@rocknrollmonkey) on Unsplash_

--- a/markdown/blog/beyond-boundaries.md
+++ b/markdown/blog/beyond-boundaries.md
@@ -94,7 +94,7 @@ By sponsoring us, we can use your sponsorship funds to provide more slots in fut
 
 ## How To Connect With Us
 
-- Join [our Slack workspace](https://www.asyncapi.com/slack-invite). Just make sure to follow our [Slack etiquette](https://github.com/asyncapi/.github/blob/master/slack-etiquette.md) and [the code of conduct](https://github.com/asyncapi/.github/blob/master/CODE_OF_CONDUCT.md).
+- Join [our Slack workspace](https://asyncapi.slack.com/). Just make sure to follow our [Slack etiquette](https://github.com/asyncapi/.github/blob/master/slack-etiquette.md) and [the code of conduct](https://github.com/asyncapi/.github/blob/master/CODE_OF_CONDUCT.md).
 - Join the dedicated Mentorship channel `#mentorships` that we use for all mentorships discussion. All mentees and mentors are there.
 
 > Photo by <a href="https://unsplash.com/@noguidebook?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Rachel</a> on <a href="https://unsplash.com/photos/U4zpPfvogJ4?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>

--- a/markdown/blog/google-season-of-docs-2022.md
+++ b/markdown/blog/google-season-of-docs-2022.md
@@ -21,7 +21,7 @@ For today's blog post about AsyncAPI Docs 📑, I wanted to share with all techn
 
 As some of you may remember from my [Gist Docs update for 31 Jan - 11 Feb 2022](https://gist.github.com/quetzalliwrites/94ca1ffb5d123b450501e40a4a3b56e2), I noted that GSoD 2022 was coming up and that AsyncAPI wanted to participate in the application process once it opened on February 23, 2022.  
 
-In anticipation of this, I also created a new AsyncAPI Slack channel named `#temp-gsod-2022` that anyone can join! First, [join our Slack workspace](https://www.asyncapi.com/slack-invite) ☎️  and please respect [our slack etiquette](https://github.com/asyncapi/community/blob/master/slack-etiquette.md).🙂 Then join the `temp-gsod-2022` channel, our temporary channel to coordinate GSoC 2022 setup. I'll publish regular updates on where we are in the application process, so stay tuned as the process continues. 😄
+In anticipation of this, I also created a new AsyncAPI Slack channel named `#temp-gsod-2022` that anyone can join! First, [join our Slack workspace](https://asyncapi.slack.com/) ☎️  and please respect [our slack etiquette](https://github.com/asyncapi/community/blob/master/slack-etiquette.md).🙂 Then join the `temp-gsod-2022` channel, our temporary channel to coordinate GSoC 2022 setup. I'll publish regular updates on where we are in the application process, so stay tuned as the process continues. 😄
 
 Join the `#temp-gsod-2022` slack channel for:
 - mentees identification

--- a/markdown/blog/governance-motivation.md
+++ b/markdown/blog/governance-motivation.md
@@ -115,7 +115,7 @@ Hopefully, these companies will take shortcuts here that will open up new job op
 
 That was not our initial goal, though. We just figured that this might happen, and we look forward to it. 
 
-I hope this rough explanation makes it easier to digest the charter. Please share what you think. Use [Twitter](https://twitter.com/AsyncAPISpec), [Slack](https://www.asyncapi.com/slack-invite/), email. Write publicly or privately. We just care about the feedback and not how you pass it on. 
+I hope this rough explanation makes it easier to digest the charter. Please share what you think. Use [Twitter](https://twitter.com/AsyncAPISpec), [Slack](https://asyncapi.slack.com//), email. Write publicly or privately. We just care about the feedback and not how you pass it on. 
 
 You can also comment on [this](https://github.com/asyncapi/.github/pull/37) pull request with the charter. You can leave generic comments that we could reuse in official communication after we join the foundation.
 

--- a/markdown/blog/hackathon-faq.md
+++ b/markdown/blog/hackathon-faq.md
@@ -79,7 +79,7 @@ The solution with the highest score wins! 😀
 ### How do I get help? Who can help with further understanding of AsyncAPI and the entire tooling landscape?
 
 - Join one of `Contributor First` meetings. These will be streamed throughout the entire month of October, 2021. Add this calendar with [Google Calendar format](https://calendar.google.com/calendar/u/0/embed?src=c_q9tseiglomdsj6njuhvbpts11c@group.calendar.google.com) or [iCal format](https://calendar.google.com/calendar/ical/c_q9tseiglomdsj6njuhvbpts11c@group.calendar.google.com/public/basic.ics).  The `Contributor First` meetings will take place every Wednesday, twice a day, at 8AM UTC and 4PM UTC.
-- Join our [Slack](https://www.asyncapi.com/slack-invite). We are a very friendly and responsive community.
+- Join our [Slack](https://asyncapi.slack.com/). We are a very friendly and responsive community.
 - Create an issue in [one of the repositories](https://github.com/asyncapi/) and explain what help you need.
 
 ### What prizes are there?

--- a/markdown/blog/hacktoberfest-2020.md
+++ b/markdown/blog/hacktoberfest-2020.md
@@ -96,7 +96,7 @@ We stream to our official media accounts:
 - [https://www.youtube.com/asyncapi](https://www.youtube.com/asyncapi)
 - [https://twitter.com/AsyncAPISpec](https://twitter.com/AsyncAPISpec)
 
-You can also join us in a more asynchronous discussion on [Slack](https://www.asyncapi.com/slack-invite/). For updates and latest news, the best is to follow our [Twitter account](https://twitter.com/AsyncAPISpec).
+You can also join us in a more asynchronous discussion on [Slack](https://asyncapi.slack.com//). For updates and latest news, the best is to follow our [Twitter account](https://twitter.com/AsyncAPISpec).
 
 ## Blooper Reel
 

--- a/markdown/blog/hdi-global-interview.md
+++ b/markdown/blog/hdi-global-interview.md
@@ -91,5 +91,5 @@ We’re thrilled to welcome HDI Global SE as not only a Silver Sponsor but also 
 
 [Read more about HDI Global SE's AsyncAPI implementation case study]( https://www.asyncapi.com/casestudies/hdiglobal)
 
-Have questions about [HDI Global SE's](https://www.hdi.global/de-de/) journey with AsyncAPI or want to share your own experience? Join our vibrant community on [Slack](https://www.asyncapi.com/slack-invite) and let's continue the conversation!
+Have questions about [HDI Global SE's](https://www.hdi.global/de-de/) journey with AsyncAPI or want to share your own experience? Join our vibrant community on [Slack](https://asyncapi.slack.com/) and let's continue the conversation!
 

--- a/markdown/blog/january-2021-at-asyncapi.md
+++ b/markdown/blog/january-2021-at-asyncapi.md
@@ -57,7 +57,7 @@ We kicked off this year with a new bronze sponsor. Thanks a lot to Bump.sh and t
 ## Community continues to grow
 
 My [last post](/blog/2020-summary) that summarizes the year 2020 was pretty clear that the community's size grew a lot. Well, it is January, and we see that not much has changed. We keep growing:
-- we went over 1k users on Slack. [Join now](https://www.asyncapi.com/slack-invite/)
+- we went over 1k users on Slack. [Join now](https://asyncapi.slack.com//)
 - we went over 1.5k followers on Twitter. [Follow us](https://twitter.com/AsyncAPISpec/) to be up to date with the latest news in the project
 - we went over 1.4k stars on GitHub. If you like the project, [express it](https://github.com/asyncapi/asyncapi/stargazers)
 - we had several issues solved by the community members from different companies, including few new features. For more details, read [Feature releases and community-driven changes](#feature-releases-and-community-driven-changes) section

--- a/markdown/blog/march-2021-at-asyncapi.md
+++ b/markdown/blog/march-2021-at-asyncapi.md
@@ -24,7 +24,7 @@ excerpt: 'AsyncAPI Initiative joined the Linux Foundation in March, but except o
 Q1 2021 came to an end. Let me summarise our targets, revenue, and forecasts :smiley:
 
 This month:
-- [Slack](https://www.asyncapi.com/slack-invite/) members up by around 100 (reached 1.1k)
+- [Slack](https://asyncapi.slack.com//) members up by around 100 (reached 1.1k)
 - [Twitter](https://twitter.com/AsyncAPISpec) followers up by around 100 (reached 1.7k)
 - [LinkedIn](https://www.linkedin.com/company/asyncapi) followers up by around 100 (reached 1k)
 - New [OpenCollective](https://opencollective.com/asyncapi) contributor, [Apideck](https://www.apideck.com/) + additional 100 USD every month
@@ -74,7 +74,7 @@ Except for regular contributions, we need help setting up tooling for our open g
 - Figure out tooling for the website
 - Setup CODEOWNERS and VOTING files in all the repositories
 
-Everyone with a different set of skills is welcome. [Just contact me](https://www.asyncapi.com/slack-invite/).
+Everyone with a different set of skills is welcome. [Just contact me](https://asyncapi.slack.com//).
 
 ### What is next
 
@@ -90,7 +90,7 @@ AsyncAPI creator, [Fran Mendez](https://twitter.com/fmvilas), published AsyncAPI
 
 Go to the [roadmap](/roadmap) view to check out what it means and what needs to be done to get there.
 
-We need a lot of help to complete this roadmap. Without engagement and support of the community, all of this is just wishful thinking. All hands aboard, we're waiting [here](https://www.asyncapi.com/slack-invite/).
+We need a lot of help to complete this roadmap. Without engagement and support of the community, all of this is just wishful thinking. All hands aboard, we're waiting [here](https://asyncapi.slack.com//).
 
 ## Google Summer of Code
 

--- a/markdown/blog/openforce-2022.md
+++ b/markdown/blog/openforce-2022.md
@@ -31,7 +31,7 @@ In exchange, every person that completes these tasks will get an AsyncAPI t-shir
 
 ## How to connect
 
-Join [our Slack workspace](https://www.asyncapi.com/slack-invite). Just make sure to follow our [Slack etiquette](https://github.com/asyncapi/community/blob/master/slack-etiquette.md) and [the code of conduct](https://github.com/asyncapi/.github/blob/master/CODE_OF_CONDUCT.md).
+Join [our Slack workspace](https://asyncapi.slack.com/). Just make sure to follow our [Slack etiquette](https://github.com/asyncapi/community/blob/master/slack-etiquette.md) and [the code of conduct](https://github.com/asyncapi/.github/blob/master/CODE_OF_CONDUCT.md).
 
 We will also have [Abir Pal](https://twitter.com/imabptweets) present in the OpenForce Discord channel, in case you need help on your way to AsyncAPI.
 

--- a/markdown/blog/release-notes-2.2.0.md
+++ b/markdown/blog/release-notes-2.2.0.md
@@ -58,6 +58,6 @@ Are you wondering how we managed to release 2.2.0 just three months after 2.1.0?
 
 <img className="w-3/4" src="/img/posts/release-notes-2.2.0/brace.webp" alt="Meme showing a knight, Ned Stark from Game of Thrones. Description says: Brace yourself, all the stars in heaven say 3.0.0 version is coming." />
 
-Does the above meme give you mixed feelings? Are you afraid of possible changes, or actually happy to see it coming? Don't overthink it! Join our [Slack](https://www.asyncapi.com/slack-invite) and talk to us, or check out the [3.0.0 milestone](https://github.com/asyncapi/spec/milestone/18).
+Does the above meme give you mixed feelings? Are you afraid of possible changes, or actually happy to see it coming? Don't overthink it! Join our [Slack](https://asyncapi.slack.com/) and talk to us, or check out the [3.0.0 milestone](https://github.com/asyncapi/spec/milestone/18).
 
 > Photo by <a href="https://unsplash.com/@jeremythomasphoto?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Jeremy Thomas</a> on <a href="https://unsplash.com/s/photos/autumn?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">Unsplash</a>

--- a/markdown/blog/using-nunjucks-with-asyncapi.md
+++ b/markdown/blog/using-nunjucks-with-asyncapi.md
@@ -205,6 +205,6 @@ You call macros like you typically call functions:
 
 Don't build tools from scratch if there are others already available, and they are open for contributions. Trying something from scratch, as I did with the templating CodeSandbox for AsyncAPI, makes sense only for learning purposes.
 
-Keep in mind that [AsyncAPI](https://www.asyncapi.com/) is an open community. We do not work on the specification only, but tools too. Join us on [Slack](https://www.asyncapi.com/slack-invite/) and help us build awesome tools or [donate](https://opencollective.com/asyncapi).
+Keep in mind that [AsyncAPI](https://www.asyncapi.com/) is an open community. We do not work on the specification only, but tools too. Join us on [Slack](https://asyncapi.slack.com//) and help us build awesome tools or [donate](https://opencollective.com/asyncapi).
 
 Take time to look into the [parser-js](https://github.com/asyncapi/parser-js/). I used it in my CodeSandbox to parse the AsyncAPI document to pass it to templates as a context.

--- a/markdown/blog/v2-important-dates.md
+++ b/markdown/blog/v2-important-dates.md
@@ -23,7 +23,7 @@ After some time, many people have reviewed the specification and they've identif
 
 Right after we're clear on what's going to be the final version 2.0.0, we'll start working on improving all the tooling and make sure they support version 2.0.0 well. Tools are going to be open source as always so feel free to test them with your own use cases and let us know how it works! Either it sucks or it's amazing :)
 
-I'll personally track some of these tests to make sure everything is smooth. If you want to participate in the Beta testing program, feel free to reach out to me on our [Slack channel](https://www.asyncapi.com/slack-invite) or send me an email to [fmvilas@gmail.com](mailto://fmvilas@gmail.com).
+I'll personally track some of these tests to make sure everything is smooth. If you want to participate in the Beta testing program, feel free to reach out to me on our [Slack channel](https://asyncapi.slack.com/) or send me an email to [fmvilas@gmail.com](mailto://fmvilas@gmail.com).
 
 ## Official announcement (Late September-Early October)
 

--- a/markdown/blog/websocket-part1.md
+++ b/markdown/blog/websocket-part1.md
@@ -129,7 +129,7 @@ Familiarize with below before you look at the AsyncAPI document:
 - Current AsyncAPI limitation is that you cannot specify that once the user sends (publish) message **ping**, the **pong** message is a reply. Look at this [thread](https://github.com/asyncapi/spec/issues/94) to participate in an ongoing discussion about request/reply pattern support in AsyncAPI. In the below document, you will notice that for such a use case, I use AsyncAPI specification extensions (**x-response**).
 
 > **Message to Kraken API developers and technical writers** <br/>
-In case you want to continue the work I started on the AsyncAPI document for Kraken API, feel free to do that. I'm happy to help, just let me know. Reach me out in our [AsyncAPI Slack workspace](https://www.asyncapi.com/slack-invite/).
+In case you want to continue the work I started on the AsyncAPI document for Kraken API, feel free to do that. I'm happy to help, just let me know. Reach me out in our [AsyncAPI Slack workspace](https://asyncapi.slack.com//).
 
 ```yml
 asyncapi: 2.0.0

--- a/markdown/blog/websocket-part2.md
+++ b/markdown/blog/websocket-part2.md
@@ -46,7 +46,7 @@ I'm going to guide you through the process of creating an AsyncAPI document. I'l
 The challenge I had here was that I'm trying to document an API basing on public docs with no access to a subject matter expert. I also have zero understanding of the cryptocurrency industry and still do not fully understand the vocabulary. 
 
 > **Message to Kraken API developers and technical writers** <br/>
-In case you want to continue the work I started on the AsyncAPI document for Kraken API, feel free to do that. I'm happy to help, just let me know. Reach me out in our [AsyncAPI Slack workspace](https://www.asyncapi.com/slack-invite/).
+In case you want to continue the work I started on the AsyncAPI document for Kraken API, feel free to do that. I'm happy to help, just let me know. Reach me out in our [AsyncAPI Slack workspace](https://asyncapi.slack.com//).
 
 More interesting here are the technical challenges though, caused by the fact that Kraken's API:
 - has two production servers for non-secure and secure message exchange
@@ -811,4 +811,4 @@ components:
         pattern: '[A-Z\s]+\/[A-Z\s]+'
 ~~~
 
-Stay tuned for more articles around WebSocket and AsyncAPI. Share your feedback and connect with the AsyncAPI community in our [Slack workspace](https://www.asyncapi.com/slack-invite/).
+Stay tuned for more articles around WebSocket and AsyncAPI. Share your feedback and connect with the AsyncAPI community in our [Slack workspace](https://asyncapi.slack.com//).

--- a/markdown/blog/websocket-part3.md
+++ b/markdown/blog/websocket-part3.md
@@ -599,4 +599,4 @@ Don't give up, though. Technical challenges are not a good excuse for avoiding t
 
 In my opinion, specification limitations and gaps in tooling support should not block you from choosing an API-first direction. The benefits are too big to resign that easily. Just join us and let us find solutions together. We want to help solve all those issues, but we just need some help from you too.
 
-That would be it. Thanks for staying with me until the end. Don't forget to read my previous articles on AsyncAPI spec and WebSocket protocol. Share your feedback and connect with the AsyncAPI community in our [Slack workspace](https://www.asyncapi.com/slack-invite/).
+That would be it. Thanks for staying with me until the end. Don't forget to read my previous articles on AsyncAPI spec and WebSocket protocol. Share your feedback and connect with the AsyncAPI community in our [Slack workspace](https://asyncapi.slack.com//).

--- a/markdown/docs/community/onboarding-guide/contribute-to-docs.md
+++ b/markdown/docs/community/onboarding-guide/contribute-to-docs.md
@@ -7,6 +7,6 @@ weight: 70
 
 There are several ways to request your first AsyncAPI docs task:
 
-1. **Connect with a docs maintainer:** Ask for a `good-first-issue` in the `#13_docs` channel of the [AsyncAPI Slack](https://www.asyncapi.com/slack-invite) workspace. 
+1. **Connect with a docs maintainer:** Ask for a `good-first-issue` in the `#13_docs` channel of the [AsyncAPI Slack](https://asyncapi.slack.com/) workspace. 
 2. **Update current docs:** Surf the existing documentation, look for `typos`, `grammar`, `errors`, create an issue, and submit a Pull Request. 
 3. **Propose new docs:** If you have any ideas or suggestions for necessary documentation, [create a new docs issue](https://github.com/asyncapi/website/issues/new?labels=%F0%9F%93%91+docs&projects=&template=docs.yml&title=%5B%F0%9F%93%91+Docs%5D%3A+) and propose yourself as the assignee. 

--- a/markdown/docs/tools/glee/crypto-websockets-interactive.md
+++ b/markdown/docs/tools/glee/crypto-websockets-interactive.md
@@ -12,6 +12,6 @@ Please become our alpha testers of the tutorial:
 
 1. Go through the tutorial [here](https://killercoda.com/asyncapi-glee/scenario/crypto-websockets)
 2. Let us know what you think using the channel that works for you the best:
-   - [Slack](https://www.asyncapi.com/slack-invite/)
+   - [Slack](https://asyncapi.slack.com//)
    - [Twitter](https://twitter.com/AsyncAPISpec)
    - [GitHub Issue](https://github.com/asyncapi/glee/issues/)

--- a/markdown/docs/tutorials/streetlights-interactive.md
+++ b/markdown/docs/tutorials/streetlights-interactive.md
@@ -8,6 +8,6 @@ weight: 180
 
 1. Go through the [Streetlights interactive tutorial](https://killercoda.com/asyncapi/scenario/streetlight-tut-v3).
 2. Share your opinion via your preferred channel:
-   - [Slack](https://www.asyncapi.com/slack-invite/)
+   - [Slack](https://asyncapi.slack.com//)
    - [Twitter](https://twitter.com/AsyncAPISpec)
    - [GitHub Issue](https://github.com/asyncapi/website/issues/)


### PR DESCRIPTION
**Description**
https://www.asyncapi.com/slack-invite this is link was not working, Fixed this by changing this to https://asyncapi.slack.com/ this is working fine

**Related issue(s)**
Fixes #3855 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Slack workspace links across community guides, blog posts, and tutorials to direct users to the correct Slack workspace.
- **Chores**
  - Revised the navigation link for the Slack community to ensure consistent and accurate access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->