### PR TITLE
Enhance layout and styling of sponsors section

### DIFF
--- a/components/sponsors/PlatinumSponsors.tsx
+++ b/components/sponsors/PlatinumSponsors.tsx
@@ -17,13 +17,13 @@ interface SponsorsProps {
 export default function PlatinumSponsors({ className = '', showSupportBanner = true }: SponsorsProps): React.ReactNode {
   return (
     <div className={`text-center ${className}`}>
-      <ul className='mb-4 flex flex-wrap items-center justify-center md:px-4'>
+      <ul className='mb-4 flex flex-wrap items-center justify-center gap-x-8 gap-y-8 px-4 sm:gap-x-12 sm:gap-y-10'>
         {platinumSponsors.map((sponsor, index) => (
-          <li key={index} className='w-2/3 sm:w-1/4 md:w-1/3 lg:w-1/5' data-testid='Sponsors-list'>
+          <li key={index} data-testid='Sponsors-list'>
             <a
               href={sponsor.website}
               target='_blank'
-              className='relative block p-4 text-center sm:p-0'
+              className='group relative flex min-h-24 items-center justify-center rounded-lg p-4 transition-all duration-300 ease-in-out hover:bg-white hover:shadow-lg'
               rel='noopener noreferrer'
               data-testid='Sponsors-link'
             >

--- a/components/sponsors/SponsorImage.tsx
+++ b/components/sponsors/SponsorImage.tsx
@@ -13,7 +13,14 @@ interface SponsorImageProps {
 export default function SponsorImage({ src, alt = 'Sponsor logo', className }: SponsorImageProps) {
   return (
     <div className='flex size-full items-center justify-center'>
-      <img src={src} alt={alt} className={twMerge('max-h-9 sm:max-h-12 w-auto object-contain', className)} />
+      <img
+        src={src}
+        alt={alt}
+        className={twMerge(
+          'max-h-16 w-auto object-contain transition-transform duration-300 ease-in-out group-hover:scale-110',
+          className
+        )}
+      />
     </div>
   );
 }


### PR DESCRIPTION
This PR reworks the sponsor section to fix the whitespace issue by making a few key changes, including getting rid of the weird gaps and improving the logo sizing.

<table>
<tr>
<td align="center"><strong>Before</strong></td>
<td align="center"><strong>After</strong></td>
</tr>
<tr>
<td>
<img width="1440" height="900" alt="Screenshot 2025-11-11 at 9 32 43 PM" src="https://github.com/user-attachments/assets/53084e17-49ac-4464-98c8-ab9905011b1d" />
</td>
<td>
<img width="1440" height="900" alt="Screenshot 2025-11-11 at 9 33 11 PM" src="https://github.com/user-attachments/assets/8e8f9fa0-6dda-496e-b64a-9407f5aac7ee" />
</td>
</tr>
</table>

Please review and let me know if any changes are needed.

Fixes #4564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved sponsor section layout with enhanced grid spacing
  * Added interactive hover effects to sponsor items, including background changes and subtle shadows
  * Enhanced sponsor logo animations with scale effects on hover
  * Updated sponsor container styling for better visual presentation with rounded corners

<!-- end of auto-generated comment: release notes by coderabbit.ai -->