### PR TITLE
Fix invalid Slack invite link on Dashboard

### DIFF
--- a/components/dashboard/Header.tsx
+++ b/components/dashboard/Header.tsx
@@ -30,7 +30,8 @@ export default function Header() {
           target='_blank'
         />
         <GithubButton text='View on Github' className='lg:mt-0' />
-        <SlackButton className='lg:mt-0' />
+        <SlackButton className='lg:mt-0'
+          href='https://join.slack.com/t/asyncapi/shared_invite/zt-3mdikt8oy-qBVhDMe23Q54FXE58vzEIA'/>
       </div>
     </div>
   );


### PR DESCRIPTION
Description
Identified that the “Join on Slack” link on the Dashboard was pointing to an invalid/expired invite.
Replaced the broken Slack URL with a valid Slack workspace invite link.
Verified the fix by navigating through Community → Dashboard → Join on Slack.
Ensured the update does not affect other dashboard links or UI components.
Improved contributor onboarding by restoring access to the project’s Slack community.

Related issue(s)
Fixes #4833 

Screenshots:
Before:

https://github.com/user-attachments/assets/9aef8163-fadb-473a-a8ca-bfc05101b6bf




After:
https://github.com/user-attachments/assets/b318c072-c085-4a78-a9b3-5499eb2e317f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit




* **New Features**
  * Slack button in the header now links to the Slack invite URL, enabling users to join the community directly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->