### PR TITLE
style: Github & Docs buttons alignment in generator page.

### DIFF
--- a/pages/tools/generator.tsx
+++ b/pages/tools/generator.tsx
@@ -138,7 +138,7 @@ export default function GeneratorPage() {
           </div>
         </div>
 
-        <div className='mt-16 text-center'>{renderButtons()}</div>
+        <div className='px-4 sm:px-6 lg:px-8 mt-16 text-center'>{renderButtons()}</div>
       </div>
     </GenericLayout>
   );


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
hey @princerajpoot20 i solved the issue.
in the button render div element don't have any padding but in the sibling element we have a padding
![issue2](https://github.com/user-attachments/assets/eb51de55-e50d-4075-9dfb-25e9cce91b65)
if you look at the the render button div element we don't have any padding.
![issue1](https://github.com/user-attachments/assets/ae7f474d-cb9d-4ed5-bb7e-7def76cced42)
 I added padding same as the sibling padding and tested in different sizes, it correctly works.
![solved](https://github.com/user-attachments/assets/cd015650-28c7-4906-9cb4-860247246ddb)

github and docs buttons at end of generator page have alignment issue.
before
![before](https://github.com/user-attachments/assets/96b5275e-5eff-4275-ae40-ad2f6b73fb4e)
after
![after](https://github.com/user-attachments/assets/2eb18338-f894-48a1-9c24-2352e3bd4596)

Closes #4882


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive spacing and padding on the generator page for better layout across all screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->