### PR TITLE
fix:  prevent GitHub button overflow with progressive enhancement

### DIFF
--- a/components/buttons/Button.tsx
+++ b/components/buttons/Button.tsx
@@ -25,6 +25,9 @@ type IButtonProps = {
   /** The class name to be applied to the button's text. */
   textClassName?: string;
 
+  /** The class name to be applied to the text span element (for visibility/display). */
+  textSpanClassName?: string;
+
   /** The icon to be displayed on the button. */
   icon?: React.ReactNode;
 
@@ -59,6 +62,7 @@ export default function Button({
   className = '',
   bgClassName = twMerge('bg-primary-500 hover:bg-primary-400'),
   textClassName = twMerge('text-white'),
+  textSpanClassName = '',
   buttonSize,
   ...props
 }: IButtonProps): React.ReactElement {
@@ -76,13 +80,20 @@ export default function Button({
         data-testid='Button-main'
       >
         {icon && iconPosition === ButtonIconPosition.LEFT && (
-          <span className='mr-2 inline-block' data-testid='Button-icon-left'>
+          <span className='inline-block' data-testid='Button-icon-left'>
             {icon}
           </span>
         )}
-        <span className='inline-block'>{text}</span>
+        <span
+          className={`inline-block ${icon && iconPosition === ButtonIconPosition.LEFT ? 'ml-2' : ''} ${textSpanClassName || ''}`}
+        >
+          {text}
+        </span>
         {icon && iconPosition === ButtonIconPosition.RIGHT && (
-          <span className='ml-2 inline-block' data-testid='Button-icon-right'>
+          <span
+            className={`inline-block ${textSpanClassName?.includes('hidden') ? '' : 'ml-2'}`}
+            data-testid='Button-icon-right'
+          >
             {icon}
           </span>
         )}
@@ -98,9 +109,15 @@ export default function Button({
       className={buttonSize === ButtonSize.SMALL ? smallButtonClasses : classNames}
       data-testid='Button-link'
     >
-      {icon && iconPosition === ButtonIconPosition.LEFT && <span className='mr-2 inline-block'>{icon}</span>}
-      <span className='inline-block'>{text}</span>
-      {icon && iconPosition === ButtonIconPosition.RIGHT && <span className='ml-2 inline-block'>{icon}</span>}
+      {icon && iconPosition === ButtonIconPosition.LEFT && <span className='inline-block'>{icon}</span>}
+      <span
+        className={`inline-block ${icon && iconPosition === ButtonIconPosition.LEFT ? 'ml-2' : ''} ${textSpanClassName || ''}`}
+      >
+        {text}
+      </span>
+      {icon && iconPosition === ButtonIconPosition.RIGHT && (
+        <span className={`inline-block ${textSpanClassName?.includes('hidden') ? '' : 'ml-2'}`}>{icon}</span>
+      )}
     </Link>
   );
 }

--- a/components/buttons/GithubButton.tsx
+++ b/components/buttons/GithubButton.tsx
@@ -40,6 +40,7 @@ export default function GithubButton({
       data-testid='Github-button'
       bgClassName='bg-gray-800 hover:bg-gray-700'
       buttonSize={inNav ? ButtonSize.SMALL : ButtonSize.DEFAULT}
+      textSpanClassName={inNav ? 'hidden xl:inline' : ''}
     />
   );
 }

--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -176,7 +176,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
         </div>
 
         <nav
-          className='hidden w-full space-x-4 lg:flex lg:items-center lg:justify-end xl:space-x-8'
+          className='hidden w-full space-x-2 lg:flex lg:items-center lg:justify-end lg:space-x-4 xl:space-x-8'
           data-testid='Navbar-main'
         >
           <div className='relative' onMouseLeave={() => showMenu(null)} ref={learningRef}>
@@ -216,9 +216,9 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
             <NavItem href={item.href} key={index} text={item.text} target={item.target} className={item.className} />
           ))}
 
-          <div className='justify-content flex flex-row items-center'>
+          <div className='justify-content flex flex-row flex-nowrap items-center shrink-0'>
             <SearchButton
-              className='mr-2 flex items-center space-x-2 rounded-md p-2 text-left text-gray-400 transition duration-150 ease-in-out hover:bg-gray-100 hover:text-gray-500 focus:bg-gray-100 focus:text-gray-500 focus:outline-none'
+              className='mr-2 flex shrink-0 items-center space-x-2 rounded-md p-2 text-left text-gray-400 transition duration-150 ease-in-out hover:bg-gray-100 hover:text-gray-500 focus:bg-gray-100 focus:text-gray-500 focus:outline-none'
               aria-label='Open Search'
             >
               <IconLoupe />
@@ -230,14 +230,14 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
               onChange={(value) => {
                 changeLanguage(value.toLowerCase(), true);
               }}
-              className=''
+              className='shrink-0'
               selected={i18n.language ? i18n.language : 'en'}
             />
 
             <GithubButton
               text='Star on GitHub'
               href='https://github.com/asyncapi/spec'
-              className='ml-2 py-2'
+              className='ml-2 shrink-0 py-2'
               inNav={true}
             />
           </div>


### PR DESCRIPTION
**Description**

- Fixed navbar overflow issue where GitHub button was wrapping and breaking layout at mid-size screens (around 1032px width)
- Implemented progressive enhancement approach to prevent wrapping:
  - GitHub button text is hidden at `lg` breakpoint (1024px-1279px), showing icon only
  - GitHub button text is visible at `xl` breakpoint (1280px+) with proper spacing
  - Mobile menu continues to work correctly below `lg` breakpoint (1024px)

**Related issue(s)**
Fixes #4648

**ScreenShots** 
*Before*
<img width="1171" height="327" alt="520453551-9a0d832d-36f8-4758-9b59-bee6456b6725" src="https://github.com/user-attachments/assets/8406c43d-11de-4e83-8e94-c15e7673c2ef" />

*After*
<img width="1112" height="204" alt="image" src="https://github.com/user-attachments/assets/c2ceac59-afd6-44a2-8848-9c977a1e0899" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable text styling options for buttons

* **Style**
  * Improved navigation bar spacing and layout alignment
  * Enhanced button rendering with refined icon and text positioning

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->