### PR TITLE
fix(security): add baseline HTTP security headers via Netlify configu…

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,12 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    X-Frame-Options = "ALLOW-FROM https://www.youtube.com/"
-    Access-Control-Allow-Origin = "*"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=()"
+    Strict-Transport-Security = "max-age=63072000; includeSubDomains;"
+    Content-Security-Policy-Report-Only = "default-src 'self'; frame-ancestors 'none'; script-src 'self' https: 'unsafe-inline' 'unsafe-eval'; style-src 'self' https: 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' https: data:; connect-src 'self' https:;"
+
 
 [build]
   command = "npm run build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(), geolocation=()"
     Strict-Transport-Security = "max-age=63072000; includeSubDomains;"
-    Content-Security-Policy-Report-Only = "default-src 'self'; frame-ancestors 'none'; script-src 'self' https: 'unsafe-inline' 'unsafe-eval'; style-src 'self' https: 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' https: data:; connect-src 'self' https:;"
+    Content-Security-Policy-Report-Only = "default-src 'self'; script-src 'self' https: 'unsafe-inline'; style-src 'self' https: 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data: https:; connect-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
 
 
 [build]

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(), geolocation=()"
     Strict-Transport-Security = "max-age=63072000; includeSubDomains;"
-    Content-Security-Policy-Report-Only = "default-src 'self'; script-src 'self' https: 'unsafe-inline'; style-src 'self' https: 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data: https:; connect-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
+    Content-Security-Policy-Report-Only = "default-src 'self'; script-src 'self' https: 'unsafe-inline'; style-src 'self' https: 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data: https:; connect-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; report-uri /.netlify/functions/csp-report;"
 
 
 [build]

--- a/netlify/functions/csp-report.ts
+++ b/netlify/functions/csp-report.ts
@@ -1,6 +1,16 @@
 import type { Handler } from '@netlify/functions';
 
 export const handler: Handler = async (event) => {
+    // CSP reports are sent via POST
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      headers: {
+      Allow: 'POST',
+    },
+      body: 'Method Not Allowed',
+    };
+  }
   try {
     if (event.body) {
       const report = JSON.parse(event.body);

--- a/netlify/functions/csp-report.ts
+++ b/netlify/functions/csp-report.ts
@@ -1,0 +1,7 @@
+import type { Handler } from '@netlify/functions';
+
+export const handler: Handler = async () => {
+  return {
+    statusCode: 204,
+  };
+};

--- a/netlify/functions/csp-report.ts
+++ b/netlify/functions/csp-report.ts
@@ -1,6 +1,19 @@
 import type { Handler } from '@netlify/functions';
 
-export const handler: Handler = async () => {
+export const handler: Handler = async (event) => {
+  try {
+    if (event.body) {
+      const report = JSON.parse(event.body);
+
+      console.warn('[CSP Violation Report]', {
+        report,
+        timestamp: new Date().toISOString(),
+      });
+    }
+  } catch (error) {
+    console.error('[CSP Report Parse Error]', error);
+  }
+
   return {
     statusCode: 204,
   };


### PR DESCRIPTION
## Description

This PR adds a baseline set of HTTP security headers to improve the security posture of the AsyncAPI website.

### Changes
- Configured standard security headers via `netlify.toml`
- Added `Content-Security-Policy` in **report-only** mode to safely observe violations without breaking the site
- Added HSTS, Referrer Policy, Permissions Policy, and content-type protections

### Notes
- CSP is intentionally added in report-only mode.
- `preload` is intentionally omitted from HSTS and can be considered in a follow-up PR.

Fixes #4724 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated site security header configuration: removed legacy headers and replaced them with a stronger set of security-focused headers.

* **New Features**
  * Enforced stricter content and transport security with reporting enabled to help detect and mitigate policy violations.
  * Added a lightweight endpoint to receive Content Security Policy violation reports and acknowledge them without returning content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->