### PR TITLE
fix: separate navigation and dropdown toggle in mega menu

### DIFF
--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -183,7 +183,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
             <NavItem
               text='Docs'
               href='/docs'
-              onClick={() => showOnClickMenu('learning')}
+              onDropdownClick={() => showOnClickMenu('learning')}
               onMouseEnter={() => showMenu('learning')}
               hasDropdown
             />
@@ -194,7 +194,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
             <NavItem
               text='Tools'
               href='/tools'
-              onClick={() => showOnClickMenu('tooling')}
+              onDropdownClick={() => showOnClickMenu('tooling')}
               onMouseEnter={() => showMenu('tooling')}
               hasDropdown
             />
@@ -205,7 +205,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
             <NavItem
               text='Community'
               href='/community'
-              onClick={() => showOnClickMenu('community')}
+              onDropdownClick={() => showOnClickMenu('community')}
               onMouseEnter={() => showMenu('community')}
               hasDropdown
             />

--- a/components/navigation/NavItem.tsx
+++ b/components/navigation/NavItem.tsx
@@ -10,6 +10,7 @@ interface NavItemProps {
   target?: string;
   onClick?: () => void;
   onMouseEnter?: () => void;
+  onDropdownClick?: () => void;
   hasDropdown?: boolean;
   className?: string;
 }
@@ -21,6 +22,7 @@ interface NavItemProps {
  * @param {string} [props.target='_self'] - The target attribute for the link.
  * @param {Function} [props.onClick] - Event handler for click event.
  * @param {Function} [props.onMouseEnter] - Event handler for mouse enter event.
+ * @param {Function} [props.onDropdownClick] - Event handler for dropdown arrow click.
  * @param {boolean} [props.hasDropdown=false] - Indicates if the navigation item has a dropdown menu.
  * @param {string} [props.className=''] - Additional CSS classes for styling.
  */
@@ -30,6 +32,7 @@ export default function NavItem({
   target = '_self',
   onClick = () => {},
   onMouseEnter = () => {},
+  onDropdownClick,
   hasDropdown = false,
   className = ''
 }: NavItemProps) {
@@ -60,16 +63,31 @@ export default function NavItem({
 
   if (href) {
     return (
-      <Link
-        href={href}
-        {...attrs}
-        className={`${attrs.className} ${router.pathname.startsWith(href) ? 'text-black' : 'text-gray-700'}`}
-        target={target}
-        data-testid='NavItem-Link'
-      >
-        <span>{text}</span>
-        {hasDropdown && <NavItemDropdown />}
-      </Link>
+      <div className='inline-flex items-center' onMouseEnter={onMouseEnter}>
+        <Link
+          href={href}
+          className={`group inline-flex items-center font-body text-base leading-6 font-semibold hover:text-gray-900 focus:outline-none focus:text-gray-900 tracking-heading transition ease-in-out duration-150 ${
+            router.pathname.startsWith(href) ? 'text-black' : 'text-gray-700'
+          } ${className}`}
+          target={target}
+          data-testid='NavItem-Link'
+        >
+          <span>{text}</span>
+        </Link>
+        {hasDropdown && (
+          <button
+            type='button'
+            onClick={(e) => {
+              e.preventDefault();
+              if (onDropdownClick) onDropdownClick();
+            }}
+            className='ml-2 text-gray-700 hover:text-gray-900 focus:outline-none'
+            aria-label='Toggle dropdown'
+          >
+            <NavItemDropdown />
+          </button>
+        )}
+      </div>
     );
   }
 

--- a/components/navigation/NavItem.tsx
+++ b/components/navigation/NavItem.tsx
@@ -66,9 +66,11 @@ export default function NavItem({
       <div className='inline-flex items-center' onMouseEnter={onMouseEnter}>
         <Link
           href={href}
-          className={`group inline-flex items-center font-body text-base leading-6 font-semibold hover:text-gray-900 focus:outline-none focus:text-gray-900 tracking-heading transition ease-in-out duration-150 ${
-            router.pathname.startsWith(href) ? 'text-black' : 'text-gray-700'
-          } ${className}`}
+          className={`group inline-flex items-center font-body text-base leading-6 font-semibold 
+            hover:text-gray-900 focus:outline-none focus:text-gray-900 tracking-heading 
+            transition ease-in-out duration-150 ${
+              router.pathname.startsWith(href) ? 'text-black' : 'text-gray-700'
+            } ${className}`}
           target={target}
           data-testid='NavItem-Link'
         >

--- a/components/navigation/NavItem.tsx
+++ b/components/navigation/NavItem.tsx
@@ -66,11 +66,12 @@ export default function NavItem({
       <div className='inline-flex items-center' onMouseEnter={onMouseEnter}>
         <Link
           href={href}
-          className={`group inline-flex items-center font-body text-base leading-6 font-semibold 
-            hover:text-gray-900 focus:outline-none focus:text-gray-900 tracking-heading 
-            transition ease-in-out duration-150 ${
-              router.pathname.startsWith(href) ? 'text-black' : 'text-gray-700'
-            } ${className}`}
+          onClick={() => {
+            if (onClick) onClick();
+          }}
+          className={`group inline-flex items-center font-body text-base leading-6 font-semibold hover:text-gray-900 focus:outline-none focus:text-gray-900 tracking-heading transition ease-in-out duration-150 ${
+            router.pathname.startsWith(href) ? 'text-black' : 'text-gray-700'
+          } ${className}`}
           target={target}
           data-testid='NavItem-Link'
         >


### PR DESCRIPTION
## Description

This PR fixes the mega menu navigation behavior where clicking the dropdown arrow would navigate to the page instead of toggling the dropdown menu.

## Changes

- Split `NavItem` component to separate text/link navigation from arrow dropdown toggle
- Text/link now navigates directly to the destination page (`/docs`, `/tools`, `/community`)
- Arrow icon triggers the dropdown menu without navigation
- Added `onDropdownClick` prop to `NavItem` for dropdown-specific click handling
- Updated `NavBar` to pass separate handlers for navigation and dropdown toggle

## Motivation

Previously, both the text and arrow icon would navigate to the page, making it difficult for users to access the dropdown menu content. This improvement gives users clear control over their navigation choice.

## Testing

- ✅ Clicking text navigates to the page
- ✅ Clicking arrow toggles dropdown menu
- ✅ Hover behavior still works
- ✅ Mobile menu functionality preserved

Fixes #4807

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation dropdown menus for Docs, Tools, and Community now include dedicated toggle buttons next to their links for clearer, more accessible interaction.
* **Bug Fixes**
  * Click behavior improved to prevent accidental navigation when opening dropdowns while preserving hover-to-open behavior for the menus.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->