### PR TITLE
fix: "Become an Ambassador Now" button in bottom banner links to 404

### DIFF
--- a/pages/community/ambassadors/index.tsx
+++ b/pages/community/ambassadors/index.tsx
@@ -205,7 +205,7 @@ export default function Index() {
                 <Button
                   className='mt-5 block text-center focus:outline-none md:mt-10 md:inline-block md:w-[48%]'
                   text='Become an Ambassador now'
-                  href='https://github.com/asyncapi/community/blob/master/AMBASSADOR_ORGANIZATION.md#are-you-interested-in-becoming-an-official-asyncapi-ambassador'
+                  href='https://github.com/asyncapi/community/blob/master/docs/020-governance-and-policies/AMBASSADOR_PROGRAM.md'
                   target='_blank'
                 />
                 <Button


### PR DESCRIPTION
Summary:
Change the href linked to the button "Become an Ambassador Now" in the bottom banner 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "Become an Ambassador now" button destination to point to the correct documentation resource.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->