### PR TITLE
docs: fix message refs in operations examples

### DIFF
--- a/markdown/docs/reference/specification/v3.0.0.md
+++ b/markdown/docs/reference/specification/v3.0.0.md
@@ -802,7 +802,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
     { "$ref": "#/components/operationTraits/kafka" }
   ],
   "messages": [
-    { "$ref": "/components/messages/userSignedUp" }
+    { "$ref": "#/channels/userSignup/messages/userSignedUp" }
   ],
   "reply": {
     "address": {
@@ -839,7 +839,7 @@ bindings:
 traits:
   - $ref: "#/components/operationTraits/kafka"
 messages:
-  - $ref: '#/components/messages/userSignedUp'
+  - $ref: '#/channels/userSignup/messages/userSignedUp'
 reply:
   address:
     location: '$message.header#/replyTo'


### PR DESCRIPTION
- Fixed the example to align with the description:
  > It [..] MUST NOT point to a subset of message definitions located in the [Messages Object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#componentsMessages) in the [Components Object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#componentsObject) or anywhere else.

- Added newline to EOF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API specification details to use relative paths for the user signup message, ensuring improved consistency in document structure.
  - Made minor formatting adjustments to enhance readability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->