### PR TITLE
feat: update community events banner for 2024 YouTube stream

### DIFF
--- a/pages/community/events/index.tsx
+++ b/pages/community/events/index.tsx
@@ -72,11 +72,11 @@ export default function EventIndex() {
           />
           <div className='w-full sm:w-[70%]'>
             <Heading level={HeadingLevel.h2} typeStyle={HeadingTypeStyle.smSemibold} className='mt-10 lg:text-2xl'>
-              Watch the AsyncAPI 2023 conference recordings from anywhere around the world for free
+              Watch the AsyncAPI 2024 conference recordings from anywhere around the world for free
             </Heading>
             <a
               data-testid='Recordings-Link'
-              href='https://www.youtube.com/playlist?list=PLbi1gRlP7pijHAnmN-n_OiTH6CAXxGthw&si=st3gY7Ri5uzhechB'
+              href='https://www.youtube.com/playlist?list=PLbi1gRlP7pijItMBmw9SeeyWxuEa3jLR2'
               target='_blank'
               rel='noreferrer'
             >


### PR DESCRIPTION
This PR updates the community events page to reflect the AsyncAPI 2024 conference stream available on YouTube.

✅ Changes:
- Updated heading from "2023" to "2024"
- Updated YouTube stream link 

Closes #4311

Demo -

https://github.com/user-attachments/assets/d1edc572-e32a-404e-94ed-d08004bfa5db





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated conference recordings copy to reference AsyncAPI 2024.
  * Replaced the YouTube playlist link so the recordings now point to the 2024 playlist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->