### PR TITLE
refactor: remove redundant try-catch in extract-tools-github.ts

### DIFF
--- a/scripts/tools/extract-tools-github.ts
+++ b/scripts/tools/extract-tools-github.ts
@@ -19,55 +19,51 @@ dotenv.config();
  * @throws {Error} When the GITHUB_TOKEN environment variable is missing or an error occurs during the fetching process.
  */
 export async function getData(): Promise<ToolsData> {
-  // eslint-disable-next-line no-useless-catch
-  try {
-    if (!process.env.GITHUB_TOKEN) {
-      throw new Error('GITHUB_TOKEN environment variable is required');
-    }
-    const allItems = new Set();
-    let page = 1;
-    let incompleteResult = false;
+  if (!process.env.GITHUB_TOKEN) {
+    throw new Error('GITHUB_TOKEN environment variable is required');
+  }
+  const allItems = new Set();
+  let page = 1;
+  let incompleteResult = false;
 
-    const maxPerPage = 50;
-    const getReqUrl = (PerPage: number, pageNo: number) =>
-      `https://api.github.com/search/code?q=filename:.asyncapi-tool&per_page=${PerPage}&page=${pageNo}`;
-    const headers = {
-      accept: 'application/vnd.github.text-match+json',
-      authorization: `token ${process.env.GITHUB_TOKEN}`
-    };
-    const result = await axios.get(getReqUrl(maxPerPage, page), {
+  const maxPerPage = 50;
+  const getReqUrl = (PerPage: number, pageNo: number) =>
+    `https://api.github.com/search/code?q=filename:.asyncapi-tool&per_page=${PerPage}&page=${pageNo}`;
+  const headers = {
+    accept: 'application/vnd.github.text-match+json',
+    authorization: `token ${process.env.GITHUB_TOKEN}`
+  };
+  const result = await axios.get(getReqUrl(maxPerPage, page), {
+    headers
+  });
+
+  incompleteResult = result.data.incomplete_results || false;
+
+  result.data.items.forEach((item: any) => {
+    allItems.add(item);
+  });
+
+  while (incompleteResult) {
+    page++;
+
+    logger.info(`Fetching page: ${page}`);
+    // pause for 1 second to avoid rate limiting
+    await pause(1000);
+    const nextPageData = await axios.get(getReqUrl(maxPerPage, page), {
       headers
     });
 
-    incompleteResult = result.data.incomplete_results || false;
+    const { data } = nextPageData;
 
-    result.data.items.forEach((item: any) => {
+    data.items.forEach((item: any) => {
       allItems.add(item);
     });
 
-    while (incompleteResult) {
-      page++;
-
-      logger.info(`Fetching page: ${page}`);
-      // pause for 1 second to avoid rate limiting
-      await pause(1000);
-      const nextPageData = await axios.get(getReqUrl(maxPerPage, page), {
-        headers
-      });
-
-      const { data } = nextPageData;
-
-      data.items.forEach((item: any) => {
-        allItems.add(item);
-      });
-
-      incompleteResult = data.incomplete_results || false;
-    }
-
-    result.data.items = [...allItems];
-
-    return result.data.items;
-  } catch (err) {
-    throw err;
+    incompleteResult = data.incomplete_results || false;
   }
+
+  result.data.items = [...allItems];
+
+  return result.data.items;
 }
+


### PR DESCRIPTION
## Removing Useless Try-Catch Block in `extract-tools-github.ts`

## Problem

The `getData` function in `scripts/tools/extract-tools-github.ts` wrapped its entire implementation in a `try-catch` block, but the `catch` block did nothing except immediately rethrow the caught error:

```typescript
// eslint-disable-next-line no-useless-catch
try {
  // ... implementation ...
} catch (err) {
  throw err; // ← Useless: just rethrows the error
}
```

This pattern is flagged by the `no-useless-catch` ESLint rule. Instead of addressing the issue, the code suppressed the warning using an `eslint-disable` directive.

## Changes

- Removed the `// eslint-disable-next-line no-useless-catch` comment
- Removed the `try { ... } catch (err) { throw err; }` wrapper
- Reduced indentation level by one

## Why This Is Correct

Removing the try-catch block has **zero behavioral impact**. Errors will propagate to the caller exactly as before, since `throw err` inside a catch block is functionally identical to not catching the error at all.

## Benefits

- ✅ Cleaner, more readable code
- ✅ Re-enables the `no-useless-catch` ESLint rule for this file
- ✅ Removes misleading error-handling structure
---
Fixes #4827
---
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure in the tool extraction process. No changes to end-user functionality or the public API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->