### PR TITLE
fix: #4065 Made Case Studies page table section mobile responsive

### DIFF
--- a/pages/casestudies/index.tsx
+++ b/pages/casestudies/index.tsx
@@ -82,38 +82,68 @@ export default function Casestudies() {
           </div>
         </div>
 
-        <center>
-          <div className='overflow-x-auto'>
-            <table className='my-8 w-full max-w-full border-collapse border'>
-              <thead>
-                <tr>
-                  <th className='border p-2 font-bold'>Company name</th>
-                  <th className='border-2 p-2 font-bold'>Use Case</th>
-                  <th className='border-2 p-2 font-bold'>Resources</th>
+        {/* Desktop Table View */}
+        <div className='hidden md:block overflow-x-auto'>
+          <table className='my-8 w-full border-collapse border table-auto'>
+            <thead>
+              <tr>
+                <th className='border p-2 font-bold text-left'>Company name</th>
+                <th className='border-2 p-2 font-bold text-left'>Use Case</th>
+                <th className='border-2 p-2 font-bold text-left'>Resources</th>
+              </tr>
+            </thead>
+            <tbody>
+              {AdoptersList.map((entry: Adopter, index: number) => (
+                <tr key={index} data-testid='Adopters'>
+                  <td className='border-2 p-2'>{entry.companyName}</td>
+                  <td className='border-2 p-2'>{entry.useCase}</td>
+                  <td className='border-2 p-2'>
+                    <ul className='space-y-1'>
+                      {entry.resources.map((resource: Resource, resourceIndex: number) => (
+                        <li key={resourceIndex}>
+                          <a className='text-cyan-500 underline hover:text-cyan-600' href={resource.link}>
+                            {resource.title}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </td>
                 </tr>
-              </thead>
-              <tbody>
-                {AdoptersList.map((entry: Adopter, index: number) => (
-                  <tr key={index} data-testid='Adopters'>
-                    <td className='border-2 p-2'>{entry.companyName}</td>
-                    <td className='border-2 p-2'>{entry.useCase}</td>
-                    <td className='border-2 p-2'>
-                      <ul>
-                        {entry.resources.map((resource: Resource, resourceIndex: number) => (
-                          <li className='p-2' key={resourceIndex}>
-                            <a className='text-cyan-500 underline' href={resource.link}>
-                              {resource.title}
-                            </a>
-                          </li>
-                        ))}
-                      </ul>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </center>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Mobile Card View */}
+        <div className='md:hidden my-8 space-y-4'>
+          {AdoptersList.map((entry: Adopter, index: number) => (
+            <div
+              key={index}
+              className='border border-gray-300 rounded-lg p-4 bg-white shadow-sm'
+              data-testid='Adopters'
+            >
+              <div className='mb-3'>
+                <h3 className='font-bold text-lg text-gray-900'>{entry.companyName}</h3>
+              </div>
+              <div className='mb-3'>
+                <h4 className='font-semibold text-sm text-gray-700 mb-1'>Use Case:</h4>
+                <p className='text-gray-600 text-sm'>{entry.useCase}</p>
+              </div>
+              <div>
+                <h4 className='font-semibold text-sm text-gray-700 mb-2'>Resources:</h4>
+                <ul className='space-y-1'>
+                  {entry.resources.map((resource: Resource, resourceIndex: number) => (
+                    <li key={resourceIndex}>
+                      <a className='text-cyan-500 underline hover:text-cyan-600 text-sm' href={resource.link}>
+                        {resource.title}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
     </GenericLayout>
   );

--- a/pages/casestudies/index.tsx
+++ b/pages/casestudies/index.tsx
@@ -87,9 +87,9 @@ export default function Casestudies() {
           <table className='my-8 w-full border-collapse border table-auto'>
             <thead>
               <tr>
-                <th className='border p-2 font-bold text-left'>Company name</th>
-                <th className='border-2 p-2 font-bold text-left'>Use Case</th>
-                <th className='border-2 p-2 font-bold text-left'>Resources</th>
+                <th className='border p-2 font-bold'>Company name</th>
+                <th className='border-2 p-2 font-bold'>Use Case</th>
+                <th className='border-2 p-2 font-bold'>Resources</th>
               </tr>
             </thead>
             <tbody>

--- a/pages/tools/generator.tsx
+++ b/pages/tools/generator.tsx
@@ -18,20 +18,13 @@ import Paragraph from '../../components/typography/Paragraph';
  */
 function renderButtons(): React.JSX.Element {
   return (
-    <div className='mt-8 flex flex-wrap gap-4'>
-      {/* <Button
-        text="Learn more"
-        href="/docs/tools/generator"
-        iconPosition="left"
-        icon={<IconRocket className="inline-block w-6 h-6 -mt-1" />}
-        className="w-full mb-2 sm:w-auto sm:mb-0 sm:mr-2"
-      /> */}
+    <div className='mt-8 flex flex-col gap-4 md:flex-row md:flex-wrap md:justify-center lg:justify-start'>
       <GithubButton
         text='View on Github'
-        className='w-full text-center sm:w-fit sm:text-left'
+        className='w-full text-center md:w-auto md:text-left'
         href='https://www.github.com/asyncapi/generator'
       />
-      <Button text='View Docs' href='/docs/tools/generator' className='w-full text-center sm:w-fit sm:text-left' />
+      <Button text='View Docs' href='/docs/tools/generator' className='w-full text-center md:w-auto md:text-left' />
     </div>
   );
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

1. Responsive Layout Strategy:
- Desktop: Traditional table view.
- Mobile: Card-based layout.

2.Mobile Card Structure:
- Each adopter entry becomes an individual card
- Clear visual hierarchy with company name as heading
- Properly labeled sections for Use Case and Resources
- Touch-friendly link targets


**Related issue(s)**
#4065 : Case Studies page table is not mobile responsive

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced a responsive case studies layout: desktop table view and mobile-friendly card view.
  - Resources are displayed as linked lists for easier access.

- Refactor
  - Replaced single table with separate desktop and mobile render paths for better responsiveness.
  - Reworked buttons layout to be responsive (vertical on small, row on md+); removed the previous "Learn more" button.

- Style
  - Updated spacing, typography, and enhanced link hover states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->