### PR TITLE
fix: updated broken slack link across the site

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -48,7 +48,7 @@ Tensions can occur between community members even when they are trying their bes
 
 When an incident does occur, it is important to report it promptly. To report a possible violation, here are a few simple ways to do it:  
 
-- Join our [AsyncAPI Slack](https://asyncapi.com/slack-invite) and share your report in the `#coc` channel.  
+- Join our [AsyncAPI Slack](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA) and share your report in the `#coc` channel.  
 - Reach out directly to any member of the [Code of Conduct Committee](https://github.com/orgs/asyncapi/teams/code_of_conduct).
 - Or, if you’d prefer, just send us an email at **conduct@asyncapi.com**.
 

--- a/components/dashboard/table/Table.tsx
+++ b/components/dashboard/table/Table.tsx
@@ -33,7 +33,7 @@ export default function Table({ title, data, className, listClassName }: TablePr
             <ul className='mt-3 list-disc pl-5 text-sm font-[400]'>
               <li className='mb-2'>
                 Join our{' '}
-                <a href='https://asyncapi.com/slack-invite' className='text-blue-500 underline'>
+                <a href='https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA' className='text-blue-500 underline'>
                   Slack
                 </a>{' '}
                 to seek help.

--- a/components/features/FeatureList.ts
+++ b/components/features/FeatureList.ts
@@ -55,7 +55,7 @@ export const features: Feature[] = [
     links: [
       {
         label: 'Join our Slack',
-        href: 'https://asyncapi.com/slack-invite',
+        href: 'https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA',
         id: 'whyasyncapi-community-slack-link'
       }
     ]

--- a/components/footer/FooterData.ts
+++ b/components/footer/FooterData.ts
@@ -57,7 +57,7 @@ export const socialMediaData: SocialMediaData[] = [
     label: 'YouTube'
   },
   {
-    url: 'https://asyncapi.com/slack-invite',
+    url: 'https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA',
     label: 'Slack'
   },
   {

--- a/components/footer/FooterList.ts
+++ b/components/footer/FooterList.ts
@@ -35,7 +35,7 @@ export const socialMediaLinks: SocialMediaLink[] = [
     icon: IconYoutubeGray({ className: 'h-8 w-8 sm:h-6 sm:w-6' })
   },
   {
-    url: 'https://asyncapi.com/slack-invite',
+    url: 'https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA',
     label: 'Slack',
     icon: IconSlack({ className: 'h-8 w-8 sm:h-6 sm:w-6' })
   },

--- a/components/navigation/communityItems.tsx
+++ b/components/navigation/communityItems.tsx
@@ -29,7 +29,7 @@ const communityItems: CommunityItem[] = [
   {
     icon: IconSlack,
     title: 'Slack Workspace',
-    href: 'https://asyncapi.com/slack-invite',
+    href: 'https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA',
     target: '_blank',
     description: "Need help? Want to share something? Join our Slack workspace. We're nice people :)"
   },

--- a/cypress/fixtures/footerPageData.json
+++ b/cypress/fixtures/footerPageData.json
@@ -14,7 +14,7 @@
     { "href": "https://github.com/asyncapi", "text": "GitHub" },
     { "href": "https://linkedin.com/company/asyncapi", "text": "LinkedIn" },
     { "href": "https://youtube.com/asyncapi", "text": "YouTube" },
-    { "href": "https://asyncapi.com/slack-invite", "text": "Slack" },
+    { "href": "https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA", "text": "Slack" },
     { "href": "https://www.twitch.tv/asyncapi", "text": "Twitch" }
   ],
   "newsLinks": [

--- a/cypress/fixtures/homePageData.json
+++ b/cypress/fixtures/homePageData.json
@@ -29,7 +29,7 @@
     },
     {
       "name": "Join our Slack",
-      "url": "https://asyncapi.com/slack-invite"
+      "url": "https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA"
     },
     {
       "name": "Read more about Open Governance",

--- a/markdown/blog/2024-gsoc-wrap.md
+++ b/markdown/blog/2024-gsoc-wrap.md
@@ -165,7 +165,7 @@ Finally, a wonderful shout to [Stephanie Taylor](https://www.linkedin.com/in/ste
 
 ## Closing Remark 
 
-If you’re considering joining GSoC with AsyncAPI next year, we encourage you to hop into our [Slack community](https://asyncapi.com/slack-invite) and say hello in the **#mentorship** channel. We’re always excited to welcome new contributors and mentors into our growing family.
+If you’re considering joining GSoC with AsyncAPI next year, we encourage you to hop into our [Slack community](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA) and say hello in the **#mentorship** channel. We’re always excited to welcome new contributors and mentors into our growing family.
 
 We’re already looking forward to next year’s program and are committed to using this year’s lessons to make the experience even better.
 

--- a/markdown/blog/hacktoberfest-2022.md
+++ b/markdown/blog/hacktoberfest-2022.md
@@ -126,4 +126,4 @@ Thank you so much to everyone who took part! We welcomed new contributors but we
 
 ## Hacktoberfest is over, but Open Source is for life
 
-Are you interested in getting involved with AsyncAPI? You can always find us on [AsyncAPI GitHub](https://github.com/asyncapi) or our [AsyncAPI Slack](https://asyncapi.com/slack-invite) workspace. Can't wait to meet you and merge your PR!
+Are you interested in getting involved with AsyncAPI? You can always find us on [AsyncAPI GitHub](https://github.com/asyncapi) or our [AsyncAPI Slack](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA) workspace. Can't wait to meet you and merge your PR!

--- a/markdown/blog/new-asyncapi-tools-page.md
+++ b/markdown/blog/new-asyncapi-tools-page.md
@@ -130,6 +130,6 @@ I completed this project during the 2022 AsyncAPI Mentorship program, mentored b
 - [feat: added new /tools page](https://github.com/asyncapi/website/pull/940)
 - [feat: manual tools added to the Tools Dashboard](https://github.com/asyncapi/website/pull/1191)
 
-You are welcome to review my work in the program and I will love to get your feedback on this. You can contact me via [my email](mailto:akshatnema.official@gmail.com) or DM me in [AsyncAPI Slack](https://asyncapi.com/slack-invite). Thank you to AsyncAPI and its community members for providing me with this opportunity and I'll be looking for more such activities to contribute to the organization. Also, we are close to announcing the next AsyncAPI Mentorship Program in the year 2023, so stay tuned with us on [AsyncAPI Slack](https://asyncapi.com/slack-invite).
+You are welcome to review my work in the program and I will love to get your feedback on this. You can contact me via [my email](mailto:akshatnema.official@gmail.com) or DM me in [AsyncAPI Slack](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA). Thank you to AsyncAPI and its community members for providing me with this opportunity and I'll be looking for more such activities to contribute to the organization. Also, we are close to announcing the next AsyncAPI Mentorship Program in the year 2023, so stay tuned with us on [AsyncAPI Slack](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA).
 
 > Photo by DEWALT hand tools: https://www.dewalt.com/products/hand-tools

--- a/markdown/docs/community/000-onboarding/docs-onboarding-checklist.md
+++ b/markdown/docs/community/000-onboarding/docs-onboarding-checklist.md
@@ -10,7 +10,7 @@ Complete in order the following onboarding tasks:
 
 - [ ] Read the [AsyncAPI Code of Conduct](https://github.com/asyncapi/.github/blob/master/CODE_OF_CONDUCT.md).
 - [ ] Read the [AsyncAPI Slack etiquette](../060-meetings-and-communication/slack-etiquette). 
-- [ ] Join [the AsyncAPI Slack workspace](https://asyncapi.com/slack-invite).
+- [ ] Join [the AsyncAPI Slack workspace](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA).
 - [ ] Add the AsyncAPI calendar found in [the AsyncAPI events page](https://www.asyncapi.com/community/events).
 - [ ] Read the list of [technical writer contributor responsibilities](../010-contribution-guidelines/technical-writer-contributor-responsibilities).
 - [ ] Read and familiarize yourself with the [prerequisite knowledge topics](../010-contribution-guidelines/prerequisite-knowledge).
@@ -18,5 +18,5 @@ Complete in order the following onboarding tasks:
 - [ ] Read all docs under the following content buckets: `Concepts`, `Tutorials`, `Reference`. (Take the time to go through each tutorial.)
 - [ ] Set up your local environment following our instructions for the [AsyncAPI git workflow](../010-contribution-guidelines/git-workflow).
 - [ ] Introduce yourself in AsyncAPI Slack in the `#01_introductions` channel and the `#13_docs` channel. Ask docs-related questions in #13_docs.
-- [ ] Request a good first docs issue in the [`#13_docs` Slack channel](https://asyncapi.com/slack-invite).
+- [ ] Request a good first docs issue in the [`#13_docs` Slack channel](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA).
 - [ ] Attend [OPEN docs meetings](https://www.asyncapi.com/community/events) to chat with other maintainers, ask docs questions, and request help on docs blockers. 

--- a/markdown/docs/community/010-contribution-guidelines/Become-maintainer-in-existing-project.md
+++ b/markdown/docs/community/010-contribution-guidelines/Become-maintainer-in-existing-project.md
@@ -18,7 +18,7 @@ We know you are nervous about making your first contribution. In this section, w
 Here's how to select an issue to contribute to:
 * Join existing PR reviews
 * Look for issues with a [**good first issue** label](https://github.com/issues?page=1&q=is%3Aopen+org%3Aasyncapi+sort%3Aupdated-desc+label%3A%22good+first+issue%22)
-* Join the [AsyncAPI Slack community workspace](https://asyncapi.com/slack-invite) and the `#11_how-to-contribute` channel
+* Join the [AsyncAPI Slack community workspace](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA) and the `#11_how-to-contribute` channel
 * Ask maintainers to do a public live stream called **Let's talk about contributing** where they can explain a specific part of the project where you want to contribute.
 
 **Step 2: Open a Pull Request**

--- a/markdown/docs/community/010-contribution-guidelines/contribution-flow.md
+++ b/markdown/docs/community/010-contribution-guidelines/contribution-flow.md
@@ -22,7 +22,7 @@ Contrary to popular belief, **contributions are not limited to code**. At AsyncA
 |  🐛   | Bug Reports          | Report bugs, help reproduce issues, suggest fixes. [Open a bug issue](https://github.com/asyncapi/community/issues/new?assignees=&labels=bug&template=bug_report.md).                                                                                 |
 |  ⚠️   | Tests                | Add or improve tests, increase coverage, verify fixes.                                                                                                                                                                                                |
 |  🎨   | Design               | Propose UI/UX improvements, contribute graphics, review design discussions.                                                                                                                                                                           |
-|  💬   | Answering Questions    | Answer questions on [Slack](https://asyncapi.com/slack-invite) or [GitHub Issues](https://github.com/asyncapi/community/issues), help new contributors, provide mentorship.                                                                                                                      |
+|  💬   | Answering Questions    | Answer questions on [Slack](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA) or [GitHub Issues](https://github.com/asyncapi/community/issues), help new contributors, provide mentorship.                                                                                                                      |
 |  📝  | Blogposts             | Write blog posts for [AsyncAPI's blog](https://www.asyncapi.com/blog).                                                                                                   |
 |  📆 | Project Management   | Triage issues and organize tasks and workflows, help with releases.                                                                                                                                                                          |
 | 🌍  | Translation          | Translate documentation or resources into other languages.                                                                                                                                                                                            |
@@ -38,9 +38,9 @@ Contrary to popular belief, **contributions are not limited to code**. At AsyncA
 |  💡 | Examples          | Provide links to examples of AsyncAPI being used in projects |
 
 ### Before You Start Contributing
-- If you are joining AsyncAPI through [Slack](https://asyncapi.com/slack-invite) or an event, take your time to explore the [AsyncAPI website](https://www.asyncapi.com/).  
+- If you are joining AsyncAPI through [Slack](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA) or an event, take your time to explore the [AsyncAPI website](https://www.asyncapi.com/).  
 - Read our [Code of Conduct](https://github.com/asyncapi/.github/blob/master/CODE_OF_CONDUCT.md).  
-- [Attend meetings](https://www.asyncapi.com/community/events) and engage in discussions in the [`#11_contributing` Slack channel](https://asyncapi.com/slack-invite).
+- [Attend meetings](https://www.asyncapi.com/community/events) and engage in discussions in the [`#11_contributing` Slack channel](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA).
 - Read the [documentation](https://www.asyncapi.com/docs) to learn more about AsyncAPI.
 
 ### Before Making a Contribution

--- a/markdown/docs/community/010-contribution-guidelines/recognize-contributors.md
+++ b/markdown/docs/community/010-contribution-guidelines/recognize-contributors.md
@@ -11,7 +11,7 @@ There should always be a **Contributors** section in the readme, like [this one]
 
 Remember, not only code matters! You can contribute to AsyncAPI in different ways. You can:
 - Report a well-written issue that explains a bug or a feature that later is fixed/implemented.
-- Share with us feedback on [slack](https://asyncapi.com/slack-invite) or some other channel. You come up with the idea that we used to do something great with the project.
+- Share with us feedback on [slack](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA) or some other channel. You come up with the idea that we used to do something great with the project.
 - Improve documentation.
 - Help with a review of pull requests. You are a language expert and can review docs or an expert in a specific programming language. As a result, you can review pull requests for a template written for a particular language.
 - Write a blog post on the AsyncAPI blog.
@@ -19,7 +19,7 @@ Remember, not only code matters! You can contribute to AsyncAPI in different way
 
 You can help us out in many different ways. Just check out [this](https://allcontributors.org/docs/en/emoji-key) list of possible contributions. All of this is a contribution!
 
-> We apologize in advance if we failed in recognizing your work. Feel free to contact us on [slack](https://asyncapi.com/slack-invite), and we will fix it immediately, or talk to All Contributors bot directly.
+> We apologize in advance if we failed in recognizing your work. Feel free to contact us on [slack](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA), and we will fix it immediately, or talk to All Contributors bot directly.
 
 ## All Contributors cheat sheet
 

--- a/markdown/docs/community/010-contribution-guidelines/recognizing-contributors-and-appointing-new-maintainers.md
+++ b/markdown/docs/community/010-contribution-guidelines/recognizing-contributors-and-appointing-new-maintainers.md
@@ -31,7 +31,7 @@ To recognize someone:
 
 2. Use the appropriate contribution types (like `code`, `doc`, `review`, `ideas`, etc.).
 
-If you notice a contribution that wasn't acknowledged, speak up in [Slack](https://asyncapi.com/slack-invite) or [GitHub](https://github.com/asyncapi). We'll gladly fix it.
+If you notice a contribution that wasn't acknowledged, speak up in [Slack](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA) or [GitHub](https://github.com/asyncapi). We'll gladly fix it.
 
 ## Appointing new maintainers
 

--- a/markdown/docs/community/040-guides/add-new-asyncapi-tool-to-website.md
+++ b/markdown/docs/community/040-guides/add-new-asyncapi-tool-to-website.md
@@ -12,7 +12,7 @@ Learn how to add your tool to the AsyncAPI website using the `.asyncapi-tool` fi
 
 ## AsyncAPI tool file
 
-The [`.asyncapi-tool` file](https://github.com/asyncapi/website/blob/master/scripts/tools/tools-schema.json) requires a specific schema to describe the type and details of your AsyncAPI tool; this file automatically adds your tool to our website's [Tools Dashboard](https://www.asyncapi.com/tools) within a week. Every Monday, we run our workflow to add new tools or update existing tools in our website and thus, notifies us regarding the wrong format of the file used somewhere in Github using Slack notifications. You can even ask the maintainers to manually trigger workflow by [Creating a Github issue](https://github.com/asyncapi/website/issues/new/choose) or contact us via [AsyncAPI Slack](https://asyncapi.com/slack-invite).
+The [`.asyncapi-tool` file](https://github.com/asyncapi/website/blob/master/scripts/tools/tools-schema.json) requires a specific schema to describe the type and details of your AsyncAPI tool; this file automatically adds your tool to our website's [Tools Dashboard](https://www.asyncapi.com/tools) within a week. Every Monday, we run our workflow to add new tools or update existing tools in our website and thus, notifies us regarding the wrong format of the file used somewhere in Github using Slack notifications. You can even ask the maintainers to manually trigger workflow by [Creating a Github issue](https://github.com/asyncapi/website/issues/new/choose) or contact us via [AsyncAPI Slack](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA).
 
 You must create and maintain your `.asyncapi-tool` file in your tool's repository, as it doesn't require AsyncAPI approval. There is no restriction on the directory in which the file has to be created. In case, you need to create 2 or more `.asyncapi-tool` files in same repository, you can do the same, just make sure you provide correct `repoUrl` for each of them. Same case applies for monorepo as well.
 
@@ -119,7 +119,7 @@ Here's what a sample JSON object for an AsyncAPI tool should look like after it 
 }
 ```
 
-> If your tool's information isn't showing up correctly in this file, please [create a new AsyncAPI GitHub issue](https://github.com/asyncapi/website/issues/new/choose) or contact us via [AsyncAPI Slack](https://asyncapi.com/slack-invite).
+> If your tool's information isn't showing up correctly in this file, please [create a new AsyncAPI GitHub issue](https://github.com/asyncapi/website/issues/new/choose) or contact us via [AsyncAPI Slack](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA).
 
 ## Adding New Category
 

--- a/markdown/docs/community/050-mentorship-program/asyncapi-mentorship-README.md
+++ b/markdown/docs/community/050-mentorship-program/asyncapi-mentorship-README.md
@@ -43,7 +43,7 @@ Our mentorship programs demonstrate strong impact with improving retention rates
 - **Thulisile Sibanda** ([@thulieblack](https://github.com/thulieblack)): [LinkedIn](https://www.linkedin.com/in/v-thulisile-sibanda/)
 
 ### Contact
-- **Slack**: Join our [AsyncAPI Slack workspace](https://asyncapi.com/slack-invite) and visit `#09_mentorships`
+- **Slack**: Join our [AsyncAPI Slack workspace](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA) and visit `#09_mentorships`
 - **GitHub Discussions**: [Community Discussions](https://github.com/asyncapi/community/discussions)
 
 ## Key Definitions

--- a/markdown/docs/community/050-mentorship-program/index.md
+++ b/markdown/docs/community/050-mentorship-program/index.md
@@ -11,7 +11,7 @@ AsyncAPI offers diverse mentorship opportunities for students, developers, and t
 
 Need assistance with mentorship programs? Connect with us:
 
-- **Slack**: Join our [AsyncAPI Slack workspace](https://asyncapi.com/slack-invite) and visit the `#mentorship` channel
+- **Slack**: Join our [AsyncAPI Slack workspace](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA) and visit the `#mentorship` channel
 - **GitHub Discussions**: Post questions on our [Discussions board](https://github.com/asyncapi/community/discussions)
 
 > **Note**: Please use public channels rather than direct messages when possible. This helps maintainers manage communications effectively and allows others to benefit from the discussion.

--- a/markdown/docs/community/050-mentorship-program/summerofcode-README.md
+++ b/markdown/docs/community/050-mentorship-program/summerofcode-README.md
@@ -28,7 +28,7 @@ TL;DR: GSoC exclusively focuses on coding projects. While initiatives like docum
   Carefully read through the guide to familiarize yourself with the initiative. The guide provides a comprehensive program overview and offers valuable advice on starting communication, proposal writing, and beginning your work. Additionally, [refer to Google's FAQ](https://developers.google.com/open-source/gsoc/faq) for more information.
 
 - **Get familiar with the AsyncAPI project.**
-  Please be sure to familiarize yourself with the AsyncAPI initiative and its mission and [get involved in the community](https://asyncapi.com/slack-invite). Explore the [AsyncAPI projects](https://github.com/asyncapi), get an idea of the project of your interest, and explore the source code and organization of the project.
+  Please be sure to familiarize yourself with the AsyncAPI initiative and its mission and [get involved in the community](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA). Explore the [AsyncAPI projects](https://github.com/asyncapi), get an idea of the project of your interest, and explore the source code and organization of the project.
 
 - **Write your project proposal.**
   Visit the [ideas page](./summerofcode-2024-asyncapi-gsoc-ideas-page) to choose a topic that catches your interest. You can also draw inspiration from projects from previous years.

--- a/markdown/docs/community/070-marketing/webinar_series_initiative.md
+++ b/markdown/docs/community/070-marketing/webinar_series_initiative.md
@@ -139,7 +139,7 @@ If you or someone you know would be a great fit, reach out to us!
 
 ## What’s Next?
 
-The AsyncAPI Webinar Series is just getting started! Stay tuned for upcoming sessions, and if you have suggestions for topics or speakers, [we’d love to hear from you](https://asyncapi.com/slack-invite).
+The AsyncAPI Webinar Series is just getting started! Stay tuned for upcoming sessions, and if you have suggestions for topics or speakers, [we’d love to hear from you](https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA).
 
 Want to attend the next session? Follow our updates on LinkedIn, [subscribe to our YouTube page and turn on notifications!](https://www.youtube.com/@AsyncAPI) Interested in speaking? Reach out to us, we’d love to have you!
 

--- a/pages/community/index.tsx
+++ b/pages/community/index.tsx
@@ -176,7 +176,7 @@ export default function CommunityIndexPage() {
               actively contribute, collaborate, and mentor others on how to
               build with AsyncAPI."
           btnText='Join AsyncAPI slack'
-          link='https://asyncapi.com/slack-invite'
+          link='https://join.slack.com/t/asyncapi/shared_invite/zt-3m4pmrguv-SUN9Js4BkQHocIH54F59sA'
           className='bg-channelCover'
         />
       </div>


### PR DESCRIPTION
**Description**
This PR updates the broken slack link with new one across the website. 

https://www.loom.com/share/548dceadf7a8445caa0388165fd0485c

**Related issue(s)**
Fixes #4817 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated AsyncAPI Slack community invite links across the site and documentation to use a direct Slack join URL, streamlining the community joining experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->