### PR TITLE
fix: replace invalid GH_TOKEN with valid GITHUB_TOKEN 

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -89,7 +89,7 @@ jobs:
         id: lighthouse_statistic_comment
         uses: marocchino/sticky-pull-request-comment@efaaab3fd41a9c3de579aba759d2552635e590fd # version 2.8 https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.8.0
         with:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ github.event.pull_request.number }}
           header: lighthouse
           message: ${{ steps.lighthouse_score_report.outputs.comment }}


### PR DESCRIPTION
fixes #4183 
This PR updates the GitHub Actions workflow to replace the invalid GH_TOKEN with GITHUB_TOKEN for proper permissions in the Lighthouse CI comment step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the authentication token used for posting Lighthouse CI comments on pull requests to improve workflow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->