### PR TITLE
fix: fixes the failing CI/CD test in .github/workflows/if-nodejs-pr-testing.yml across all platforms

### DIFF
--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -76,4 +76,7 @@ async function start() {
 
 export { start };
 
-start();
+/* istanbul ignore next */
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  start();
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -36,10 +36,16 @@ describe('start function', () => {
   });
 
   test('should throw an error if no finance data is found', async () => {
-    const readdirSyncSpy = jest.spyOn(fs, 'readdirSync').mockReturnValue([]);
+    const originalReaddirSync = fs.readdirSync;
+    const readdirSyncSpy = jest.spyOn(fs, 'readdirSync').mockImplementation((path) => {
+      if (typeof path === 'string' && path.includes('finance')) {
+        return [] as any;
+      }
+      return originalReaddirSync(path as any);
+    });
 
     await expect(start()).rejects.toThrow('No finance data found in the finance directory.');
-    expect(readdirSyncSpy).toHaveBeenCalledTimes(1);
+    expect(readdirSyncSpy).toHaveBeenCalledWith(expect.stringContaining('finance'));
     expect(buildFinanceInfoList).not.toHaveBeenCalled();
 
     readdirSyncSpy.mockRestore();


### PR DESCRIPTION

Problem: 

The test start function › should throw an error if no finance data is found was failing on macOS (but passing on Ubuntu) in CI. The test expected fs.readdirSync to be called once, but it was called twice.
Root cause: scripts/index.ts was calling start() at module load time . When Jest imported the module, start() ran during import, then again when the test called it, causing the double call.

Solution: (Fixes the failing CI/CD test in .github/workflows/if-nodejs-pr-testing.yml across all platforms)

- Added a conditional execution guard in scripts/index.ts to only run start() when the script is executed directly, matching the pattern used by other build scripts (build-meetings.ts, build-tools.ts, etc.). This prevents module-level execution during tests.

- Updated the test to verify behavior (that the finance directory is checked) rather than call count, and to use selective mocking so other readdirSync calls aren’t affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Prevents automatic execution when the module is imported, ensuring it only runs when invoked directly.
  * Refines tests to more precisely validate finance-specific data handling paths and assertions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->