### PR TITLE
fix: replace Promise.reject with throw in build-dashboard error handling

### DIFF
--- a/scripts/dashboard/build-dashboard.ts
+++ b/scripts/dashboard/build-dashboard.ts
@@ -107,7 +107,7 @@ async function getDiscussions(
   } catch (e) {
     logger.error(e);
 
-    return Promise.reject(e);
+    throw e;
   }
 }
 
@@ -141,7 +141,7 @@ async function getDiscussionByID(isPR: boolean, id: string): Promise<PullRequest
   } catch (e) {
     logger.error(e);
 
-    return Promise.reject(e);
+    throw e;
   }
 }
 


### PR DESCRIPTION
**Description**
- This PR improves error handling in the `build-dashboard.ts` script by replacing `Promise.reject(e)` with direct `throw` statements, making the asynchronous functions more idiomatic and easier to read.

**Related issue(s)**
- Resolves #3305

<img width="302" height="86" alt="Screenshot 2025-09-18 181347" src="https://github.com/user-attachments/assets/6672cc40-c363-4a32-94d4-675b7b34e3c2" />