### PR TITLE
feat: add DeveloperWeek CfP

### DIFF
--- a/components/campaigns/banners.ts
+++ b/components/campaigns/banners.ts
@@ -18,48 +18,12 @@ export function shouldShowBanner(cfpDeadline: string) {
 export const banners = [
   {
     title: 'AsyncAPI Conference',
-    city: 'Singapore Edition',
-    dateLocation: '15th - 16th of April, 2025 | Singapore, Singapore',
-    cfaText: 'Get Free Tickets',
-    eventName: 'you get a Free Ticket',
-    cfpDeadline: '2025-04-13T06:00:00Z',
-    link: 'https://ticket.apidays.global/event/apidays-singapore-2025/4c745e62-0e52-4c4a-9221-29f47bc57128/cart?coupon=ASYNCAPICOMMUNITY'
-  },
-  {
-    title: 'AsyncAPI Conference',
-    city: 'Munich Edition',
-    dateLocation: '2nd - 3rd of July, 2025 | München, Germany',
-    cfaText: 'Apply To Speak',
-    eventName: 'the end of Call for Speakers',
-    cfpDeadline: '2025-05-11T06:00:00Z',
-    link: 'https://apidays.typeform.com/apidayscfp?typeform-source=www.apidays.global'
-  },
-  {
-    title: 'AsyncAPI Conference',
-    city: 'Lagos Edition',
-    dateLocation: '18th - 19th of July, 2025 | Lagos, Nigeria',
-    cfaText: 'Apply To Speak',
-    eventName: 'the end of Call for Speakers',
-    cfpDeadline: '2025-05-17T06:00:00Z',
-    link: 'https://conference.asyncapi.com/venue/Lagos'
-  },
-  {
-    title: 'AsyncAPI Conference',
     city: 'London Edition',
     dateLocation: '22nd - 24th of September, 2025 | London, UK',
     cfaText: 'Apply To Speak',
     eventName: 'the end of Call for Speakers',
     cfpDeadline: '2025-07-13T06:00:00Z',
     link: 'https://conference.asyncapi.com/venue/London'
-  },
-  {
-    title: 'AsyncAPI Conference',
-    city: 'Bangalore Edition',
-    dateLocation: '8th - 9th of October, 2025 | Bangalore, India',
-    cfaText: 'Apply To Speak',
-    eventName: 'the end of Call for Speakers',
-    cfpDeadline: '2025-06-29T06:00:00Z',
-    link: 'https://conference.asyncapi.com/venue/Bangalore'
   },
   {
     title: 'AsyncAPI Conference',
@@ -78,5 +42,14 @@ export const banners = [
     eventName: 'the end of Call for Speakers',
     cfpDeadline: '2025-08-05T06:00:00Z',
     link: 'https://conference.asyncapi.com/venue/Paris'
+  },
+  {
+    title: 'AsyncAPI Conference',
+    city: 'DeveloperWeek 2026',
+    dateLocation: '18th - 20th of February, 2026 | San Jose, United States',
+    cfaText: 'Apply To Speak',
+    eventName: 'the end of Call for Speakers',
+    cfpDeadline: '2025-11-07T06:00:00Z',
+    link: 'https://confengine.com/conferences/asyncapi-summit-at-developerweek2026'
   }
 ];


### PR DESCRIPTION
Add the DeveloperWeek 2026 cfp on the website

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new banner for DeveloperWeek 2026 in San Jose, United States.

* **Chores**
  * Removed banners for previous AsyncAPI Conference editions in Singapore, Munich, Lagos, and Bangalore.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->