### PR TITLE
fix(navbar): prevent GitHub button from wrapping on mid-size screens

### DIFF
--- a/components/buttons/GithubButton.tsx
+++ b/components/buttons/GithubButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { twMerge } from 'tailwind-merge';
 
 import { ButtonIconPosition, ButtonSize } from '@/types/components/buttons/ButtonPropsType';
 
@@ -6,7 +7,6 @@ import type { IButtonDefaultProps } from '../../types/components/buttons/types';
 import { useTranslation } from '../../utils/i18n';
 import IconGithub from '../icons/Github';
 import Button from './Button';
-import { twMerge } from 'tailwind-merge';
 
 interface IGithubButtonProps extends IButtonDefaultProps {
   inNav?: boolean;
@@ -37,10 +37,7 @@ export default function GithubButton({
       href={href}
       iconPosition={iconPosition}
       target={target}
-      className={twMerge(
-        'ml-2 px-2 py-2 md:px-4 md:py-3 flex items-center whitespace-nowrap',
-        className
-      )}
+      className={twMerge('ml-2 px-2 py-2 md:px-4 md:py-3 flex items-center whitespace-nowrap', className)}
       data-testid='Github-button'
       bgClassName='bg-gray-800 hover:bg-gray-700'
       buttonSize={inNav ? ButtonSize.SMALL : ButtonSize.DEFAULT}

--- a/components/buttons/GithubButton.tsx
+++ b/components/buttons/GithubButton.tsx
@@ -6,6 +6,7 @@ import type { IButtonDefaultProps } from '../../types/components/buttons/types';
 import { useTranslation } from '../../utils/i18n';
 import IconGithub from '../icons/Github';
 import Button from './Button';
+import { twMerge } from 'tailwind-merge';
 
 interface IGithubButtonProps extends IButtonDefaultProps {
   inNav?: boolean;
@@ -36,7 +37,10 @@ export default function GithubButton({
       href={href}
       iconPosition={iconPosition}
       target={target}
-      className={className}
+      className={twMerge(
+        'ml-2 px-2 py-2 md:px-4 md:py-3 flex items-center whitespace-nowrap',
+        className
+      )}
       data-testid='Github-button'
       bgClassName='bg-gray-800 hover:bg-gray-700'
       buttonSize={inNav ? ButtonSize.SMALL : ButtonSize.DEFAULT}


### PR DESCRIPTION
Fixes #4648 

**Description**
When the browser window width is reduced to around 1032px, the navigation bar layout breaks. Specifically, the GitHub button wraps to the next line, causing misalignment in the navbar. The UI becomes inconsistent until the screen reaches the mobile breakpoint, where the hamburger menu appears and the layout becomes stable again.

This issue affects the visual consistency of the navbar on medium-sized screens.

<img width="1252" height="291" alt="async_api_nav_bar_fix" src="https://github.com/user-attachments/assets/0fa8eb63-4e92-49b1-811d-cd9059977e2f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved styling for the GitHub button to ensure consistent spacing, layout and responsiveness across screen sizes and when custom classes are applied.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->