### PR TITLE
docs: fix broken and outdated links in Mentorship Program documentation

### DIFF
--- a/markdown/docs/community/050-mentorship-program/asyncapi-mentorship-README.md
+++ b/markdown/docs/community/050-mentorship-program/asyncapi-mentorship-README.md
@@ -32,9 +32,9 @@ Our mentorship programs demonstrate strong impact with improving retention rates
 
 | Year | Term | Status | Details |
 | ---- | ---- | ------ | ------- |
-| 2024 | Sept-May | Completed | [2024 Projects](./asyncapi-mentorship-2024-project-ideas.md) |
-| 2023 | Jan-Nov | Completed | [2023 Projects](./asyncapi-mentorship-2023-project-ideas.md) |
-| 2022 | Jan-Nov | Completed | [2022 Projects](./asyncapi-mentorship-2022-project-ideas.md) |
+| 2024 | Sept-May | Completed | [2024 Projects](./asyncapi-mentorship-2024-project-ideas) |
+| 2023 | Jan-Nov | Completed | [2023 Projects](./asyncapi-mentorship-2023-project-ideas) |
+| 2022 | Jan-Nov | Completed | [2022 Projects](./asyncapi-mentorship-2022-project-ideas) |
 
 ## Program Leadership
 
@@ -43,7 +43,8 @@ Our mentorship programs demonstrate strong impact with improving retention rates
 - **Thulisile Sibanda** ([@thulieblack](https://github.com/thulieblack)): [LinkedIn](https://www.linkedin.com/in/v-thulisile-sibanda/)
 
 ### Contact
-- **Slack**: Join our [AsyncAPI Slack workspace](https://asyncapi.com/slack-invite) and visit `#09_mentorships`
+- **Slack**: Join our [AsyncAPI Slack workspace](https://asyncapi.com/slack-invite) and visit [`#09_mentorships`](https://app.slack.com/client/T34F2JRQU/C023A7K5M3N)
+
 - **GitHub Discussions**: [Community Discussions](https://github.com/asyncapi/community/discussions)
 
 ## Key Definitions
@@ -76,8 +77,9 @@ To participate in the AsyncAPI Mentorship Program, you must:
 ### How to Apply
 
 1. **Verify Eligibility**: Ensure you meet all eligibility requirements
-2. **Review Projects**: Browse the [Ideas List](./asyncapi-mentorship-2025-README) for available projects
-3. **Connect with Mentors**: Join our Slack and discuss project ideas in `#09_mentorships`
+2. **Review Projects**: Browse the [Ideas List](./asyncapi-mentorship-2024-project-ideas) for available projects
+3. **Connect with Mentors**: Join our Slack and discuss project ideas in [`#09_mentorships`](https://app.slack.com/client/T34F2JRQU/C023A7K5M3N)
+
 4. **Submit Proposal**: Submit your Project Proposal to the project mentor during the application period
 5. **Wait for Acceptance**: Accepted proposals will be announced on the Program Slack channel and GitHub Discussions
 
@@ -198,7 +200,8 @@ AsyncAPI may suspend, cancel, or modify the program structure if:
 ### Dispute Resolution
 
 For questions, concerns, or disputes:
-1. Contact Program Administrators via Slack (`#09_mentorships`)
+1. Contact Program Administrators via Slack ([`#09_mentorships`](https://app.slack.com/client/T34F2JRQU/C023A7K5M3N)
+)
 2. Open a discussion in [GitHub Discussions](https://github.com/asyncapi/community/discussions)
 3. Program Administrator decisions are final
 


### PR DESCRIPTION
## Description

This pull request fixes broken and outdated links in the AsyncAPI Mentorship Program documentation.

Changes include:
- Corrected outdated Ideas List links to point to accessible resources
- Standardized Slack channel references to use consistent, clickable links
- Fixed incorrect or broken reference links within the document

These changes improve navigation and reduce confusion for contributors and applicants.

## Related issue(s)

Fixes #4987

## Screenshots

### 1. Ideas List link
**Before (broken / outdated link)**


https://github.com/user-attachments/assets/067287d5-0fa5-4ab7-910b-f37e4968d1f0





**After (corrected link)**

https://github.com/user-attachments/assets/b1348c8a-5f93-4997-8976-10a300007bcc




---

### 2. Slack channel reference
**Before (plain text / inconsistent reference)**
<img width="1918" height="694" alt="Screenshot 2026-01-21 223049" src="https://github.com/user-attachments/assets/fcda95fb-51ee-4555-80f8-d7dece313432" />


**After (consistent, clickable link)**

https://github.com/user-attachments/assets/56e11289-11ab-4a0c-be16-9065332a4bf7


---

### 3. Archive / reference links
**Before (incorrect or outdated links)**

https://github.com/user-attachments/assets/270a7b42-d5a1-4179-b5b6-06f9c0282485



**After (corrected links)**

https://github.com/user-attachments/assets/987702da-6c02-44b8-a528-3751ff383668






