### PR TITLE
fix(events): update broken FAQ link on Events page

### DIFF
--- a/pages/community/events/index.tsx
+++ b/pages/community/events/index.tsx
@@ -51,7 +51,7 @@ export default function EventIndex() {
               All events/meetings are live streamed to all AsyncAPI social media accounts. To learn more about meetings
               setup and automation&nbsp;
               <TextLink
-                href='https://github.com/asyncapi/community/blob/master/MEETINGS_ORGANIZATION.md'
+                href='https://github.com/asyncapi/community/blob/master/docs/060-meetings-and-communication/MEETINGS_ORGANIZATION.md'
                 target='_blank'
               >
                 read our FAQ


### PR DESCRIPTION
Fix broken FAQ link on Events page

Description

This PR fixes the broken "Read FAQ" link on the [Events page](https://www.asyncapi.com/community/events?utm_source=chatgpt.com)
.
The link was previously pointing to a non-existent path in the community repo:

https://github.com/asyncapi/community/blob/master/MEETINGS_ORGANIZATION.md


It now correctly points to:

https://github.com/asyncapi/community/blob/master/docs/060-meetings-and-communication/MEETINGS_ORGANIZATION.md

Related issue(s)

Resolves #4382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Meetings organization” link on the Community Events page to the current documentation location, improving accuracy and navigation.
  * Prevents users from landing on an outdated path or potential 404s.
  * No changes to page layout, interactions, or functionality; only the link destination was updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->