### PR TITLE
chore: incorrect repourl for AsyncApi-format modified (#4547)

### DIFF
--- a/config/tools-manual.json
+++ b/config/tools-manual.json
@@ -753,7 +753,7 @@
                 "title": "AsyncAPI-format",
                 "description": "Format an AsyncAPI document by ordering, casing, formatting, and filtering fields.",
                 "links": {
-                    "repoUrl": "https://github.com/asyncapi/converter-go"
+                    "repoUrl": "https://github.com/thim81/asyncapi-format"
                 },
                 "filters": {
                     "language": "JavaScript",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
AsyncApi-format card in CLIs category in tools page (https://asyncapi.com/tools) redirects to wrong github repo and thus url link to repo has been modified.
<img width="1278" height="501" alt="image" src="https://github.com/user-attachments/assets/0adbe494-c1e4-4dc3-ba2d-281cb5dd2de9" />


**Related issue(s)**
Fixes #4547
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AsyncAPI-format CLI tool reference to point to the current repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->