### PR TITLE
fix: update GitHub button text to "Start on GitHub"

### DIFF
--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -235,7 +235,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
             />
 
             <GithubButton
-              text='Star on GitHub'
+              text='Start on GitHub'
               href='https://github.com/asyncapi/spec'
               className='ml-2 py-2'
               inNav={true}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Hey everyone,

This PR is a quick fix for an idea that came from issue asyncapi/spec#1125. The original issue was posted in the spec repo, but the button code lives here in the website repo, so I've made the change here.

I updated the main GitHub button in the navbar to say "Start on GitHub" instead of "Star on GitHub". 

I've already run it locally and it works as expected.

Here's a screenshot showing the new text on my machine:
<img width="1440" height="900" alt="Screenshot 2025-10-05 at 10 57 17 AM" src="https://github.com/user-attachments/assets/6168a569-bbaf-4649-8492-e909b9a3a785" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the GitHub button label in the navigation bar from “Star on GitHub” to “Start on GitHub,” improving clarity and consistency for users. This change updates only the visible text; the link destination, styling, and behavior remain the same. Users will now see the intended label across the site’s navigation, reducing potential confusion and aligning the interface with the expected copy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->