### PR TITLE
docs: fixed broken link on About page

### DIFF
--- a/markdown/about/index.md
+++ b/markdown/about/index.md
@@ -18,7 +18,7 @@ The AsyncAPI project started at Hitch (a.k.a. API Changelog). Hitch needed a mac
 
 Free software allows users to apply, modify, and continue in the chain by distributing copies to help others and, in this case, disseminating modified versions of the specification. 
 
-Transferring AsyncAPI to the Linux Foundation and forming [an open governance model](https://github.com/asyncapi/community/blob/master/CHARTER.md) assures the community that a single company does not control AsyncAPI Initiative. This move takes the project to a higher level of transparency. 
+Transferring AsyncAPI to the Linux Foundation and forming [an open governance model](https://github.com/asyncapi/community/blob/master/docs/020-governance-and-policies/CHARTER.md) assures the community that a single company does not control AsyncAPI Initiative. This move takes the project to a higher level of transparency. 
 
 In doing so, we achieve:
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This PR fixes a broken link on the About page.

The "open governance model" link was pointing to `https://github.com/asyncapi/community/blob/master/CHARTER.md`, which returns a 404 error.
Updated the link to point to the correct location: `https://github.com/asyncapi/community/blob/master/docs/020-governance-and-policies/CHARTER.md`.

**Related issue(s)**
#4926 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated governance model hyperlink to point to the correct resource location.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->