### PR TITLE
fix: resolve react-hooks/exhaustive-deps warnings (#4789)

### DIFF
--- a/components/campaigns/AnnouncementHero.tsx
+++ b/components/campaigns/AnnouncementHero.tsx
@@ -21,7 +21,7 @@ interface IAnnouncementHeroProps {
 export default function AnnouncementHero({ className = '', small = false }: IAnnouncementHeroProps) {
   const [activeIndex, setActiveIndex] = useState(0);
 
-  const visibleBanners = useMemo(() => banners.filter((banner) => shouldShowBanner(banner.cfpDeadline)), [banners]);
+  const visibleBanners = useMemo(() => banners.filter((banner) => shouldShowBanner(banner.cfpDeadline)), []);
   const numberOfVisibleBanners = visibleBanners.length;
 
   const goToPrevious = () => {

--- a/components/dashboard/table/Filters.tsx
+++ b/components/dashboard/table/Filters.tsx
@@ -39,7 +39,7 @@ function useOutsideAlerter(ref: RefObject<any>, setOpen: (open: boolean) => void
       // Unbind the event listener on clean up
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [ref]);
+  }, [ref, setOpen]);
 }
 
 /**

--- a/components/navigation/DocsNav.tsx
+++ b/components/navigation/DocsNav.tsx
@@ -76,7 +76,7 @@ export default function DocsNav({ item, active, onClick = () => {} }: DocsNavPro
 
   useEffect(() => {
     setOpenSubCategory(active.startsWith(item.item.slug));
-  }, [active]);
+  }, [active, item.item.slug]);
 
   return (
     <li className='mb-4' key={item.item.title} data-testid='DocsNav-item'>

--- a/components/tools/ToolsCard.tsx
+++ b/components/tools/ToolsCard.tsx
@@ -32,7 +32,8 @@ export default function ToolsCard({ toolData }: ToolsCardProp) {
     if (descriptionRef.current) {
       setIsTruncated(descriptionRef.current?.scrollHeight! > descriptionRef.current?.clientHeight!);
     }
-  }, [descriptionRef.current]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Check truncation on mount after ref is attached
+  }, []);
 
   let onGit = false;
 

--- a/components/tools/ToolsDashboard.tsx
+++ b/components/tools/ToolsDashboard.tsx
@@ -155,14 +155,15 @@ export default function ToolsDashboard() {
 
     if (hash) {
       const elementID = decodeURIComponent(hash.slice(1));
-      const element = toolsList[elementID]?.elementRef!;
+      const element = toolsList[elementID]?.elementRef;
 
-      if (element.current) {
+      if (element?.current) {
         document.documentElement.style.scrollPaddingTop = '6rem';
         element.current.scrollIntoView({ behavior: 'smooth' });
         document.documentElement.style.scrollPaddingTop = '0';
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Intentionally run only on mount to scroll to hash once
   }, []);
   // Function to update the list of tools according to the current filters applied
   const clearFilters = () => {


### PR DESCRIPTION
Fixes #4789
This PR resolves all 8 `react-hooks/exhaustive-deps` warnings across 7 files.

`components/AlgoliaSearch.tsx`
`components/campaigns/AnnouncementHero.tsx`
`components/dashboard/table/Filters.tsx`
`components/navigation/DocsNav.tsx`
`components/navigation/Filter.tsx`
`components/tools/ToolsCard.tsx`
`components/tools/ToolsDashboard.tsx`
<img width="532" height="191" alt="Screenshot 2025-12-29 at 8 01 16 PM" src="https://github.com/user-attachments/assets/676ff701-15f7-4955-8a0b-8d77d44a03aa" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer handling of missing element references when auto-scrolling, reducing crashes.

* **Refactor**
  * Optimized update timing for announcement banners, navigation, and tools components to reduce unnecessary re-checks and improve mount-time performance.
  * Adjusted truncation and outside-click handling to rely on stable effect triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->