### PR TITLE
fix: Aligned the Event banner display schedule according to their sequence. #4035

### DIFF
--- a/components/campaigns/banners.ts
+++ b/components/campaigns/banners.ts
@@ -45,15 +45,6 @@ export const banners = [
   },
   {
     title: 'AsyncAPI Conference',
-    city: 'Bangalore Edition',
-    dateLocation: '8th - 9th of October, 2025 | Bangalore, India',
-    cfaText: 'Apply To Speak',
-    eventName: 'the end of Call for Speakers',
-    cfpDeadline: '2025-06-29T06:00:00Z',
-    link: 'https://conference.asyncapi.com/venue/Bangalore'
-  },
-  {
-    title: 'AsyncAPI Conference',
     city: 'London Edition',
     dateLocation: '22nd - 24th of September, 2025 | London, UK',
     cfaText: 'Apply To Speak',
@@ -63,12 +54,12 @@ export const banners = [
   },
   {
     title: 'AsyncAPI Conference',
-    city: 'Paris Edition',
-    dateLocation: '9th - 11th of December, 2025 | Paris, France',
+    city: 'Bangalore Edition',
+    dateLocation: '8th - 9th of October, 2025 | Bangalore, India',
     cfaText: 'Apply To Speak',
     eventName: 'the end of Call for Speakers',
-    cfpDeadline: '2025-08-05T06:00:00Z',
-    link: 'https://conference.asyncapi.com/venue/Paris'
+    cfpDeadline: '2025-06-29T06:00:00Z',
+    link: 'https://conference.asyncapi.com/venue/Bangalore'
   },
   {
     title: 'AsyncAPI Conference',
@@ -78,5 +69,14 @@ export const banners = [
     eventName: 'the end of Call for Speakers',
     cfpDeadline: '2025-09-07T06:00:00Z',
     link: 'https://conference.asyncapi.com/venue/Online'
+  },
+  {
+    title: 'AsyncAPI Conference',
+    city: 'Paris Edition',
+    dateLocation: '9th - 11th of December, 2025 | Paris, France',
+    cfaText: 'Apply To Speak',
+    eventName: 'the end of Call for Speakers',
+    cfpDeadline: '2025-08-05T06:00:00Z',
+    link: 'https://conference.asyncapi.com/venue/Paris'
   }
 ];


### PR DESCRIPTION
Describe the bug.

The event shows the October conference for India, September for London, December for Paris, and October Online.

Expected behavior

The event should show September for London, then the October conference for India, the October Online, and the December conference in Paris.

Screenshots - 
![image](https://github.com/user-attachments/assets/64ec5eba-950b-4a34-9302-3286525b2505)
![image](https://github.com/user-attachments/assets/456c7286-b1c9-407b-82c5-c699b12261d7)


Fixes: #4035

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Revised conference banners: The event details have been reorganized. The updated Bangalore information has been reassigned to an existing banner entry.
  - Added a new event banner: The Paris edition now features the original scheduling details and information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->