### PR TITLE
fix: resolve CI pipeline failure caused by invalid pull_request.number check in workflow

### DIFF
--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           # Checkout the merge commit instead of the pull request head commit for a pull request
           # Fallback to the head commit if its not a pull request
-          ref: ${{ github.event.pull_request.number != '' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
+          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
 
       - if: steps.should_run.outputs.shouldrun == 'true'
         name: Check if Node.js project and has package.json


### PR DESCRIPTION
This PR fixes a CI failure that caused all PRs in the website repository to remain stuck in the “Waiting for status to be reported” state. As a result, no PR could be merged.

**Problem**
The following checks were never executed because the workflow crashed at startup:
	•	Test NodeJS PR – macos-latest
	•	Test NodeJS PR – ubuntu-latest
	•	Test NodeJS PR – windows-latest
	•	codecov/patch
	•	codecov/project

**Description**

Result
	•	CI pipeline no longer fails at startup.
	•	All Test NodeJS PR jobs now run across macOS, Ubuntu, and Windows.
	•	Codecov reporting works properly again.
	•	PRs correctly exit the “Waiting for status to be reported” state.

**Related issue(s)**
Fixes -> #4671


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal CI/CD workflow logic for pull request testing by simplifying conditional checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->