### PR TITLE
chore: add php, laravel and symphony in tage-color.ts

### DIFF
--- a/scripts/tools/tags-color.ts
+++ b/scripts/tools/tags-color.ts
@@ -81,6 +81,11 @@ const languagesColor: LanguageColorItem[] = [
     name: 'Groovy',
     color: 'bg-[#B6D5E5]',
     borderColor: 'border-[#609DBC]'
+  },
+  {
+    name: 'Php',
+    color: 'bg-[#B0B3D6]',
+    borderColor: 'border-[#787CB5]'
   }
 ];
 
@@ -169,6 +174,21 @@ const technologiesColor: LanguageColorItem[] = [
     name: 'Nest Js',
     color: 'bg-[#E1224E]',
     borderColor: 'border-[#B9012b]'
+  },
+  {
+    name: 'Php',
+    color: 'bg-[#B0B3D6]',
+    borderColor: 'border-[#787CB5]'
+  },
+  {
+    name: 'Laravel',
+    color: 'bg-[#f55247]',
+    borderColor: 'border-[#f43b2f]'
+  },
+  {
+    name: 'Symfony',
+    color: 'bg-[#666666]',
+    borderColor: 'border-[#333333]'
   }
 ];
 

--- a/scripts/tools/tags-color.ts
+++ b/scripts/tools/tags-color.ts
@@ -83,7 +83,7 @@ const languagesColor: LanguageColorItem[] = [
     borderColor: 'border-[#609DBC]'
   },
   {
-    name: 'Php',
+    name: 'PHP',
     color: 'bg-[#B0B3D6]',
     borderColor: 'border-[#787CB5]'
   }
@@ -176,14 +176,14 @@ const technologiesColor: LanguageColorItem[] = [
     borderColor: 'border-[#B9012b]'
   },
   {
-    name: 'Php',
+    name: 'PHP',
     color: 'bg-[#B0B3D6]',
     borderColor: 'border-[#787CB5]'
   },
   {
     name: 'Laravel',
-    color: 'bg-[#f55247]',
-    borderColor: 'border-[#f43b2f]'
+    color: 'bg-[#F55247]',
+    borderColor: 'border-[#F43B2F]'
   },
   {
     name: 'Symfony',


### PR DESCRIPTION
Add  languages to tags-color.ts
- php in languageColor array
- php, laravel and symphony in technologiesColor array

Fixes #4664

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added visual styling entries for PHP and the PHP ecosystem (Laravel, Symfony), defining their display colors and border styles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->