### PR TITLE
fix: Title Card Data is empty for many title cards on AsyncAPI Website Tools section

### DIFF
--- a/components/tools/ToolsCard.tsx
+++ b/components/tools/ToolsCard.tsx
@@ -50,6 +50,8 @@ export default function ToolsCard({ toolData }: ToolsCardProp) {
     tech: false,
     desc: false
   });
+  const hasLanguageData = toolData.filters?.language && toolData.filters.language.length > 0; // Check if we have valid language data to display
+  const hasTechnologyData = toolData.filters?.technology && toolData.filters.technology.length > 0 // Check if we have valid Technology data to display
 
   return (
     <div className='flex h-auto flex-col rounded-lg border shadow-md'>
@@ -116,9 +118,9 @@ export default function ToolsCard({ toolData }: ToolsCardProp) {
       </div>
       <hr className='mx-6' />
       <div className='grow'>
-        {toolData.filters?.language || toolData?.filters?.technology?.length ? (
+        {(hasLanguageData || hasTechnologyData) ?  (
           <div className='my-6'>
-            {toolData.filters.language && (
+            {hasLanguageData && (
               <div className='mx-6 flex flex-col gap-2'>
                 <CardData
                   className='text-sm'
@@ -138,7 +140,7 @@ export default function ToolsCard({ toolData }: ToolsCardProp) {
                 </div>
               </div>
             )}
-            {toolData.filters.technology?.length !== 0 && (
+            {hasTechnologyData && (
               <div className='mx-6 my-4 flex flex-col gap-2'>
                 <CardData
                   className='text-sm'


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Fixed issue where the LANGUAGE section was being rendered even when language data was empty
- Added explicit checks for both language and technology data arrays to ensure they exist and contain items
- Improved conditional rendering logic to prevent empty sections from displaying
- Simplified the tag rendering by removing redundant checks

**Related issue(s)**
Fixes #3881
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the logic for displaying language and technology details, ensuring that sections appear consistently and accurately based on available content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->