### PR TITLE
fix: remove icon_url from Slack postMessage to fix type error

### DIFF
--- a/netlify/functions/save-discussion-background/Slack.ts
+++ b/netlify/functions/save-discussion-background/Slack.ts
@@ -128,7 +128,6 @@ export namespace Slack {
         text: message,
         as_user: true,
         thread_ts: threadTS,
-        icon_url: AVATAR_URL,
       });
     } catch (err) {
       console.error(


### PR DESCRIPTION
# Remove `icon_url` from Slack postMessage config

Fixes #3895 : TypeScript type error in Slack message configuration


## What
- Removed `icon_url: AVATAR_URL` from the `postMessage` configuration in `Slack.ts`

## Why
- Fix TypeScript type error: `icon_url` is incompatible with `as_user: true` in Slack Web API
- When `as_user: true` is set, the bot uses the authenticated user's profile picture automatically

## Testing
- Run `npx tsc netlify/functions/save-discussion-background/Slack.ts --noEmit` to confirm type error is resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Slack notifications by removing a custom icon configuration, so messages now display with Slack’s standard icon for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->