### PR TITLE
fix: update slack invite url

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -53,7 +53,7 @@ https://www.asyncapi.io/* https://www.asyncapi.com/:splat 301!
 /asyncapi-react https://asyncapi.github.io/asyncapi-react 301!
 
 # Slack
-/slack-invite https://join.slack.com/t/asyncapi/shared_invite/zt-33bsaqqgz-ZL0a3ZUiuy4stSbXB~~E9A 302!
+/slack-invite https://join.slack.com/t/asyncapi/shared_invite/zt-3clk6rmc0-Cujl2fChHYnHDUwFKRlQCw 302!
 
 # Central Maven repository verification
 /OSSRH-63280 https://github.com/asyncapi/java-asyncapi


### PR DESCRIPTION
**Description**
 
Updated the slack url in <https://github.com/asyncapi/website/blob/master/public/_redirects#L56>

**Related issue(s)**
fixes #4362 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the /slack-invite redirect to point to the latest Slack join URL, ensuring continued access to the community workspace.
  * Redirect behavior remains a temporary 302; no other redirect rules were modified.
  * Users navigating to /slack-invite will be seamlessly routed to the new invite page without any changes to their workflow or additional steps required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->