### PR TITLE
fix: remove transition for breakpoint lg

### DIFF
--- a/components/DemoAnimation.tsx
+++ b/components/DemoAnimation.tsx
@@ -310,7 +310,7 @@ export default function DemoAnimation({ className = '' }: IDemoAnimationProps) {
             <OpenInStudioButton />
           </div>
           <MacWindow
-            className={`min-h-full border border-gray-200 bg-gray-50 shadow-lg transition-all duration-500 ease-in-out ${showControls ? 'h-0 -translate-x-full opacity-0 lg:h-auto lg:-translate-x-3/4 lg:opacity-100' : ''}`}
+            className={`min-h-full border border-gray-200 bg-gray-50 shadow-lg transition-all duration-500 ease-in-out ${showControls ? 'h-0 -translate-x-full opacity-0' : ''}`}
             contentClassName='text-left h-full text-gray-800 text-sm font-medium transition-all duration-500 ease-in-out'
             title='Account Service Documentation'
           >


### PR DESCRIPTION
fixed demo transition for larger screens.
<img width="1567" height="672" alt="image" src="https://github.com/user-attachments/assets/28da7642-edab-4f8d-979a-572423029979" />

fixes #4934 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed control visibility behavior in the demo animation component on larger screens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->