### PR TITLE
fix: remove deprecated AddThis script and styles

### DIFF
--- a/components/layout/BlogLayout.tsx
+++ b/components/layout/BlogLayout.tsx
@@ -80,31 +80,11 @@ export default function BlogLayout({ post, children }: IBlogLayoutProps) {
           </header>
           <article className='mb-32'>
             <Head title={post.title} description={post.excerpt} image={post.cover} />
-            <HtmlHead>
-              <script
-                type='text/javascript'
-                src='//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-5cb852c7b57ed596'
-                async
-              />
-              <style>{`
-                /* AddThis hack */
-
-                #at4-share {
-                    left: 50%;
-                    margin-left: -500px !important;
-                    position: absolute;
-
-                    &amp;.addthis-animated {
-                      animation-duration: 0s !important;
-                    }
-                }
-
-                #at4-scc {
-                    display: none !important;
-                }
-              `}</style>
-              {post.canonical && <link rel='canonical' href={post.canonical} />}
-            </HtmlHead>
+            {post.canonical && (
+              <HtmlHead>
+                <link rel='canonical' href={post.canonical} />
+              </HtmlHead>
+            )}
             <img src={post.cover} alt={post.coverCaption} title={post.coverCaption} className='my-6 w-full' />
             {children}
           </article>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -23,11 +23,6 @@ li>p {
   display: inline;
 }
 
-.atss {
-  /* AddThis plugin */
-  z-index: 10 !important;
-}
-
 abbr[title] {
   text-decoration: none;
 }


### PR DESCRIPTION
AddThis social sharing service was terminated by Oracle on May 31, 2023. The script (//s7.addthis.com/js/300/addthis_widget.js) is completely unreachable, causing failed network requests on every blog page load.

Changes:
- Remove AddThis script from BlogLayout.tsx
- Remove AddThis CSS hack styles from BlogLayout.tsx
- Remove .atss class from globals.css
- Preserve canonical link functionality (now conditionally rendered)

Fixes #4758


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unnecessary third-party script injections from blog posts.
  * Optimized stylesheet by removing unused styling rules.
  * Improved canonical link handling to render conditionally based on availability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->