### PR TITLE
fix: remove pointer cursor from non-interactive outer orbit avatars

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -145,9 +145,9 @@ abbr[title] {
   transition: 0.2s;
 }
 
-.orbit > div {
+/* .orbit > div {
   cursor: pointer;
-}
+} */
 
 .orbit > div > img {
   border-radius: 100%;


### PR DESCRIPTION
## What this PR does
Removes the pointer cursor from avatars on the outermost orbit of the Community page when they are not interactive, improving visual consistency.

## Related Issue
Closes #4810

## Video demonstrating the fix
https://drive.google.com/file/d/11o7xeXoCyShk74AlrPJuU0z8kTAVlufx/view?usp=sharing
