### PR TITLE
docs: update outdated links on community-related pages

### DIFF
--- a/pages/community/ambassadors/index.tsx
+++ b/pages/community/ambassadors/index.tsx
@@ -64,7 +64,7 @@ export default function Index() {
             <Button
               className='mt-10 block text-center focus:outline-none md:inline-block'
               text='Become an AsyncAPI Ambassador'
-              href='https://github.com/asyncapi/community/blob/master/docs/050-mentorship-program/ambassador-program/AMBASSADOR_PROGRAM.md'
+              href='https://www.asyncapi.com/community/ambassadors'
               target='_blank'
             />
           </div>


### PR DESCRIPTION
### Summary

- Fixed outdated link on the Ambassadors page.
- Ensured no other links in `edit-page-config.json` needed changes.
- This PR is part of maintenance on community documentation links.


### Checklist

- [x] Follow the contribution guidelines
- [x] Fix applied in `pages/community/ambassadors/index.tsx`
- [x] Confirmed no change required in `edit-page-config.json`
- [x] Test the changes and attach their results to the pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "Become an AsyncAPI Ambassador" button to direct users to the official community ambassadors page on the AsyncAPI website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->