### PR TITLE
fix: proper alignment of modal in center of screen

### DIFF
--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -42,7 +42,7 @@ export default function Modal({ title, children, onModalClose = () => {} }: IMod
     <div
       ref={modalRef}
       tabIndex={-1}
-      className='fixed inset-0 z-30 my-auto mt-2 flex min-h-full items-end justify-center bg-black/30 p-4 text-center backdrop-blur sm:items-center sm:p-0'
+      className='fixed inset-0 z-30 my-auto mt-10 flex min-h-full items-end justify-center bg-black/30 p-4 text-center backdrop-blur sm:items-center sm:p-0'
       onClick={backdropClickHandler}
       onKeyUp={onKeyUpHandler}
     >


### PR DESCRIPTION
**Description**
The alignment of modal in center of screen for modal with larger content.

ScreenShot-  

![image](https://github.com/user-attachments/assets/94e824c8-8134-45f7-a37f-5570a4e9ae9f)


**Related issue(s)**
Fixes #3941 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the modal's vertical spacing to appear further down, enhancing the overall layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->