### PR TITLE
fix: remove adjacent duplicate tool cards from the tool section

### DIFF
--- a/components/tools/ToolsList.tsx
+++ b/components/tools/ToolsList.tsx
@@ -35,6 +35,7 @@ export default function ToolsList({ toolsListData }: ToolsListProp) {
                   if (toolIndex === 0 || tool.title !== toolsListData[categoryName].toolsList[toolIndex-1]?.title) {
                     return <ToolsCard key={toolIndex} toolData={tool} />;
                   }
+                  return null;
                 })}
               </div>
             </div>

--- a/components/tools/ToolsList.tsx
+++ b/components/tools/ToolsList.tsx
@@ -31,9 +31,11 @@ export default function ToolsList({ toolsListData }: ToolsListProp) {
               <Paragraph typeStyle={ParagraphTypeStyle.md}>{toolsListData[categoryName].description}</Paragraph>
               <hr className='my-8' />
               <div className='flex grid-cols-3 flex-col gap-8 lg:grid'>
-                {toolsListData[categoryName].toolsList.map((tool, toolIndex) => (
-                  <ToolsCard key={toolIndex} toolData={tool} />
-                ))}
+                {toolsListData[categoryName].toolsList.map((tool, toolIndex) => {
+                  if (toolIndex === 0 || tool.title !== toolsListData[categoryName].toolsList[toolIndex-1]?.title) {
+                    return <ToolsCard key={toolIndex} toolData={tool} />;
+                  }
+                })}
               </div>
             </div>
           );

--- a/components/tools/ToolsList.tsx
+++ b/components/tools/ToolsList.tsx
@@ -32,9 +32,10 @@ export default function ToolsList({ toolsListData }: ToolsListProp) {
               <hr className='my-8' />
               <div className='flex grid-cols-3 flex-col gap-8 lg:grid'>
                 {toolsListData[categoryName].toolsList.map((tool, toolIndex) => {
-                  if (toolIndex === 0 || tool.title !== toolsListData[categoryName].toolsList[toolIndex-1]?.title) {
+                  if (toolIndex === 0 || tool.title !== toolsListData[categoryName].toolsList[toolIndex - 1]?.title) {
                     return <ToolsCard key={toolIndex} toolData={tool} />;
                   }
+
                   return null;
                 })}
               </div>


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
This PR fixes an issue where duplicate adjacent tool cards were being rendered on tool section. The update ensures that only unique tool cards appear by checking if the current tool's title is the same as the previous one.

**Related issue(s)**
Fixes #3903  

**Before**
![Screenshot from 2025-03-21 02-24-32](https://github.com/user-attachments/assets/0b034bcd-810d-40c8-9ccc-ddd7fed26907)

**After**
![Screenshot from 2025-03-21 02-23-39](https://github.com/user-attachments/assets/59c45170-b6cc-4994-bb62-06caf2df804b)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Refined the tools list display so that duplicate items are no longer shown consecutively, resulting in a clearer and more consistent view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->