### PR TITLE
fix: smooth dropdown transitions for navbar #4427

### DIFF
--- a/coderabbit.txt
+++ b/coderabbit.txt
@@ -1,0 +1,1 @@
+"test setup" 

--- a/components/navigation/CommunityPanel.tsx
+++ b/components/navigation/CommunityPanel.tsx
@@ -3,9 +3,13 @@ import React from 'react';
 import communityItems from './communityItems';
 import FlyoutMenu from './FlyoutMenu';
 
+interface CommunityPanelProps {
+  open?: boolean;
+}
+
 /**
  * @description Component representing the community panel.
  */
-export default function CommunityPanel() {
-  return <FlyoutMenu items={communityItems} />;
+export default function CommunityPanel({ open = false }: CommunityPanelProps) {
+  return <FlyoutMenu items={communityItems} open={open} />;
 }

--- a/components/navigation/FlyoutMenu.tsx
+++ b/components/navigation/FlyoutMenu.tsx
@@ -5,17 +5,21 @@ import MenuBlocks from './MenuBlocks';
 
 interface FlyoutProps {
   items?: MenuItem[];
+  open?: boolean;
 }
 
 /**
- * @description Component representing a flyout menu.
+ * @description Component representing a flyout menu with enter/exit transitions.
  * @param {MenuItem[]} [props.items=[]] - The list of items to be displayed in the flyout menu.
+ * @param {boolean} [props.open=false] - Whether the flyout is open (used to apply animation classes).
  */
-export default function Flyout({ items = [] }: FlyoutProps) {
+export default function Flyout({ items = [], open = false }: FlyoutProps) {
   return (
     <div
-      className='absolute z-50 -ml-4 md:h-[80vh] overflow-x-scroll w-screen max-w-md pt-3 md:ml-12 md:-translate-x-1/2 lg:left-1/2 lg:max-w-3xl lg:-translate-x-1/2'
       data-testid='Flyout-main'
+      className={`absolute z-50 -ml-4 md:h-[80vh] overflow-x-scroll w-screen max-w-md pt-3 md:ml-12 md:-translate-x-1/2 lg:left-1/2 lg:max-w-3xl lg:-translate-x-1/2 transition-all duration-500 ease-out transform origin-top ${
+        open ? 'opacity-100 translate-y-0 pointer-events-auto' : 'opacity-0 -translate-y-6 pointer-events-none'
+      }`}
     >
       <div className='rounded-lg shadow-lg'>
         <div className='shadow-xs overflow-hidden rounded-lg'>

--- a/components/navigation/LearningPanel.tsx
+++ b/components/navigation/LearningPanel.tsx
@@ -3,9 +3,13 @@ import React from 'react';
 import { buckets } from '../data/buckets';
 import FlyoutMenu from './FlyoutMenu';
 
+interface LearningPanelProps {
+  open?: boolean;
+}
+
 /**
  * @description Component representing the learning panel.
  */
-export default function LearningPanel() {
-  return <FlyoutMenu items={buckets} />;
+export default function LearningPanel({ open = false }: LearningPanelProps) {
+  return <FlyoutMenu items={buckets} open={open} />;
 }

--- a/components/navigation/ToolsPanel.tsx
+++ b/components/navigation/ToolsPanel.tsx
@@ -3,9 +3,13 @@ import React from 'react';
 import FlyoutMenu from './FlyoutMenu';
 import toolingItems from './toolingItems';
 
+interface ToolsPanelProps {
+  open?: boolean;
+}
+
 /**
  * @description Renders a panel containing tools using a flyout menu.
  */
-export default function ToolsPanel() {
-  return <FlyoutMenu items={toolingItems} />;
+export default function ToolsPanel({ open = false }: ToolsPanelProps) {
+  return <FlyoutMenu items={toolingItems} open={open} />;
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Fixed abrupt open/close behavior of navbar dropdown menus.
- Added smooth fade + slide transition for dropdowns.
- Dropdown remains visible while hovering over its content.
- Dropdown only closes when the cursor leaves both the menu item and the panel.
- Improved accessibility with proper ARIA state handling on the mobile menu button.

**Related issue(s)**
Resolves #4427
