### PR TITLE
fix: update new maintainers

### DIFF
--- a/assets/docs/fragments/contribution-notes.md
+++ b/assets/docs/fragments/contribution-notes.md
@@ -11,4 +11,4 @@ To get started as a Docs contributor:
 
 Do you have a documentation contributor question and you're wondering how to tag me into a GitHub discussion or PR? Never fear!
 
-Tag me in your AsyncAPI Doc PRs or [GitHub Discussions](https://github.com/asyncapi/community/discussions/categories/docs) via my GitHub handle, [`quetzalliwrites`](https://github.com/quetzalliwrites) 🐙.
+Tag me in your AsyncAPI Doc PRs or [GitHub Discussions](https://github.com/asyncapi/community/discussions/categories/docs) via my GitHub handle, [`derberg`](https://github.com/derberg) 🐙.


### PR DESCRIPTION
Fixes #4252

This PR addresses issue #4252 by updating the maintainer reference in the contribution guide.

- Replaces maintainer `Quetzali` with `derberg` as per the current maintainer list.

Let me know if any other sections need updating!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the GitHub handle for tagging documentation contributors in contribution notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->