### PR TITLE
Fixes Navbar style for certain screens

### DIFF
--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -156,7 +156,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
           </div>
         )}
 
-        <div className='-my-2 -mr-2 flex flex-row items-center justify-center lg:hidden' data-testid='Navbar-search'>
+        <div className='-my-2 -mr-2 flex flex-row items-center justify-center custom-lg:hidden' data-testid='Navbar-search'>
           <SearchButton
             className='flex items-center space-x-2 rounded-md p-2 text-left text-gray-400 transition duration-150 ease-in-out hover:bg-gray-100 hover:text-gray-500 focus:bg-gray-100 focus:text-gray-500 focus:outline-none'
             aria-label='Open Search'
@@ -176,7 +176,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
         </div>
 
         <nav
-          className='hidden w-full space-x-4 lg:flex lg:items-center lg:justify-end xl:space-x-8'
+          className='hidden w-full space-x-4 custom-lg:flex lg:items-center lg:justify-end xl:space-x-8'
           data-testid='Navbar-main'
         >
           <div className='relative' onMouseLeave={() => showMenu(null)} ref={learningRef}>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -202,7 +202,8 @@ const config: Config = {
         'body-lg': ['18px', '1.625']
       },
       screens: {
-        xs: '475px'
+        xs: '475px',
+        'custom-lg': '1128px',
       }
     }
   },


### PR DESCRIPTION
**Description**

1. **Created a Custom Large Breakpoint:** Defined a new `custom-lg` breakpoint at **1128px** instead of using Tailwind's default `lg` (**1024px**) to fix the NavBar for certain screen sizes.  
2. **Updated Visibility Classes:** Replaced `lg:hidden` and `lg:flex` with `custom-lg:hidden` and `custom-lg:flex` to control when the mobile menu appears.

**Related issue(s)**
Fixes #3899 
**For >1128px**
![Screenshot 2025-03-16 164245](https://github.com/user-attachments/assets/594c427e-ef88-4fc0-98aa-7eca08af0d37)
**For <=1128px**
![Screenshot 2025-03-16 164302](https://github.com/user-attachments/assets/b04659f9-d360-4886-a78f-de68acc384e7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a custom responsive breakpoint to further tailor the layout on larger screens.
- **Style**
  - Enhanced navigation styling for improved display on mobile and desktop devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->