### PR TITLE
fix: centralize Announcement banner spacing; make it consistent across all pages

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -29,7 +29,7 @@ export default function Hero({ className = '' }: HeroProps) {
 
   return (
     <>
-      <AnnouncementHero className='my-4' />
+      <AnnouncementHero />
       <header className={`mt-12 px-2 ${className}`}>
         <div className='text-center'>
           <Heading level={HeadingLevel.h1} typeStyle={HeadingTypeStyle.xl} className='mb-4'>

--- a/components/campaigns/AnnouncementBanner.tsx
+++ b/components/campaigns/AnnouncementBanner.tsx
@@ -48,8 +48,8 @@ export default function Banner({
 }: BannerProps) {
   return (
     <div
-      className={`size-full rounded border border-gray-200 bg-gray-50 py-6
-          transition-transform${className} ${small ? 'mb-4' : 'mx-3 my-6 p-3'}
+      className={`size-full rounded border border-gray-200 bg-gray-50 py-6 p-3
+          transition-transform ${className}
           ${activeBanner ? 'z-10 scale-100 opacity-100' : 'z-0 scale-90 opacity-0'}`}
       data-testid='AnnouncementHero-main-div'
     >

--- a/components/campaigns/AnnouncementBanner.tsx
+++ b/components/campaigns/AnnouncementBanner.tsx
@@ -17,7 +17,6 @@ interface BannerProps {
   link: string;
   city: string;
   activeBanner: boolean;
-  small: boolean;
   className: string;
 }
 
@@ -31,7 +30,6 @@ interface BannerProps {
  * @param {string} props.link - The link of the banner
  * @param {string} props.city - The city of the banner
  * @param {Boolean} props.activeBanner - Whether the banner is active
- * @param {Boolean} props.small - Whether the banner is small
  * @param {string} props.className - The class name of the banner
  */
 export default function Banner({
@@ -43,7 +41,6 @@ export default function Banner({
   link,
   city,
   activeBanner,
-  small,
   className
 }: BannerProps) {
   return (

--- a/components/campaigns/AnnouncementHero.tsx
+++ b/components/campaigns/AnnouncementHero.tsx
@@ -48,8 +48,10 @@ export default function AnnouncementHero({ className = '', small = false }: IAnn
     return null;
   }
 
+  const outerSpacing = small ? 'my-4' : 'my-6';
+
   return (
-    <Container as='section' padding='' className='text-center'>
+    <Container as='section' padding='' className={`text-center ${outerSpacing}`}>
       <div className='relative flex flex-row items-center justify-center overflow-x-hidden md:gap-4'>
         {numberOfVisibleBanners > 1 && (
           <div

--- a/components/layout/BlogLayout.tsx
+++ b/components/layout/BlogLayout.tsx
@@ -36,7 +36,7 @@ export default function BlogLayout({ post, children }: IBlogLayoutProps) {
 
   return (
     <BlogContext.Provider value={{ post }}>
-      <AnnouncementHero className='mx-8 my-4' />
+      <AnnouncementHero className='mx-8' />
       <Container cssBreakingPoint='lg' flex flexReverse>
         <TOC
           toc={post.toc}

--- a/components/layout/GenericLayout.tsx
+++ b/components/layout/GenericLayout.tsx
@@ -40,7 +40,7 @@ export default function GenericLayout({
       <Head title={title} description={description} image={image} />
       <Container wide={wide}>
         <div data-testid='GenericLayout-banner'>
-          <AnnouncementHero className={`m-4 text-center ${hideBanner && 'hidden'}`} small={true} />
+          <AnnouncementHero className={`${hideBanner && 'hidden'}`} />
         </div>
         <div id='main-content' data-testid='Generic-main'>
           {children}


### PR DESCRIPTION
Fix [[BUG] AnnouncementBanner UI inconsistency across pages #4367](https://github.com/asyncapi/website/issues/4367#issue-3363762262)

Someone mentioned in Slack that the Announcement banner kept looking different across pages so centralized vertical spacing in AnnouncementHero so one place controls it for every page

All spacing now comes from a single component AnnouncementHero so we won’t reintroduce per age differences over time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Unified spacing for announcement components: standardized padding and removed excess vertical margins for a cleaner, more consistent layout across pages.

* **Refactor**
  * Announcement banner now mounts only when visible, reducing layout shifts and improving perceived performance.
  * Simplified usage of announcement components across layouts for consistency.
  * Reduced conditional styling complexity while maintaining existing behavior and visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->