### PR TITLE
fix: add slack-light color to tailwind config for button hover state

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -116,7 +116,10 @@ const config: Config = {
         dark: '#1B1130',
         'cool-gray': '#9C96A8',
         hub: '#252f3f',
-        slack: '#371038',
+        slack: {
+          DEFAULT: '#371038',
+          light: '#4A154B'
+        },
         'mac-window': {
           close: '#ff5f56',
           minimize: '#ffbd2e',


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

The Slack button hover effect was failing because the color `slack-light` was referenced in the component but not defined in [tailwind.config.ts](cci:7://file:///Users/ankush/Desktop/os/website/tailwind.config.ts:0:0-0:0).
This PR adds the missing `slack-light` color definition (`#4A154B`) to the configuration, restoring the intended hover behavior.

**Screenshots**

<!-- Please attach the before and after screenshots here as requested -->

Before:
<video src="https://github.com/user-attachments/assets/63086168-697f-4f36-a14d-a969f4228377" controls width="600"></video>

After:
<video src="https://github.com/user-attachments/assets/d8804df4-dee7-4807-a773-9cf5862d6fab" controls width="600"></video>

**Related issue(s)**
Fixes #4907

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Expanded the Slack brand color palette with a default shade and lighter variant, providing enhanced design flexibility for themed UI elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->