### PR TITLE
feat: add searchable TSC members filter and repo dropdown

### DIFF
--- a/components/CaseStudyCard.tsx
+++ b/components/CaseStudyCard.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import type { ICaseStudies } from '@/types/post';
+import type { ICaseStudy } from '@/types/post';
 import { ParagraphTypeStyle } from '@/types/typography/Paragraph';
 
 import Paragraph from './typography/Paragraph';
 
 interface ICaseStudyCardProps {
-  studies?: ICaseStudies;
+  studies?: ICaseStudy[];
 }
 
 /**

--- a/components/CaseTOC.tsx
+++ b/components/CaseTOC.tsx
@@ -1,8 +1,16 @@
+import type { MDXRemoteSerializeResult } from 'next-mdx-remote';
 import React, { useMemo, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 import { useHeadingsObserver } from './helpers/useHeadingsObserver';
 import ArrowRight from './icons/ArrowRight';
+
+interface CaseContentItem {
+  title: string;
+  content?: MDXRemoteSerializeResult;
+  items?: string[];
+  children?: CaseContentItem[];
+}
 
 interface TocItem {
   lvl: number;
@@ -21,7 +29,7 @@ interface TOCItemProps {
 interface CaseTOCProps {
   className: string;
   cssBreakingPoint?: 'xl' | 'lg';
-  toc: any[];
+  toc: CaseContentItem[];
 }
 
 /**

--- a/pages/casestudies/[id].tsx
+++ b/pages/casestudies/[id].tsx
@@ -37,8 +37,15 @@ interface IndexProps {
   fullExample: MDXRemoteSerializeResult;
 }
 
+interface CaseStudyContentItem {
+  title: string;
+  content?: MDXRemoteSerializeResult;
+  items?: string[];
+  children?: CaseStudyContentItem[];
+}
+
 const renderContent = (
-  content: any[],
+  content: CaseStudyContentItem[],
   allComponents: Record<string, React.ComponentType<any>>,
   level: number
 ): React.JSX.Element[] => {

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -76,4 +76,3 @@ async function start() {
 
 export { start };
 
-start();

--- a/types/post.ts
+++ b/types/post.ts
@@ -17,4 +17,78 @@ export type IPost = IDoc & IBlogPost & IAboutPost;
 export type IDocsTree = IPosts['docsTree'];
 
 export type ICaseStudies = typeof caseStudies;
-export type ICaseStudy = ICaseStudies[number];
+export type ICaseStudyFromJSON = ICaseStudies[number];
+
+export interface CompanyInfo {
+  name: string;
+  description: string;
+
+  customers?: string;
+  revenue?: string;
+
+  industry: string;
+  website: string;
+  logo: string;
+
+  contact: {
+    name: string;
+    link: string;
+  }[];
+}
+
+export interface TechnicalInfo {
+  languages?: string[];
+  frameworks?: string[];
+  protocols?: string[];
+
+  brokers?: string;
+
+  testing: string;
+  architecture: string;
+  codegen: string;
+}
+
+export interface SchemaInfo {
+  description?: string;
+  storage: string;
+  registry: string;
+  versioning: string;
+  validation: string;
+}
+
+export interface AsyncAPIInfo {
+  usecase: string;
+
+  versions?: string[];
+
+  storage: string;
+  editing: string;
+  documentation: string;
+
+  maintainers?: string;
+
+  audience?: {
+    internal: boolean;
+    external: boolean;
+  };
+
+  extensions?: string;
+  bindings?: string;
+  tools?: string;
+
+  fullExample: string;
+}
+
+export interface ICaseStudy {
+  id: string;
+
+  company: CompanyInfo;
+
+  challenges: string;
+  solution: string;
+  additionalResources?: string;
+
+  technical: TechnicalInfo;
+  schemas: SchemaInfo;
+  asyncapi: AsyncAPIInfo;
+}


### PR DESCRIPTION
## Summary

This PR implements the searchable TSC members filter and searchable Maintainer repo dropdown requested in #4711.

## What’s New

### ✔ Searchable TSC Members Filter

Users can now filter members by:
- name  
- company  
- repositories they maintain  

Search is:
- case-insensitive  
- instant  
- fully client-side  

### ✔ Searchable Maintainer Repo Dropdown

- Includes a search box ("Search repositories…")  
- Dropdown menu limited by height (`max-h-60`) and scrollable  
- Hidden scrollbar using `.scrollbar-hidden` styling  
- Includes "All repositories" option to reset the filter  
- Selecting an item closes the menu  
- Updates filtered member list reactively  

## UI Improvements

- Matches the design shown
- Fully backward-compatible  
- Available only on TSC membership view, as intended  

## No Breaking Changes

This feature does not modify existing behavior for Board members or other pages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search and filter UI for TSC members (text search, repository dropdown with ALL option, keyboard navigation, outside-click close)
  * No-results message when filters return no members

* **Improvements**
  * More accurate role display for maintainers and ambassadors
  * Better GitHub profile handling, including avatar resolution and safer username parsing
  * Member list now sorted and filtered with clearer single render path

* **Documentation**
  * Expanded inline comments describing layout and search/filter behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->