### PR TITLE
fix(docs): reinitialize TOC on route change

### DIFF
--- a/components/layout/DocsLayout.tsx
+++ b/components/layout/DocsLayout.tsx
@@ -143,6 +143,7 @@ export default function DocsLayout({ post, navItems = {}, children }: IDocsLayou
 
               <div className={`xl:flex ${post.toc && post.toc.length ? 'xl:flex-row-reverse' : ''}`}>
                 <TOC
+                  key = {router.asPath}
                   toc={post.toc}
                   depth={3}
                   className='sticky top-20 mt-4 max-h-screen overflow-y-auto bg-blue-100 p-4 xl:mt-0 xl:w-72 xl:bg-transparent xl:pb-8'


### PR DESCRIPTION

**Description**

Fixes  #4845

- Fixes an issue where the **“On this page” (TOC) active highlight** does not persist correctly when navigating between documentation pages.
- Reinitializes the TOC/ScrollSpy behavior on **route change**, ensuring the correct section is highlighted after navigation.
- Improves consistency and usability of the Docs reading experience.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the Table of Contents did not properly refresh when navigating between different pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->