### PR TITLE
fix: correct broken links in getting started of tutorial

### DIFF
--- a/components/StyledLink.tsx
+++ b/components/StyledLink.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+interface StyledLinkProps {
+  href: string;
+  children: ReactNode;
+}
+
+export const StyledLink = ({ href, children }: StyledLinkProps) => (
+  <a
+    href={href}
+    target='_blank'
+    rel='noopener noreferrer'
+    className={
+      'border-b border-secondary-400 font-semibold text-gray-900 ' +
+      'transition duration-300 ease-in-out hover:border-secondary-500 ' +
+      'font-body antialiased'
+    }
+  >
+    {children}
+  </a>
+);

--- a/markdown/docs/tutorials/getting-started/coming-from-openapi.md
+++ b/markdown/docs/tutorials/getting-started/coming-from-openapi.md
@@ -5,7 +5,9 @@ weight: 20
 
 If you're coming from OpenAPI, you must know that AsyncAPI [started as an adaptation of the OpenAPI specification](https://medium.com/asyncapi/whats-new-on-asyncapi-lots-2d9019a1869d). AsyncAPI wanted to be as compatible as possible with OpenAPI so that the users could reuse parts in both.
 
-Before AsyncAPI `3.0.0`, you could find many similarities between OpenAPI and AsyncAPI. Remember that in the world of Event-Driven Architectures, you have more than one protocol; therefore, some things are different. Check out the following comparison chart, inspired by [Darrel Miller's blog post](https://www.openapis.org/news/blogs/2016/10/tdc-structural-improvements-explaining-30-spec-part-2):
+import { StyledLink } from '../../../../components/StyledLink'
+
+Before AsyncAPI `3.0.0`, you could find many similarities between OpenAPI and AsyncAPI. Remember that in the world of Event-Driven Architectures, you have more than one protocol; therefore, some things are different. Check out the following comparison chart, inspired by <StyledLink href='https://www.openapis.org/blog/2016/10/03/tdc-structural-improvements-explaining-the-3-0-spec-part-2'>Darrel Miller&apos;s blog post</StyledLink>:
 
 import OpenAPIComparison from '../../../../components/OpenAPIComparison'
 
@@ -21,8 +23,8 @@ Aside from structural differences, you should know:
 
 1. AsyncAPI is compatible with OpenAPI schemas.
 1. The message payload in AsyncAPI can be any value, not just an AsyncAPI/OpenAPI schema. For instance, it could be an [Avro](https://avro.apache.org/) schema.
-1. The [AsyncAPI server object](/docs/specifications/2.2.0/#serverObject) is almost identical to its OpenAPI counterpart, with the exception that `scheme` has been renamed to `protocol` and AsyncAPI introduces a new property called `protocolVersion`. AsyncAPI supports multiple protocols, not only HTTP, like in the case of OpenAPI.
-1. OpenAPI path parameters and [AsyncAPI channel parameters](/docs/specifications/2.2.0/#parameterObject) are a bit different since AsyncAPI doesn't have the notion of "query" and "cookie", and header parameters can be defined in the [message object](/docs/specifications/2.2.0/#messageObject). Therefore, AsyncAPI channel parameters are the equivalent of OpenAPI path parameters.
+1. The <StyledLink href='https://www.asyncapi.com/docs/reference/specification/v3.0.0#server-object'>AsyncAPI server object</StyledLink> is almost identical to its OpenAPI counterpart, with the exception that `scheme` has been renamed to `protocol` and AsyncAPI introduces a new property called `protocolVersion`. AsyncAPI supports multiple protocols, not only HTTP, like in the case of OpenAPI.
+1. OpenAPI path parameters and <StyledLink href='https://www.asyncapi.com/docs/reference/specification/v3.0.0#parameter-object'>AsyncAPI channel parameters</StyledLink> are a bit different since AsyncAPI doesn't have the notion of "query" and "cookie", and header parameters can be defined in the <StyledLink href='https://www.asyncapi.com/docs/reference/specification/v3.0.0#message-object'>message object</StyledLink>. Therefore, AsyncAPI channel parameters are the equivalent of OpenAPI path parameters.
 
 ## Conclusion
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32124,21 +32124,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.26.tgz",
-      "integrity": "sha512-GQWg/Vbz9zUGi9X80lOeGsz1rMH/MtFO/XqigDznhhhTfDlDoynCM6982mPCbSlxJ/aveZcKtTlwfAjwhyxDpg==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     }
   }
 }


### PR DESCRIPTION
🛠️ What’s Fixed
Fixes #4225

This PR addresses [Issue #4225](https://github.com/asyncapi/website/issues/4225) — broken links in the "Coming from OpenAPI" tutorial docs.

🔗 Fix Summary
✅ Replaced outdated Darrel Miller's blog link with a working URL
✅ Fixed anchor links to the following sections:

[Darrel Miller's blog post](https://www.openapis.org/blog/2016/10/03/tdc-structural-improvements-explaining-the-3-0-spec-part-2
)

[AsyncAPI Server Object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#server-object)

[AsyncAPI Channel Parameters](https://www.asyncapi.com/docs/reference/specification/v3.0.0#parameter-object)

[Message Object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#message-object)

✅ Wrapped all links in StyledLink to match design and accessibility standards











<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new styled external link component for consistent and enhanced link appearance.

* **Documentation**
  * Updated tutorial documentation to use the new styled link component for external references, improving link consistency and updating URLs.
  * Refreshed a documentation link in the TypeScript environment file to point to the latest Next.js reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->