### PR TITLE
docs(community): add content to Where to Contribute page

### DIFF
--- a/markdown/docs/community/000-onboarding/where-to-contribute.md
+++ b/markdown/docs/community/000-onboarding/where-to-contribute.md
@@ -20,8 +20,9 @@ Examples of documentation contributions:
 - Updating outdated content
 
 Relevant repositories:
-- https://github.com/asyncapi/website
-- https://github.com/asyncapi/spec
+- [AsyncAPI Website](https://github.com/asyncapi/website)
+- [AsyncAPI Specification](https://github.com/asyncapi/spec)
+
 
 ---
 
@@ -36,9 +37,10 @@ Common contribution areas include:
 - Core libraries
 
 Relevant repositories:
-- https://github.com/asyncapi/cli
-- https://github.com/asyncapi/generator
-- https://github.com/asyncapi/website
+- [AsyncAPI CLI](https://github.com/asyncapi/cli)
+- [AsyncAPI Generator](https://github.com/asyncapi/generator)
+- [AsyncAPI Website](https://github.com/asyncapi/website)
+
 
 ---
 

--- a/markdown/docs/community/000-onboarding/where-to-contribute.md
+++ b/markdown/docs/community/000-onboarding/where-to-contribute.md
@@ -3,6 +3,75 @@ title: Where to Contribute
 weight: 10
 ---
 
-🚧 This document is under construction.
+### Where to Contribute
 
-Please be patient as we work on it. Thank you. 🫶
+This section helps new contributors understand the different areas where they can contribute to the AsyncAPI project.
+
+AsyncAPI welcomes contributions from people with different skill sets, experience levels, and interests.
+
+### Documentation
+
+You can contribute to documentation by improving clarity and accuracy across guides and references.
+
+Examples of documentation contributions:
+- Fixing typos and grammatical errors
+- Improving explanations and structure
+- Adding examples or diagrams
+- Updating outdated content
+
+Relevant repositories:
+- https://github.com/asyncapi/website
+- https://github.com/asyncapi/spec
+
+---
+
+### Code
+
+Contributors can work on features, bug fixes, and enhancements across various AsyncAPI projects.
+
+Common contribution areas include:
+- Website frontend
+- CLI tools
+- Generators
+- Core libraries
+
+Relevant repositories:
+- https://github.com/asyncapi/cli
+- https://github.com/asyncapi/generator
+- https://github.com/asyncapi/website
+
+---
+
+### Testing and Quality
+
+Help improve the reliability and stability of AsyncAPI by:
+- Writing or improving tests
+- Identifying and reporting bugs
+- Improving test coverage
+
+---
+
+### Design and User Experience
+
+Design-focused contributions are also valuable and include:
+- Improving UI and UX
+- Creating diagrams or visual assets
+- Enhancing accessibility
+
+---
+
+### Community and Support
+
+You can also contribute without writing code by:
+- Helping contributors in Slack and GitHub Discussions
+- Reviewing pull requests
+- Improving onboarding and contributor resources
+
+---
+
+### How to Get Started
+
+To begin contributing:
+- Look for issues labeled `good first issue` or `help wanted`
+- Start with small documentation updates or minor bug fixes
+- Join the AsyncAPI Slack workspace to ask questions and get guidance


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

Closes #4774

This PR adds content to the "Where to Contribute" page in the
community onboarding section to help new contributors understand
different ways they can contribute to the AsyncAPI project.

<img width="1559" height="877" alt="{56AD5200-66A5-456F-87FB-69780CF1A573}" src="https://github.com/user-attachments/assets/0871945b-ccec-4ee1-a866-5665407a6df4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced the placeholder onboarding page with a comprehensive "Where to Contribute" guide. Adds detailed sections for Documentation, Code, Testing & Quality, Design & UX, and Community & Support, with example contribution ideas, pointers to relevant repositories, and clear getting-started guidance. Sections are organized for easy navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->