### PR TITLE
feat: replace bitly urls with netlify redirect

### DIFF
--- a/components/GeneratorInstallation.tsx
+++ b/components/GeneratorInstallation.tsx
@@ -24,7 +24,7 @@ export default function GeneratorInstallation() {
   const [template, setTemplate] = useState<string>('@asyncapi/html-template@3.0.0');
   // By default we will have output folder flag so its set here.
   const [params, setParams] = useState<string>('-o example --use-new-generator');
-  const [specPath, setSpecPath] = useState<string>('https://bit.ly/asyncapi');
+  const [specPath, setSpecPath] = useState<string>('https://asyncapi.com/s/asyncapiv2');
 
   const generatorflags = generatorflagList as GeneratorFlags;
 

--- a/config/generator-flags.json
+++ b/config/generator-flags.json
@@ -1,15 +1,15 @@
 {
     "@asyncapi/html-template@3.0.0": {
         "flag": "-o example --use-new-generator",
-        "specPath" : "https://bit.ly/asyncapi"
+        "specPath" : "https://asyncapi.com/s/asyncapiv2"
     },
     "@asyncapi/markdown-template": {
         "flag": "-o example",
-        "specPath" : "https://bit.ly/asyncapi"
+        "specPath" : "https://asyncapi.com/s/asyncapiv2"
     },
     "@asyncapi/nodejs-template": {
         "flag": "-p server=production -o example",
-        "specPath" : "https://bit.ly/asyncapi"
+        "specPath" : "https://asyncapi.com/s/asyncapiv2"
     },
     "@asyncapi/nodejs-ws-template": {
         "flag": "-p server=localhost -o example",
@@ -17,14 +17,14 @@
     },
     "@asyncapi/java-spring-cloud-stream-template": {
         "flag": "-o example",
-        "specPath" : "https://bit.ly/asyncapi"
+        "specPath" : "https://asyncapi.com/s/asyncapiv2"
     },
     "@asyncapi/java-spring-template": {
         "flag": "-o example",
-        "specPath" : "https://bit.ly/asyncapi"
+        "specPath" : "https://asyncapi.com/s/asyncapiv2"
     },
     "@asyncapi/python-paho-template": {
         "flag": "-o example",
-        "specPath" : "https://bit.ly/asyncapi"
+        "specPath" : "https://asyncapi.com/s/asyncapiv2"
     }
 }

--- a/markdown/blog/february-2021-at-asyncapi.md
+++ b/markdown/blog/february-2021-at-asyncapi.md
@@ -36,7 +36,7 @@ We had some significant traffic in the area of code generation templates in Febr
 [Emiliano Zublena](https://github.com/emilianozublena) joined the AsyncAPI community big time by starting with donating [a new template for PHP](https://github.com/asyncapi/asyncapi-php-template). It is not yet released under **@asyncapi** scope on npm, but you can already play with it by using the AsyncAPI Generator with a direct GitHub link like:
 
 ```bash
-ag https://bit.ly/asyncapi https://github.com/asyncapi/asyncapi-php-template -o output`
+ag https://asyncapi.com/s/asyncapiv2 https://github.com/asyncapi/asyncapi-php-template -o output`
 ```
 
 ### Go
@@ -44,7 +44,7 @@ ag https://bit.ly/asyncapi https://github.com/asyncapi/asyncapi-php-template -o 
 We merged the initial pull request to the [Go template](https://github.com/asyncapi/go-template). The initial contributor was not able to continue working on the template, but the foundation was there. [Emiliano Zublena](https://github.com/emilianozublena) and [Takumi Sueda](https://github.com/puhitaku) will try to help to drive forward template development. This template is not yet released as we need to get some feedback from the community first. Give it a try with:
 
 ```bash
-ag https://bit.ly/asyncapi https://github.com/asyncapi/go-template -o output
+ag https://asyncapi.com/s/asyncapiv2 https://github.com/asyncapi/go-template -o output
 ```
 Let us know what you think in the GitHub issues section. Thank you, [Jacob Poston](https://github.com/jposton96a) for your initial hard work on the template!
 
@@ -154,7 +154,7 @@ We are very noisy :sweat_smile:
   EOF
 
   # 3, Generate Markdown file that includes the frontmatter
-  ag https://bit.ly/asyncapi @asyncapi/markdown-template -o output -p frontMatter=ssg.yml
+  ag https://asyncapi.com/s/asyncapiv2 @asyncapi/markdown-template -o output -p frontMatter=ssg.yml
 
   # 4. Check out the output
   cat output/asyncapi.md

--- a/markdown/docs/tools/generator/usage.md
+++ b/markdown/docs/tools/generator/usage.md
@@ -45,7 +45,7 @@ asyncapi generate fromTemplate asyncapi.yaml @asyncapi/html-template@3.0.0 --use
 
 **Generating from a URL:**
 ```bash
-asyncapi generate fromTemplate https://bit.ly/asyncapi @asyncapi/html-template@3.0.0 --use-new-generator
+asyncapi generate fromTemplate https://asyncapi.com/s/asyncapiv2 @asyncapi/html-template@3.0.0 --use-new-generator
 ```
 
 **Specify where to put the result:**

--- a/public/_redirects
+++ b/public/_redirects
@@ -70,3 +70,6 @@ https://www.asyncapi.io/* https://www.asyncapi.com/:splat 301!
 # Additional redirection
 /community/meetings /community/events 301!
 /cheatsheet https://github.com/asyncapi/website/tree/master/cheatsheet 302!
+
+# Short URLs
+/s/asyncapiv2 https://raw.githubusercontent.com/asyncapi/asyncapi/2.0.0/examples/2.0.0/streetlights.yml 301!


### PR DESCRIPTION
This PR replaces all bit.ly short URLs with /s path, using Netlify’s _redirects functionality. All occurrences across the codebase have been updated accordingly.

part of https://github.com/asyncapi/website/issues/3005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated generator usage examples, blog posts, and documentation with new specification URL references.

* **Chores**
  * Updated template configurations and registered new short URL redirects for specification access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->