### PR TITLE
style: minor layout spacing tweak for announcement banner

### DIFF
--- a/components/campaigns/AnnouncementHero.tsx
+++ b/components/campaigns/AnnouncementHero.tsx
@@ -60,7 +60,7 @@ export default function AnnouncementHero({ className = '', small = false }: IAnn
             <ArrowLeft className='text-white' />
           </div>
         )}
-        <div className='relative flex w-4/5 md:w-5/6 flex-col items-center justify-center gap-2'>
+        <div className='relative flex w-4/5 md:w-5/6 flex-col items-center justify-center gap-2 py-10'>
           <div className='relative flex min-h-72 w-full justify-center overflow-hidden lg:h-[17rem] lg:w-[38rem]'>
             {visibleBanners.map((banner, index) => {
               // Only render the active banner

--- a/components/campaigns/AnnouncementHero.tsx
+++ b/components/campaigns/AnnouncementHero.tsx
@@ -60,7 +60,7 @@ export default function AnnouncementHero({ className = '', small = false }: IAnn
             <ArrowLeft className='text-white' />
           </div>
         )}
-        <div className='relative flex w-4/5 md:w-5/6 flex-col items-center justify-center gap-2 py-10'>
+        <div className='relative flex w-4/5 md:w-5/6 flex-col items-center justify-center gap-2'>
           <div className='relative flex min-h-72 w-full justify-center overflow-hidden lg:h-[17rem] lg:w-[38rem]'>
             {visibleBanners.map((banner, index) => {
               // Only render the active banner

--- a/components/layout/GenericLayout.tsx
+++ b/components/layout/GenericLayout.tsx
@@ -40,7 +40,7 @@ export default function GenericLayout({
       <Head title={title} description={description} image={image} />
       <Container wide={wide}>
         <div data-testid='GenericLayout-banner'>
-          <AnnouncementHero className={`m-4 text-center ${hideBanner && 'hidden'}`} small={true} />
+          <AnnouncementHero className={` m-6 text-center ${hideBanner && 'hidden'}`} small={true} />
         </div>
         <div id='main-content' data-testid='Generic-main'>
           {children}

--- a/components/layout/GenericLayout.tsx
+++ b/components/layout/GenericLayout.tsx
@@ -40,7 +40,7 @@ export default function GenericLayout({
       <Head title={title} description={description} image={image} />
       <Container wide={wide}>
         <div data-testid='GenericLayout-banner'>
-          <AnnouncementHero className={` m-6 text-center ${hideBanner && 'hidden'}`} small={true} />
+          <AnnouncementHero className={` my-4 text-center ${hideBanner && 'hidden'}`} small={true} />
         </div>
         <div id='main-content' data-testid='Generic-main'>
           {children}

--- a/components/layout/GenericPostLayout.tsx
+++ b/components/layout/GenericPostLayout.tsx
@@ -32,7 +32,7 @@ export default function GenericPostLayout({ post, children }: IGenericPostLayout
 
   return (
     <GenericPostContext.Provider value={{ post }}>
-      <AnnouncementHero className='m-4 text-center' small={true} />
+      <AnnouncementHero className='my-4 text-center' small={true} />
       <Container>
         <main className='mt-8 px-4 sm:px-6' data-testid='GenericPostLayout-main-div'>
           <header className='pr-4 sm:pr-6 md:pr-8'>

--- a/components/layout/GenericWideLayout.tsx
+++ b/components/layout/GenericWideLayout.tsx
@@ -35,7 +35,7 @@ export default function GenericWideLayout({
     <>
       <Head title={title} description={description} image={image} />
       <Row>
-        <AnnouncementHero className='m-4 text-center' small={true} />
+        <AnnouncementHero className='my-4 text-center' small={true} />
         {children}
       </Row>
     </>


### PR DESCRIPTION
**Description**

- Fixed layout and spacing issue for the blog section.  
- Ensured better readability and consistent alignment.  
- Updated responsive styles in `AnnouncementHero.tsx`.

<img width="1365" height="462" alt="Screenshot 2025-10-26 at 3 16 22 PM" src="https://github.com/user-attachments/assets/11697723-07e3-43c2-9a86-4087aede03d3" />


**Related issue(s)**  
Resolves #4495 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted announcement banner spacing across layouts: increased vertical (top/bottom) spacing for improved visual separation while preserving horizontal centering and side spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->