### PR TITLE
fix: fix: replace invalid shortcode with heart emoji

### DIFF
--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -94,7 +94,7 @@ export default function Footer() {
         <div className='justify-between py-8 sm:flex sm:py-12 xl:mt-20' data-testid='Footer-content'>
           <div className='w-full sm:w-2/3'>
             <p className='mb-3 text-left text-base leading-6 text-cool-gray'>
-              Made with <span className='font-mono text-secondary-500'>:love:</span> by the AsyncAPI Initiative.
+              Made with <span className='font-mono text-secondary-500'>❤️</span> by the AsyncAPI Initiative.
             </p>
             <p className='w-full text-left text-sm leading-6 text-cool-gray sm:w-2/3' data-testid='Footer-copyright'>
               Copyright &copy; AsyncAPI Project a Series of LF Projects, LLC. For web site terms of use, trademark


### PR DESCRIPTION


**Description**

The footer was displaying the raw text `:love:` because the shortcode is invalid or not supported in this component.

I have replaced the text `:love:` directly with the Unicode heart emoji (❤️) to ensure it renders correctly.
<img width="840" height="296" alt="Screenshot 2026-01-02 212741" src="https://github.com/user-attachments/assets/234e8770-4c61-4255-9904-4dcc7718febe" />


**Related issue(s)**
#4851 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated footer text to display the heart emoji properly instead of a text placeholder.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->