### PR TITLE
fix(navbar): change text from 'Star on GitHub' to 'Start on GitHub'

### DIFF
--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -234,12 +234,13 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
               selected={i18n.language ? i18n.language : 'en'}
             />
 
-            <GithubButton
-              text='Star on GitHub'
-              href='https://github.com/asyncapi/spec'
-              className='ml-2 py-2'
-              inNav={true}
-            />
+           <GithubButton
+                text='Start on GitHub'
+                 href='https://github.com/asyncapi/spec'
+                 className='ml-2 py-2'
+                 inNav={true}
+              />
+
           </div>
         </nav>
       </div>


### PR DESCRIPTION
**Description**

- Changed the navbar button text from **"Star on GitHub"** to **"Start on GitHub"**.  
- Improves the call-to-action wording to encourage users to begin contributing rather than only starring the repo.  
- Verified the change locally using `npm run dev`.  

**Related issue(s)**

Resolves #4452


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Updated the GitHub button label in the navigation bar from “Star on GitHub” to “Start on GitHub” for a clearer call-to-action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->