### PR TITLE
docs: add django and fastapi to technologies

### DIFF
--- a/config/all-tags.json
+++ b/config/all-tags.json
@@ -173,6 +173,16 @@
       "borderColor": "border-[#A387D2]"
     },
     {
+      "name": "Django",
+      "color": "bg-[#A3D9B1]",
+      "borderColor": "border-[#0C4B33]"
+    },
+    {
+      "name": "FastAPI",
+      "color": "bg-[#7DD3C0]",
+      "borderColor": "border-[#009688]"
+    },
+    {
       "name": "Nest Js",
       "color": "bg-[#E1224E]",
       "borderColor": "border-[#B9012b]"

--- a/scripts/tools/tags-color.ts
+++ b/scripts/tools/tags-color.ts
@@ -169,6 +169,16 @@ const technologiesColor: LanguageColorItem[] = [
     name: 'Nest Js',
     color: 'bg-[#E1224E]',
     borderColor: 'border-[#B9012b]'
+  },
+  {
+    name: 'Django',
+    color: 'bg-[#A3D9B1]',
+    borderColor: 'border-[#0C4B33]'
+  },
+  {
+    name: 'FastAPI',
+    color: 'bg-[#7DD3C0]',
+    borderColor: 'border-[#009688]'
   }
 ];
 


### PR DESCRIPTION
Description
- Added Django and FastAPI to the technology tags list in tags-color.ts.
- Updated the asyncapi-tool metadata so packages using these technologies can be correctly tagged and recognized.
- Ensured consistency with existing technology definitions and naming conventions used in the project.

Related issue(s)
Resolves #4680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Django and FastAPI programming frameworks with personalized color themes. Both technologies now include dedicated background and border color styling, enabling enhanced visual organization, improved identification, and clearer distinction between frameworks in your development environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->