### PR TITLE
fix: make useMemo pure and derive hasTools state in ToolsDashboard

### DIFF
--- a/components/tools/ToolsDashboard.tsx
+++ b/components/tools/ToolsDashboard.tsx
@@ -28,8 +28,7 @@ export default function ToolsDashboard() {
   // filter parameters extracted from the context
   const { isPaid, isAsyncAPIOwner, languages, technologies, categories } = useContext(ToolFilterContext);
   const [searchName, setSearchName] = useState<string>(''); // state variable used to get the search name
-  // state variable used to check whether any tool is available according to the needs of the user.
-  const [checkToolsList, setCheckToolsList] = useState<boolean>(true);
+
 
   // useEffect function to enable the close Modal feature when clicked outside of the modal
   useEffect(() => {
@@ -61,7 +60,7 @@ export default function ToolsDashboard() {
     };
   });
 
-  // useMemo function to filter the tools according to the filters applied by the user
+  // useMemo function(only for calculations, no side effects) to filter the tools according to the filters applied by the user
   const toolsList = useMemo(() => {
     let tempToolsList: ToolsListData = {};
 
@@ -80,9 +79,6 @@ export default function ToolsDashboard() {
       // if no category is selected, then all tools are selected for further check on filters
       tempToolsList = JSON.parse(JSON.stringify(ToolsData));
     }
-
-    // checkToolsList is initially made false to check whether any tools are present according to the filters.
-    setCheckToolsList(false);
 
     // Each tool selected is then traversed to check against each filter variable (only if the filter is applied),
     // whether they match with the filter applied or not.
@@ -135,9 +131,6 @@ export default function ToolsDashboard() {
         return isLanguageTool && isTechnologyTool && isSearchTool && isAsyncAPITool && isPaidTool;
       });
 
-      if (tempToolsList[category].toolsList.length) {
-        setCheckToolsList(true);
-      }
     });
 
     Object.keys(tempToolsList).map((category) => {
@@ -148,6 +141,13 @@ export default function ToolsDashboard() {
 
     return tempToolsList;
   }, [isPaid, isAsyncAPIOwner, languages, technologies, categories, searchName]);
+
+  // helper function for checking if at least one tool exists after filtering
+  const hasTools = useMemo(() => {
+    return Object.values(toolsList).some(
+      (category) => category.toolsList.length > 0
+    );
+  }, [toolsList]);
 
   // useEffect to scroll to the opened category when url has category as element id
   useEffect(() => {
@@ -235,7 +235,7 @@ export default function ToolsDashboard() {
           </div>
         )}
         <div className='mt-0'>
-          {checkToolsList ? (
+          {hasTools ? (
             <ToolsList toolsListData={toolsList} />
           ) : (
             <div className='p-4'>

--- a/components/tools/ToolsDashboard.tsx
+++ b/components/tools/ToolsDashboard.tsx
@@ -1,5 +1,12 @@
 import { useRouter } from 'next/router';
-import React, { createRef, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  createRef,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import type { ToolsListData } from '@/types/components/tools/ToolDataType';
 
@@ -26,14 +33,18 @@ export default function ToolsDashboard() {
   const [openFilter, setOpenFilter] = useState<boolean>(false);
   const [openCategory, setopenCategory] = useState<boolean>(false);
   // filter parameters extracted from the context
-  const { isPaid, isAsyncAPIOwner, languages, technologies, categories } = useContext(ToolFilterContext);
+  const { isPaid, isAsyncAPIOwner, languages, technologies, categories } =
+    useContext(ToolFilterContext);
   const [searchName, setSearchName] = useState<string>(''); // state variable used to get the search name
-
 
   // useEffect function to enable the close Modal feature when clicked outside of the modal
   useEffect(() => {
     const checkIfClickOutside = (event: MouseEvent) => {
-      if (openFilter && filterRef.current && !filterRef.current.contains(event.target as Node)) {
+      if (
+        openFilter &&
+        filterRef.current &&
+        !filterRef.current.contains(event.target as Node)
+      ) {
         setOpenFilter(false);
       }
     };
@@ -48,7 +59,11 @@ export default function ToolsDashboard() {
   // useEffect function to enable the close Category dropdown Modal feature when clicked outside of the modal
   useEffect(() => {
     const checkIfClickOutside = (event: MouseEvent) => {
-      if (openCategory && categoryRef.current && !categoryRef.current.contains(event.target as Node)) {
+      if (
+        openCategory &&
+        categoryRef.current &&
+        !categoryRef.current.contains(event.target as Node)
+      ) {
         setopenCategory(false);
       }
     };
@@ -83,7 +98,9 @@ export default function ToolsDashboard() {
     // Each tool selected is then traversed to check against each filter variable (only if the filter is applied),
     // whether they match with the filter applied or not.
     Object.keys(tempToolsList).forEach((category) => {
-      tempToolsList[category].toolsList = tempToolsList[category].toolsList.filter((tool) => {
+      tempToolsList[category].toolsList = tempToolsList[
+        category
+      ].toolsList.filter((tool) => {
         // These are filter check variables for respective filters, which are initially made true.
         // If the particular filter is applied by the user, the respective check variable is made false first,
         // and then tool parameters are checked against the filter variable value to decide
@@ -97,7 +114,10 @@ export default function ToolsDashboard() {
         if (languages.length) {
           isLanguageTool = false;
           for (const language of languages) {
-            if (tool?.filters?.language && tool.filters.language.find((item) => item.name === language)) {
+            if (
+              tool?.filters?.language &&
+              tool.filters.language.find((item) => item.name === language)
+            ) {
               isLanguageTool = true;
             }
           }
@@ -106,14 +126,19 @@ export default function ToolsDashboard() {
         if (technologies.length) {
           isTechnologyTool = false;
           for (const technology of technologies) {
-            if (tool?.filters?.technology && tool.filters.technology.find((item) => item.name === technology)) {
+            if (
+              tool?.filters?.technology &&
+              tool.filters.technology.find((item) => item.name === technology)
+            ) {
               isTechnologyTool = true;
             }
           }
         }
 
         if (searchName) {
-          isSearchTool = tool.title.toLowerCase().includes(searchName.toLowerCase());
+          isSearchTool = tool.title
+            .toLowerCase()
+            .includes(searchName.toLowerCase());
         }
 
         if (isAsyncAPIOwner) {
@@ -128,9 +153,14 @@ export default function ToolsDashboard() {
           }
         }
 
-        return isLanguageTool && isTechnologyTool && isSearchTool && isAsyncAPITool && isPaidTool;
+        return (
+          isLanguageTool &&
+          isTechnologyTool &&
+          isSearchTool &&
+          isAsyncAPITool &&
+          isPaidTool
+        );
       });
-
     });
 
     Object.keys(tempToolsList).map((category) => {
@@ -140,12 +170,19 @@ export default function ToolsDashboard() {
     });
 
     return tempToolsList;
-  }, [isPaid, isAsyncAPIOwner, languages, technologies, categories, searchName]);
+  }, [
+    isPaid,
+    isAsyncAPIOwner,
+    languages,
+    technologies,
+    categories,
+    searchName,
+  ]);
 
   // helper function for checking if at least one tool exists after filtering
   const hasTools = useMemo(() => {
     return Object.values(toolsList).some(
-      (category) => category.toolsList.length > 0
+      (category) => category.toolsList.length > 0,
     );
   }, [toolsList]);
 
@@ -163,7 +200,7 @@ export default function ToolsDashboard() {
         document.documentElement.style.scrollPaddingTop = '0';
       }
     }
-  }, []);
+  }, [toolsList]);
   // Function to update the list of tools according to the current filters applied
   const clearFilters = () => {
     setOpenFilter(false);
@@ -171,76 +208,105 @@ export default function ToolsDashboard() {
   };
 
   const isFiltered = Boolean(
-    isPaid !== 'all' || isAsyncAPIOwner || languages.length || technologies.length || categories.length
+    isPaid !== 'all' ||
+      isAsyncAPIOwner ||
+      languages.length ||
+      technologies.length ||
+      categories.length,
   );
 
   return (
     <ToolFilter>
       <div>
-        <div className='my-10 flex flex-wrap justify-between gap-4 lg:flex-nowrap'>
-          <div className='flex h-auto w-[47%] gap-5 lg:w-1/5'>
-            <div className='relative h-auto w-full' ref={filterRef as React.LegacyRef<HTMLDivElement>}>
+        <div className="my-10 flex flex-wrap justify-between gap-4 lg:flex-nowrap">
+          <div className="flex h-auto w-[47%] gap-5 lg:w-1/5">
+            <div
+              className="relative h-auto w-full"
+              ref={filterRef as React.LegacyRef<HTMLDivElement>}
+            >
               <div
-                className='flex h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-gray-300 px-4 py-1 text-sm text-gray-700 shadow hover:border-gray-600 hover:shadow-md'
+                className="flex h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-gray-300 px-4 py-1 text-sm text-gray-700 shadow hover:border-gray-600 hover:shadow-md"
                 onClick={() => setOpenFilter(!openFilter)}
-                data-testid='ToolsDashboard-Filters-Click'
+                data-testid="ToolsDashboard-Filters-Click"
               >
                 <FilterIcon />
                 <div>Filter</div>
               </div>
               {openFilter && (
-                <button className='absolute top-16 z-20 min-w-[20rem]'>
+                <button className="absolute top-16 z-20 min-w-[20rem]">
                   <Filters setOpenFilter={setOpenFilter} />
                 </button>
               )}
             </div>
           </div>
-          <div className='flex h-auto w-[47%] gap-5 lg:w-1/5'>
-            <div className='relative h-auto w-full' ref={categoryRef as React.LegacyRef<HTMLDivElement>}>
+          <div className="flex h-auto w-[47%] gap-5 lg:w-1/5">
+            <div
+              className="relative h-auto w-full"
+              ref={categoryRef as React.LegacyRef<HTMLDivElement>}
+            >
               <div
-                className='flex h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-gray-300 px-4 py-1 text-sm text-gray-700 shadow hover:border-gray-600 hover:shadow-md'
+                className="flex h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-gray-300 px-4 py-1 text-sm text-gray-700 shadow hover:border-gray-600 hover:shadow-md"
                 onClick={() => setopenCategory(!openCategory)}
-                data-testid='ToolsDashboard-category'
+                data-testid="ToolsDashboard-category"
               >
                 <div>Jump to Category</div>
-                <ArrowDown className={`my-auto ${openCategory ? 'rotate-180' : ''}`} />
+                <ArrowDown
+                  className={`my-auto ${openCategory ? 'rotate-180' : ''}`}
+                />
               </div>
               {openCategory && (
-                <div className='absolute right-52 top-16 z-20'>
+                <div className="absolute right-52 top-16 z-20">
                   <CategoryDropdown setopenCategory={setopenCategory} />
                 </div>
               )}
             </div>
           </div>
-          <div className='flex h-14 w-full rounded-lg border border-gray-300 px-4 py-1 text-sm text-gray-700 shadow hover:border-gray-600 focus:border-gray-600 lg:w-4/5'>
-            <SearchIcon className='my-auto opacity-70' />
+          <div className="flex h-14 w-full rounded-lg border border-gray-300 px-4 py-1 text-sm text-gray-700 shadow hover:border-gray-600 focus:border-gray-600 lg:w-4/5">
+            <SearchIcon className="my-auto opacity-70" />
             <input
-              className='w-11/12 flex-1 border-none outline-none focus:ring-0'
-              placeholder='Search by name'
-              type='text'
+              className="w-11/12 flex-1 border-none outline-none focus:ring-0"
+              placeholder="Search by name"
+              type="text"
               value={searchName}
               onChange={(e) => setSearchName(e.target.value)}
             />
             {searchName && (
-              <button className='my-auto h-fit rounded-full p-2 hover:bg-gray-100' onClick={() => setSearchName('')}>
-                <img src='/img/illustrations/icons/close-icon.svg' alt='close' width='10' />
+              <button
+                className="my-auto h-fit rounded-full p-2 hover:bg-gray-100"
+                onClick={() => setSearchName('')}
+              >
+                <img
+                  src="/img/illustrations/icons/close-icon.svg"
+                  alt="close"
+                  width="10"
+                />
               </button>
             )}
           </div>
         </div>
         {isFiltered && (
-          <div className='mt-4 flex cursor-pointer items-center text-gray-600 hover:text-black' onClick={clearFilters}>
+          <div
+            className="mt-4 flex cursor-pointer items-center text-gray-600 hover:text-black"
+            onClick={clearFilters}
+          >
             <Cross />
-            <span className='ml-3'>Clear Filters</span>
+            <span className="ml-3">Clear Filters</span>
           </div>
         )}
-        <div className='mt-0'>
+        <div className="mt-0">
           {hasTools ? (
             <ToolsList toolsListData={toolsList} />
           ) : (
-            <div className='p-4'>
-              <img src='/img/illustrations/not-found.webp' alt='not found' className='m-auto w-1/2' />
-              <div className='text-center text-lg'> Sorry, we don&apos;t have tools according to your needs. </div>
+            <div className="p-4">
+              <img
+                src="/img/illustrations/not-found.webp"
+                alt="not found"
+                className="m-auto w-1/2"
+              />
+              <div className="text-center text-lg">
+                {' '}
+                Sorry, we don&apos;t have tools according to your needs.{' '}
+              </div>
             </div>
           )}
         </div>


### PR DESCRIPTION
**Fixes #4847**

**What?**
- Removed state updates from `useMemo`
- now `useMemo` is a pure computation
- made `hasTools` instead of storing state

**Why?**
- `useMemo` should not contain side effects
- no unnecessary re-renders and unpredictable behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal filtering and rendering in the Tools Dashboard for more consistent UI behavior.
  * Ensures the "no tools" message and tool list display update reliably when filters or the tool set change.
  * Standardized styling/markup for more consistent presentation without changing external behavior or public interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->