### PR TITLE
Roadmap youtube recommendations

### DIFF
--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -679,7 +679,7 @@ export default function RoadmapPage() {
             </Paragraph>
 
             <div className='mx-auto lg:w-1/2'>
-              <YouTubeEmbed id='u83V2gIUGHU' appendSrc='?start=86' />
+              <YouTubeEmbed id='u83V2gIUGHU' appendSrc='?start=86&rel=0' />
             </div>
 
             <Warning


### PR DESCRIPTION
Updated the YouTube video player on the roadmap page to show related videos only from the AsyncAPI channel instead of showing recommendations from various channels based on user's feed.
Changes Made

Modified the YouTube embed configuration in roadmap.tsx to include the rel=0 parameter
This ensures that when the video is paused or ends, only videos from the AsyncAPI YouTube channel are recommended to viewers


This change improves brand consistency and keeps users engaged with AsyncAPI content by preventing unrelated video recommendations from appearing in the embedded player.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified YouTube video embed on Roadmap page; related videos no longer appear after playback ends.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->