### PR TITLE
fix: add React error boundary to prevent full app crash (#4688)

### DIFF
--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends React.Component<
+  React.PropsWithChildren<{}>,
+  State
+> {
+  constructor(props: any) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(_: Error): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("Error caught by ErrorBoundary:", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex flex-col items-center justify-center p-6 bg-red-50 text-red-800">
+          <h1 className="text-2xl font-semibold mb-4">Something went wrong.</h1>
+          <p className="mb-6 max-w-md text-center">
+            An unexpected error occurred while rendering this page. Please try refreshing the page.
+          </p>
+          <button
+            className="px-4 py-2 bg-red-600 text-white rounded-md"
+            onClick={() => window.location.reload()}
+          >
+            Reload Page
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/pages/[lang]/index.tsx
+++ b/pages/[lang]/index.tsx
@@ -38,6 +38,9 @@ export { getStaticPaths, getStaticProps };
  */
 export default function HomePage() {
   const { t } = useTranslation('landing-page');
+  
+
+  
 
   return (
     <>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,6 +13,8 @@ import Layout from '@/components/layout/Layout';
 import NavBar from '@/components/navigation/NavBar';
 import StickyNavbar from '@/components/navigation/StickyNavbar';
 import AppContext from '@/context/AppContext';
+import ErrorBoundary from '@/components/ErrorBoundary';
+
 
 /**
  * @description The MyApp component is the root component for the application.
@@ -21,6 +23,7 @@ function MyApp({ Component, pageProps, router }: AppProps) {
   return (
     <AppContext.Provider value={{ path: router.asPath }}>
       {/* <MDXProvider components={mdxComponents}> */}
+      <ErrorBoundary>
       <Head>
         <script async defer src='https://buttons.github.io/buttons.js'></script>
       </Head>
@@ -39,6 +42,7 @@ function MyApp({ Component, pageProps, router }: AppProps) {
           </div>
         </div>
       </AlgoliaSearch>
+        </ErrorBoundary>
       {/* </MDXProvider> */}
     </AppContext.Provider>
   );


### PR DESCRIPTION

### Summary
This PR adds a global React Error Boundary to ensure the application does not completely crash when a component throws a runtime error. Instead, the user sees a clean fallback UI.

### What This Fixes
Currently, if any component throws an error, the entire page breaks.
This PR catches such errors and prevents a full blank crash.

### Changes Made
- Added `ErrorBoundary.tsx` component with fallback UI.
- Wrapped the entire application inside `ErrorBoundary` in `_app.tsx`.
- Verified behavior by intentionally triggering a test crash during development.
- Removed test crash code after confirming fallback UI works.

### Screenshots
<img width="1441" height="925" alt="Screenshot 2025-12-09 170352" src="https://github.com/user-attachments/assets/ea879faa-8ae4-4e8f-8685-7c48c6ab40a6" />


### Related Issue
Fixes #4688


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error recovery interface that displays when the application encounters unexpected errors. Users can now reload the page using a dedicated button to restore functionality and continue using the application.

* **Style**
  * Minor formatting adjustments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->