### PR TITLE
chore: update slack invite link

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -53,7 +53,7 @@ https://www.asyncapi.io/* https://www.asyncapi.com/:splat 301!
 /asyncapi-react https://asyncapi.github.io/asyncapi-react 301!
 
 # Slack
-/slack-invite https://join.slack.com/t/asyncapi/shared_invite/zt-31q8fxoeo-cDtm4cV~p0NXGv0yixZHHQ302!
+/slack-invite https://join.slack.com/t/asyncapi/shared_invite/zt-31q8fxoeo-cDtm4cV~p0NXGv0yixZHHQ 302!
 
 # Central Maven repository verification
 /OSSRH-63280 https://github.com/asyncapi/java-asyncapi

--- a/public/_redirects
+++ b/public/_redirects
@@ -53,7 +53,7 @@ https://www.asyncapi.io/* https://www.asyncapi.com/:splat 301!
 /asyncapi-react https://asyncapi.github.io/asyncapi-react 301!
 
 # Slack
-/slack-invite https://join.slack.com/t/asyncapi/shared_invite/zt-2yv98pzj5-sPoBxgPaoJdGF2yEFMcn3A 302!
+/slack-invite https://join.slack.com/t/asyncapi/shared_invite/zt-31q8fxoeo-cDtm4cV~p0NXGv0yixZHHQ302!
 
 # Central Maven repository verification
 /OSSRH-63280 https://github.com/asyncapi/java-asyncapi


### PR DESCRIPTION
Current link has expired, update with the new one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Slack invite link so that users clicking the join button are now directed to the current invitation page.
  - This refresh ensures that everyone receives the latest approved link when accessing our community via Slack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->