### PR TITLE
Renamed News section to Contact Us #3852

### DIFF
--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -7,6 +7,7 @@ import AsyncAPILogoLight from '../logos/AsyncAPILogoLight';
 import Heading from '../typography/Heading';
 import type { InitiativeLink, SocialMediaLink } from './FooterList';
 import { initiativeLinks, socialMediaLinks } from './FooterList';
+import IconEmail from '../icons/Email'; // ✅ Import the Email Icon
 
 /**
  * @description The Footer component is the footer for the application.
@@ -52,6 +53,7 @@ export default function Footer() {
                 </ul>
               </div>
 
+              {/* ✅ Contact Us Section with Email Us */}
               <div className='mb-5 px-14 sm:ml-10 sm:px-8 md:ml-5'>
                 <div className='py-2'>
                   <div className='text-white'>
@@ -60,9 +62,10 @@ export default function Footer() {
                 </div>
                 <ul className='justify-center'>
                   <li className='py-2'>
-                    <div className='text-base leading-6 text-cool-gray transition duration-300 ease-in-out hover:text-white'>
-                      <a href='mailto:press@asyncapi.io'>Email Us</a>
-                    </div>
+                    <a href='mailto:press@asyncapi.io' className='flex items-center text-base leading-6 text-cool-gray transition duration-300 ease-in-out hover:text-white'>
+                      <IconEmail className="w-5 h-5 mr-2" />  {/* ✅ Email Icon Added */}
+                      <span>Email Us</span>
+                    </a>
                   </li>
                 </ul>
               </div>
@@ -97,8 +100,8 @@ export default function Footer() {
               Made with <span className='font-mono text-secondary-500'>:love:</span> by the AsyncAPI Initiative.
             </p>
             <p className='w-full text-left text-sm leading-6 text-cool-gray sm:w-2/3' data-testid='Footer-copyright'>
-              Copyright &copy; AsyncAPI Project a Series of LF Projects, LLC. For web site terms of use, trademark
-              policy and general project policies please see{' '}
+              Copyright &copy; AsyncAPI Project a Series of LF Projects, LLC. For website terms of use, trademark
+              policy, and general project policies please see{' '}
               <a
                 href='https://lfprojects.org'
                 className='text-secondary-500 underline transition duration-300 ease-in-out hover:text-white'

--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -55,7 +55,7 @@ export default function Footer() {
               <div className='mb-5 px-14 sm:ml-10 sm:px-8 md:ml-5'>
                 <div className='py-2'>
                   <div className='text-white'>
-                    <Heading typeStyle={HeadingTypeStyle.smSemibold}>News</Heading>
+                    <Heading typeStyle={HeadingTypeStyle.smSemibold}>Contact Us</Heading>
                   </div>
                 </div>
                 <ul className='justify-center'>


### PR DESCRIPTION
**Title:**
Renamed News Section to Contact Us (#3852)

Description:
This PR addresses issue [#3852](https://github.com/asyncapi/website/issues/3852) by renaming the News section to Contact Us as discussed in the issue thread. Also added EmailUs icon.

Changes Made:

**Updated the section title from News to Contact Us. (Footer\footer.tsx)**


Ensured consistency in the UI and layout.
Verified that the changes align with the discussion in the issue thread.
Screenshots (if applicable):
Before fix :
![image](https://github.com/user-attachments/assets/9bfc13d8-fdd7-40f5-abc7-1b57a8d7f0b4)


after Fix:
![image](https://github.com/user-attachments/assets/aad07f98-590b-4d49-bf03-1e85e4da70bf)


Checklist:
 Code follows the project’s contributing guidelines.
 Tested changes locally to ensure proper display.
 Linked the PR with issue #3852.






- **New Features**
  - Updated the footer heading from "News" to "Contact Us," making it easier for users to locate contact information.
  - Enhanced the "Email Us" link with an email icon for improved visual presentation.


Please take a look maintainers:
@sambhavgupta0705 @Mayaleeeee @antoniogarrote @maintainer(s)
