### PR TITLE
style: missing vertical spacing between navbar and announcement banner on tools, community, case studies, blog, and roadmap pages #4549

### DIFF
--- a/components/campaigns/AnnouncementHero.tsx
+++ b/components/campaigns/AnnouncementHero.tsx
@@ -61,7 +61,7 @@ export default function AnnouncementHero({ className = '', small = false }: IAnn
           </div>
         )}
         <div className='relative flex w-4/5 md:w-5/6 flex-col items-center justify-center gap-2'>
-          <div className='relative flex min-h-72 w-full justify-center overflow-hidden lg:h-[17rem] lg:w-[38rem]'>
+          <div className='relative flex min-h-72 w-full justify-center overflow-hidden lg:h-[17rem] lg:w-[38rem] mt-4'>
             {visibleBanners.map((banner, index) => {
               // Only render the active banner
               const isVisible = index === activeIndex;

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -521,7 +521,7 @@ export default function RoadmapPage() {
 
             <div className='relative mt-20'>
               <div className='grid lg:grid-cols-3 lg:gap-8'>
-                <div className='bg-white  border border-gray-100 dark:border-gray-400 rounded-lg p-6 shadow-sm flex flex-col justify-start lg:h-full'>
+                <div className='bg-white  border border-gray-200 rounded-lg shadow-md p-6 flex flex-col justify-start lg:h-full'>
                   <div className='mb-2 lg:my-0 lg:text-center'>
                     <Paragraph
                       typeStyle={ParagraphTypeStyle.md}
@@ -549,7 +549,7 @@ export default function RoadmapPage() {
                     to integrate with the existing tools and specs instead.
                   </Paragraph>
                 </div>
-                <div className='bg-white border border-gray-100 dark:border-gray-400 rounded-lg p-6 shadow-sm flex flex-col justify-start lg:h-full'>
+                <div className='bg-white  border border-gray-200 rounded-lg shadow-md p-6 flex flex-col justify-start lg:h-full'>
                   <div className='mb-2 mt-6 lg:my-0 lg:text-center'>
                     <Paragraph
                       typeStyle={ParagraphTypeStyle.md}
@@ -572,7 +572,7 @@ export default function RoadmapPage() {
                     the programming language or framework of choice.
                   </Paragraph>
                 </div>
-                <div className='bg-white border border-gray-100 dark:border-gray-400 rounded-lg p-6 shadow-sm flex flex-col justify-start lg:h-full'>
+                <div className='bg-white  border border-gray-200 rounded-lg shadow-md p-6 flex flex-col justify-start lg:h-full'>
                   <div className='mb-2 mt-6 lg:my-0 lg:text-center'>
                     <Paragraph
                       typeStyle={ParagraphTypeStyle.md}

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -521,7 +521,7 @@ export default function RoadmapPage() {
 
             <div className='relative mt-20'>
               <div className='grid lg:grid-cols-3 lg:gap-8'>
-                <div>
+                <div className='bg-white  border border-gray-100 dark:border-gray-400 rounded-lg p-6 shadow-sm flex flex-col justify-start lg:h-full'>
                   <div className='mb-2 lg:my-0 lg:text-center'>
                     <Paragraph
                       typeStyle={ParagraphTypeStyle.md}
@@ -549,7 +549,7 @@ export default function RoadmapPage() {
                     to integrate with the existing tools and specs instead.
                   </Paragraph>
                 </div>
-                <div>
+                <div className='bg-white border border-gray-100 dark:border-gray-400 rounded-lg p-6 shadow-sm flex flex-col justify-start lg:h-full'>
                   <div className='mb-2 mt-6 lg:my-0 lg:text-center'>
                     <Paragraph
                       typeStyle={ParagraphTypeStyle.md}
@@ -572,7 +572,7 @@ export default function RoadmapPage() {
                     the programming language or framework of choice.
                   </Paragraph>
                 </div>
-                <div>
+                <div className='bg-white border border-gray-100 dark:border-gray-400 rounded-lg p-6 shadow-sm flex flex-col justify-start lg:h-full'>
                   <div className='mb-2 mt-6 lg:my-0 lg:text-center'>
                     <Paragraph
                       typeStyle={ParagraphTypeStyle.md}


### PR DESCRIPTION
Fixes #4549 
<img width="1440" height="900" alt="Screenshot 2025-11-06 at 8 31 14 PM" src="https://github.com/user-attachments/assets/52a4e8d0-b75b-47a3-8625-4a3ade5a5269" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved vertical spacing for announcement banners.
  * Enhanced roadmap cards with refined styling including updated backgrounds, borders, and shadows for better visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->