### PR TITLE
Corrected the text of the button present in the nav bar from "star on github" to "start on github" 

### DIFF
--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -235,7 +235,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
             />
 
             <GithubButton
-              text='Star on GitHub'
+              text='Start on GitHub'
               href='https://github.com/asyncapi/spec'
               className='ml-2 py-2'
               inNav={true}


### PR DESCRIPTION
🔹 Description

This PR updates the navbar button text from “Star on GitHub” to “Start on GitHub”.

🔹 Reason for Change
	•	The current text “Star on GitHub” refers to the GitHub action of giving a repository a star, but it may confuse new users as a call-to-action.
	•	Updating it to “Start on GitHub” makes it feel more engaging and action-oriented, encouraging users to get involved with the project rather than just starring it.

🔹 Changes Made
	•	Modified the navbar component to display “Start on GitHub” instead of “Star on GitHub”.

🔹 Impact
	•	UI update in the navigation bar.
	•	No breaking changes to functionality.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Style
  - Updated the GitHub button label in the navigation bar from “Star on GitHub” to “Start on GitHub” for clearer wording. This is a text-only change with no impact on links, click behavior, routing, or layout. Users will see the revised label in the header across the app. No other UI elements were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->