### PR TITLE
fix:  Markdown specific Emoji call in place of Unicode in Footer Section. Issue #4941

### DIFF
--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -94,7 +94,7 @@ export default function Footer() {
         <div className='justify-between py-8 sm:flex sm:py-12 xl:mt-20' data-testid='Footer-content'>
           <div className='w-full sm:w-2/3'>
             <p className='mb-3 text-left text-base leading-6 text-cool-gray'>
-              Made with <span className='font-mono text-secondary-500'>:love:</span> by the AsyncAPI Initiative.
+              Made with <span className='font-mono text-secondary-500'>❤️</span> by the AsyncAPI Initiative.
             </p>
             <p className='w-full text-left text-sm leading-6 text-cool-gray sm:w-2/3' data-testid='Footer-copyright'>
               Copyright &copy; AsyncAPI Project a Series of LF Projects, LLC. For web site terms of use, trademark


### PR DESCRIPTION
This PR aims to close issue #4941
---

### 🚀 Changes Made
* replaced the line 97 in Footer.tsx 
* before
```jsx              
Made with <span className='font-mono text-secondary-500'>:love:</span> by the AsyncAPI Initiative.
```
* current 
```jsx
Made with <span className='font-mono text-secondary-500'>❤️</span> by the AsyncAPI Initiative.
```

### 🧠 How It Works
* In line 97 of Footer.tsx there was a Markdown centric emoji code :love:, which is replaced by a unicode heart emoji.

### 🧪 Testing
✅ Tested the Branch with npm install, npm run dev
✅ Tested the Branch with npm run build
✅ Checked  visual consistency of footer section.

---

<img width="1440" height="900" alt="Screenshot 2026-01-13 at 10 18 12 PM" src="https://github.com/user-attachments/assets/195ad1b2-2d52-4cea-8564-b466da3a20b0" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the footer text to display a heart emoji (❤️) instead of a text-based placeholder, enhancing the visual presentation of the attribution message.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->