### PR TITLE
fix: updated the Github Button to IconGithub Button when screen size becomes small

### DIFF
--- a/components/buttons/GithubButton.tsx
+++ b/components/buttons/GithubButton.tsx
@@ -38,7 +38,7 @@ export default function GithubButton({
         href={href}
         iconPosition={iconPosition}
         target={target}
-        className={`${className}ml-1 hidden xl:inline-block`}
+        className={`${className} ml-1 hidden xl:inline-block`}
         data-testid='Github-button'
         bgClassName='bg-gray-800 hover:bg-gray-700'
         buttonSize={inNav ? ButtonSize.SMALL : ButtonSize.DEFAULT}

--- a/components/buttons/GithubButton.tsx
+++ b/components/buttons/GithubButton.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import React from 'react';
 
 import { ButtonIconPosition, ButtonSize } from '@/types/components/buttons/ButtonPropsType';
@@ -30,16 +31,21 @@ export default function GithubButton({
   const { t } = useTranslation('common');
 
   return (
-    <Button
-      text={t(text)}
-      icon={<IconGithub className='-mt-1 inline-block size-6' />}
-      href={href}
-      iconPosition={iconPosition}
-      target={target}
-      className={className}
-      data-testid='Github-button'
-      bgClassName='bg-gray-800 hover:bg-gray-700'
-      buttonSize={inNav ? ButtonSize.SMALL : ButtonSize.DEFAULT}
-    />
+    <div>
+      <Button
+        text={t(text)}
+        icon={<IconGithub className='-mt-1 inline-block size-6' />}
+        href={href}
+        iconPosition={iconPosition}
+        target={target}
+        className={`${className}ml-1 hidden xl:inline-block`}
+        data-testid='Github-button'
+        bgClassName='bg-gray-800 hover:bg-gray-700'
+        buttonSize={inNav ? ButtonSize.SMALL : ButtonSize.DEFAULT}
+      />
+      <Link href={href} target={target} aria-label='Visit AsyncAPI Github Repository'>
+        <IconGithub className='-mt-1 ml-2 inline-block size-8 xl:hidden' />
+      </Link>
+    </div>
   );
 }

--- a/components/buttons/GithubButton.tsx
+++ b/components/buttons/GithubButton.tsx
@@ -38,7 +38,7 @@ export default function GithubButton({
         href={href}
         iconPosition={iconPosition}
         target={target}
-        className={`${className} ml-1 hidden xl:inline-block`}
+        className={`${className}ml-1 hidden xl:inline-block`}
         data-testid='Github-button'
         bgClassName='bg-gray-800 hover:bg-gray-700'
         buttonSize={inNav ? ButtonSize.SMALL : ButtonSize.DEFAULT}

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -59,7 +59,7 @@ async function start() {
       return parseFloat(b) - parseFloat(a);
     });
 
-  if (yearsList.length === 0) {
+  if (!yearsList || yearsList.length === 0) {
     throw new Error('No finance data found in the finance directory.');
   }
 


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
Fixes [#4575 ]
- 1. Added the utils/windowSize.ts file which is exporting the size of the window after it resizes
- 2. In the components/buttons/GithubButton.tsx file just imported the the size and put the check on it so that if the width greater than 1144px it remains the same when window size becomes less than 1144px it changes to IconGithub
-3. Also encapsulated the IconButton in the Link so that after clicking it one could be redirected to the asyncapi github repo.

**Final Look**
<img width="1386" height="109" alt="Screenshot 2025-11-12 134832" src="https://github.com/user-attachments/assets/8545bb7b-b2f7-4d72-a27e-cf2415234cc5" />


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * GitHub button is now responsive: full button on large screens and a compact, accessible icon link on small screens for improved layout and accessibility.

* **Bug Fixes**
  * Made the finance data check more robust to avoid runtime errors when no yearly data is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->