### PR TITLE
fix: missing image asset canela-quetzalli.webp returns 404

### DIFF
--- a/markdown/blog/google-season-of-docs-2022.md
+++ b/markdown/blog/google-season-of-docs-2022.md
@@ -8,7 +8,7 @@ tags:
 cover: /img/posts/gsod-2022/SeasonofDocs_Logo.webp
 authors:
   - name: Quetzalli Writes
-    photo: /canela-quetzalli.webp
+    photo: /img/avatars/canela-quetzalli.webp
     link: https://www.linkedin.com/in/quetzalli-writes/
     byline: Our proposal? Update Docs Information Architecture
 excerpt: Check out the Docs project proposal we're submitting to GSoD 2022! You won't want to miss out.


### PR DESCRIPTION
**Description**
This PR fixes the 404 missing image asset issue. 

**Related issue(s)**
Fixes #4788 [BUG] Missing image asset canela-quetzalli.webp returns 404 on blog page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the author photo path used in the Google Season of Docs 2022 blog post so the author image displays correctly. No other post content or metadata was changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->