### PR TITLE
fix: restore TOC active section highlighting after client-side navigation

### DIFF
--- a/components/TOC.tsx
+++ b/components/TOC.tsx
@@ -89,7 +89,7 @@ export default function TOC({ className, cssBreakingPoint = 'xl', toc, contentSe
       </div>
       <div className={`${!open && 'hidden'} ${cssBreakingPoint === 'xl' ? 'xl:block' : 'lg:block'}`}>
         <Scrollspy
-          key={router.asPath}
+          key={router.pathname}
           items={tocItems.map((item) => (item.slug ? item.slug : item.slugWithATag))}
           currentClassName='text-primary-500 font-bold'
           componentTag='div'

--- a/components/TOC.tsx
+++ b/components/TOC.tsx
@@ -1,7 +1,8 @@
+import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import Scrollspy from 'react-scrollspy';
 import { twMerge } from 'tailwind-merge';
-import { useRouter } from 'next/router';
+
 import ArrowRight from './icons/ArrowRight';
 
 interface ITOCProps {
@@ -88,7 +89,7 @@ export default function TOC({ className, cssBreakingPoint = 'xl', toc, contentSe
       </div>
       <div className={`${!open && 'hidden'} ${cssBreakingPoint === 'xl' ? 'xl:block' : 'lg:block'}`}>
         <Scrollspy
-        key = {router.asPath}
+          key={router.asPath}
           items={tocItems.map((item) => (item.slug ? item.slug : item.slugWithATag))}
           currentClassName='text-primary-500 font-bold'
           componentTag='div'

--- a/components/TOC.tsx
+++ b/components/TOC.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Scrollspy from 'react-scrollspy';
 import { twMerge } from 'tailwind-merge';
-
+import { useRouter } from 'next/router';
 import ArrowRight from './icons/ArrowRight';
 
 interface ITOCProps {
@@ -26,6 +26,7 @@ interface ITOCProps {
  * @param {number} props.depth - The depth of the table of contents
  */
 export default function TOC({ className, cssBreakingPoint = 'xl', toc, contentSelector, depth = 2 }: ITOCProps) {
+  const router = useRouter();
   const [open, setOpen] = useState(false);
 
   if (!toc || !toc.length) return null;
@@ -87,6 +88,7 @@ export default function TOC({ className, cssBreakingPoint = 'xl', toc, contentSe
       </div>
       <div className={`${!open && 'hidden'} ${cssBreakingPoint === 'xl' ? 'xl:block' : 'lg:block'}`}>
         <Scrollspy
+        key = {router.asPath}
           items={tocItems.map((item) => (item.slug ? item.slug : item.slugWithATag))}
           currentClassName='text-primary-500 font-bold'
           componentTag='div'


### PR DESCRIPTION
**Description**

This PR fixes an issue where the **“On this page”** Table of Contents (TOC) active section highlight stops working after navigating between documentation pages using client-side routing.

The TOC uses `react-scrollspy`, which does not automatically reset when the route changes. As a result, it continues to track headings from the previously visited page, causing the active section highlight to break until a full page reload.

**What was Changed**

- Added `useRouter` to detect route changes
- Keyed the `Scrollspy` component with `router.asPath` to force a remount on navigation
- Ensured headings are re-scanned and scroll listeners are re-initialized after each route change

**Why this Works**

Changing the `key` forces React to recreate the `Scrollspy` component whenever the route changes. This resets its internal state and restores correct active section tracking without introducing custom scroll logic or breaking existing behavior.

**Related issue(s)**
 Fixes #4845 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the table of contents and scrollspy so the active section reliably updates when navigating between pages, preventing incorrect highlighting after route changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->