### PR TITLE
docs: fix broken link to contribution guidelines

### DIFF
--- a/markdown/docs/community/000-onboarding/index.md
+++ b/markdown/docs/community/000-onboarding/index.md
@@ -6,7 +6,7 @@ weight: 2
 
 The AsyncAPI technical writer onboarding guide teaches new community members how to contribute to our documentation effectively. 
 
-> For a comprehensive understanding of the various ways you can contribute to the AsyncAPI Initiative, please consult the [AsyncAPI contributing guidelines](../../CONTRIBUTING.md).
+> For a comprehensive understanding of the various ways you can contribute to the AsyncAPI Initiative, please consult the [AsyncAPI contribution guidelines](https://www.asyncapi.com/docs/community/010-contribution-guidelines).
 
 The goal is providing docs contributors with the necessary tools and knowledge to:
 


### PR DESCRIPTION
**Description**

This PR fixes a broken link in the docs > community > onboarding section.
The link previously pointed to a relative CONTRIBUTING.md path that resulted
in a 404 on the website. It now points to the correct AsyncAPI contribution
guidelines page to improve onboarding for new contributors.

**Related issue(s)**

Fixes #4869


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated community onboarding documentation with an external link to the contribution guidelines, making it easier for new members to access contribution information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->