### PR TITLE
fix: header dropdowns consistent shadow and border radius

### DIFF
--- a/components/navigation/FlyoutMenu.tsx
+++ b/components/navigation/FlyoutMenu.tsx
@@ -14,12 +14,12 @@ interface FlyoutProps {
 export default function Flyout({ items = [] }: FlyoutProps) {
   return (
     <div
-      className='absolute z-50 bg-white rounded-lg -ml-4 md:max-h-[80vh] shadow-lg overflow-x-auto w-screen max-w-md pt-3 md:ml-12 md:-translate-x-1/2 lg:left-1/2 lg:max-w-3xl lg:-translate-x-1/2'
-      data-testid='Flyout-main'
+      className="absolute z-50 bg-white rounded-lg -ml-4 md:max-h-[80vh] shadow-lg overflow-x-auto w-screen max-w-md pt-3 md:ml-12 md:-translate-x-1/2 lg:left-1/2 lg:max-w-3xl lg:-translate-x-1/2"
+      data-testid="Flyout-main"
     >
-        <div className='relative z-20 grid gap-6 px-5 py-6 sm:gap-8 sm:p-8 lg:grid-cols-2'>
-          <MenuBlocks items={items} />
-        </div>
+      <div className="relative z-20 grid gap-6 px-5 py-6 sm:gap-8 sm:p-8 lg:grid-cols-2">
+        <MenuBlocks items={items} />
+      </div>
     </div>
   );
 }

--- a/components/navigation/FlyoutMenu.tsx
+++ b/components/navigation/FlyoutMenu.tsx
@@ -14,16 +14,12 @@ interface FlyoutProps {
 export default function Flyout({ items = [] }: FlyoutProps) {
   return (
     <div
-      className='absolute z-50 -ml-4 md:h-[80vh] overflow-x-auto w-screen max-w-md pt-3 md:ml-12 md:-translate-x-1/2 lg:left-1/2 lg:max-w-3xl lg:-translate-x-1/2'
+      className='absolute z-50 bg-white rounded-lg -ml-4 md:max-h-[80vh] shadow-lg overflow-x-auto w-screen max-w-md pt-3 md:ml-12 md:-translate-x-1/2 lg:left-1/2 lg:max-w-3xl lg:-translate-x-1/2'
       data-testid='Flyout-main'
     >
-      <div className='rounded-lg shadow-lg'>
-        <div className='shadow-xs overflow-hidden rounded-lg'>
-          <div className='relative z-20 grid gap-6 bg-white px-5 py-6 sm:gap-8 sm:p-8 lg:grid-cols-2'>
-            <MenuBlocks items={items} />
-          </div>
+        <div className='relative z-20 grid gap-6 px-5 py-6 sm:gap-8 sm:p-8 lg:grid-cols-2'>
+          <MenuBlocks items={items} />
         </div>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
<!--
Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation if needed.
-->

**Description**  
Fixes visual issues in header dropdown menus (Docs, Tools, Community) where shadows and border radius were inconsistent or missing.  

**Related issue(s)**  
Fixes #4911 

**Changes**  
- Flyout menus now have:
  - consistent `shadow-lg` on all sides
  - `rounded-lg` border radius on all corners
- No changes to Navbar logic or behavior  
- Minimal changes to prevent introducing new layout issues

Screenshots after fix:
<img width="1833" height="887" alt="Screenshot From 2026-01-09 22-54-52" src="https://github.com/user-attachments/assets/7e705613-7b1a-4329-9d23-ca87005517c0" />


<img width="1833" height="887" alt="Screenshot From 2026-01-09 22-54-33" src="https://github.com/user-attachments/assets/02b1d2b3-d67c-4513-aee7-eeb726ea78bd" />


<img width="1833" height="887" alt="Screenshot From 2026-01-09 22-55-29" src="https://github.com/user-attachments/assets/2971d4df-2169-499d-90e7-936b07d3a558" />


**Result**  
- Dropdowns now visually appear as floating popups above the page content  
- Shadow is visible on all sides  
- Rounded corners are consistent, including for scrollable community dropdowns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the flyout menu to a cleaner white panel with rounded corners and stronger shadow for improved visual depth.
  * Simplified internal layout for consistent padding and spacing, enabling a responsive two-column arrangement on larger screens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->