### PR TITLE
chore: update slack invite link 

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -53,7 +53,7 @@ https://www.asyncapi.io/* https://www.asyncapi.com/:splat 301!
 /asyncapi-react https://asyncapi.github.io/asyncapi-react 301!
 
 # Slack
-/slack-invite https://join.slack.com/t/asyncapi/shared_invite/zt-31q8fxoeo-cDtm4cV~p0NXGv0yixZHHQ 302!
+/slack-invite https://join.slack.com/t/asyncapi/shared_invite/zt-33bsaqqgz-ZL0a3ZUiuy4stSbXB~~E9A 302!
 
 # Central Maven repository verification
 /OSSRH-63280 https://github.com/asyncapi/java-asyncapi


### PR DESCRIPTION
update the expired slack link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Slack invite link to direct users to the latest invitation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->