### PR TITLE
docs: fix FastStream tools dead links

### DIFF
--- a/config/tools-manual.json
+++ b/config/tools-manual.json
@@ -232,8 +232,8 @@
                 "title": "FastStream",
                 "description": "A powerful and easy-to-use Python framework for building asynchronous services interacting with event streams such as Apache Kafka, RabbitMQ and NATS.",
                 "links": {
-                    "websiteUrl": "https://faststream.airt.ai",
-                    "repoUrl": "https://github.com/airtai/FastStream"
+                    "websiteUrl": "https://faststream.ag2.ai",
+                    "repoUrl": "https://github.com/ag2ai/FastStream"
                 },
                 "filters": {
                     "language": "Python",

--- a/config/tools-manual.json
+++ b/config/tools-manual.json
@@ -524,8 +524,8 @@
                 "title": "FastStream",
                 "description": "A powerful and easy-to-use Python framework for building asynchronous services interacting with event streams such as Apache Kafka, RabbitMQ and NATS.",
                 "links": {
-                    "websiteUrl": "https://faststream.airt.ai",
-                    "repoUrl": "https://github.com/airtai/FastStream"
+                    "websiteUrl": "https://faststream.ag2.ai",
+                    "repoUrl": "https://github.com/ag2ai/FastStream"
                 },
                 "filters": {
                     "language": "Python",

--- a/config/tools.json
+++ b/config/tools.json
@@ -1612,8 +1612,8 @@
         "title": "FastStream",
         "description": "A powerful and easy-to-use Python framework for building asynchronous services interacting with event streams such as Apache Kafka, RabbitMQ and NATS.",
         "links": {
-          "websiteUrl": "https://faststream.airt.ai",
-          "repoUrl": "https://github.com/airtai/FastStream"
+          "websiteUrl": "https://faststream.ag2.ai",
+          "repoUrl": "https://github.com/ag2ai/FastStream"
         },
         "filters": {
           "language": [

--- a/config/tools.json
+++ b/config/tools.json
@@ -249,8 +249,8 @@
         "title": "FastStream",
         "description": "A powerful and easy-to-use Python framework for building asynchronous services interacting with event streams such as Apache Kafka, RabbitMQ and NATS.",
         "links": {
-          "websiteUrl": "https://faststream.airt.ai",
-          "repoUrl": "https://github.com/airtai/FastStream"
+          "websiteUrl": "https://faststream.ag2.ai",
+          "repoUrl": "https://github.com/ag2ai/FastStream"
         },
         "filters": {
           "language": [


### PR DESCRIPTION
The FastStream framework has recently changed its ownership, GitHub organization, and domain name. This pull request is intended to update broken links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated FastStream links across the tools catalog to the new official website (faststream.ag2.ai) and repository (github.com/ag2ai/FastStream), replacing outdated airt.ai/airtai references so listings and detail pages now point to the correct destinations for reliable access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->