### PR TITLE
fix:  revert ci workflows

### DIFF
--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -2,7 +2,7 @@
 name: PR testing - if Node project
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
   push:
     branches: [master]

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -81,16 +81,6 @@ jobs:
         shell: bash
         run: npm run generate:assets --if-present
 
-
-      - if: steps.should_run.outputs.shouldrun == 'true' && steps.packagejson.outputs.exists == 'true'
-        name: Run Cypress E2E Tests
-        uses: cypress-io/github-action@6c143abc292aa835d827652c2ea025d098311070
-        with:
-          start: npm run dev
-          wait-on: 'http://localhost:3000'  # Adjust port as needed
-          wait-on-timeout: 120
-          install: false  # Reuse existing dependencies
-
       # Run the test:md script and capture output
       - if: ${{ steps.packagejson.outputs.exists == 'true' && matrix.os == 'ubuntu-latest' }}
         name: Run markdown checks

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -2,7 +2,7 @@
 name: PR testing - if Node project
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
   push:
     branches: [master]


### PR DESCRIPTION
Reverts asyncapi/website#4227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the step that ran Cypress end-to-end tests from the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->