### PR TITLE
fix(mega-menu): dropdown visibility issue on mid-size screens

### DIFF
--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -8,7 +8,6 @@ import { defaultLanguage, i18nPaths, languages } from '@/utils/i18n';
 
 import { SearchButton } from '../AlgoliaSearch';
 import GithubButton from '../buttons/GithubButton';
-import { isMobileDevice } from '../helpers/is-mobile';
 import { useOutsideClick } from '../helpers/use-outside-click';
 import IconLoupe from '../icons/Loupe';
 import LanguageSelect from '../languageSelector/LanguageSelect';
@@ -24,8 +23,6 @@ interface NavBarProps {
   className?: string;
   hideLogo?: boolean;
 }
-
-const isMobile = isMobileDevice();
 
 /**
  * @description Renders the navigation bar component.
@@ -131,7 +128,9 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
    */
   function showOnClickMenu(event: React.MouseEvent, menu: 'learning' | 'tooling' | 'community' | null) {
     // Check if device supports hover directly from media query (not relying on state which might be out of sync)
-    const supportsHover = typeof window !== 'undefined' && window.matchMedia('(hover: hover) and (pointer: fine)').matches;
+    const supportsHover =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(hover: hover) and (pointer: fine)').matches;
 
     // For devices that cannot hover (touch/tablet/Nest Hub), toggle dropdown on click
     // and prevent navigation to the page. For devices that can hover, let navigation happen.

--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -129,12 +129,16 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
    * @description Shows or hides the specified menu on click (for mobile).
    * @param {('learning' | 'tooling' | 'community' | null)} menu - The menu to show or hide.
    */
-  function showOnClickMenu(menu: 'learning' | 'tooling' | 'community' | null) {
-    if (!isMobile) return;
-    if (open === menu) {
-      setOpen(null);
-    } else {
-      setOpen(menu);
+  function showOnClickMenu(event: React.MouseEvent, menu: 'learning' | 'tooling' | 'community' | null) {
+    // Check if device supports hover directly from media query (not relying on state which might be out of sync)
+    const supportsHover = typeof window !== 'undefined' && window.matchMedia('(hover: hover) and (pointer: fine)').matches;
+    
+    // For devices that cannot hover (touch/tablet/Nest Hub), toggle dropdown on click
+    // and prevent navigation to the page. For devices that can hover, let navigation happen.
+    if (!supportsHover) {
+      event.preventDefault();
+      event.stopPropagation();
+      setOpen((current) => (current === menu ? null : menu));
     }
   }
 
@@ -183,7 +187,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
             <NavItem
               text='Docs'
               href='/docs'
-              onClick={() => showOnClickMenu('learning')}
+              onClick={(event) => showOnClickMenu(event, 'learning')}
               onMouseEnter={() => showMenu('learning')}
               hasDropdown
             />
@@ -194,7 +198,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
             <NavItem
               text='Tools'
               href='/tools'
-              onClick={() => showOnClickMenu('tooling')}
+              onClick={(event) => showOnClickMenu(event, 'tooling')}
               onMouseEnter={() => showMenu('tooling')}
               hasDropdown
             />
@@ -205,7 +209,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
             <NavItem
               text='Community'
               href='/community'
-              onClick={() => showOnClickMenu('community')}
+              onClick={(event) => showOnClickMenu(event, 'community')}
               onMouseEnter={() => showMenu('community')}
               hasDropdown
             />

--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -132,7 +132,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
   function showOnClickMenu(event: React.MouseEvent, menu: 'learning' | 'tooling' | 'community' | null) {
     // Check if device supports hover directly from media query (not relying on state which might be out of sync)
     const supportsHover = typeof window !== 'undefined' && window.matchMedia('(hover: hover) and (pointer: fine)').matches;
-    
+
     // For devices that cannot hover (touch/tablet/Nest Hub), toggle dropdown on click
     // and prevent navigation to the page. For devices that can hover, let navigation happen.
     if (!supportsHover) {

--- a/components/navigation/NavItem.tsx
+++ b/components/navigation/NavItem.tsx
@@ -8,7 +8,7 @@ interface NavItemProps {
   text: string;
   href?: string;
   target?: string;
-  onClick?: () => void;
+  onClick?: (event: React.MouseEvent) => void;
   onMouseEnter?: () => void;
   hasDropdown?: boolean;
   className?: string;


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where the **mega menu dropdowns (Docs, Tools, Community)** were not opening on the **first click** on **mid-size screen breakpoints** (approximately **900–1100px width**, e.g. **Nest Hub tablets in landscape mode**).

Users were required to **double-click** to open the dropdown.

---

## Root Cause

### State Synchronisation Timing Issue

- The `canHover` state was initialised as `true` on component mount.
- A `useEffect` hook was responsible for detecting hover capability using the media query  
  `(hover: hover) and (pointer: fine)`.
- This effect only ran **after the initial render**, leading to a timing mismatch.

---

## What Went Wrong

### First Click
- `canHover` was still `true`
- `preventDefault()` was skipped
- Click triggered **navigation instead of opening the dropdown**

### After Navigation
- Page reload occurred
- `useEffect` ran and updated `canHover` correctly

### Second Click
- `canHover = false`
- `preventDefault()` executed
- Dropdown finally opened

### Switching Between Dropdowns
- Navigation caused a full state reset
- Each dropdown required a **double-click again**

---

## Why a Double-Click Was Required

| Step | Behavior |
|------|----------|
| First Click | `canHover = true` → Page navigation |
| Page Load | `useEffect` updates `canHover` |
| Second Click | `canHover = false` → Dropdown opens |
| Switch Dropdown | Page reload → State resets → Double-click cycle repeats |

---

## Solution

- Removed the `canHover` state and the associated `useEffect`
- Directly evaluate hover capability synchronously inside the click handler using  
  `window.matchMedia("(hover: hover) and (pointer: fine)").matches`
- This ensures **immediate and accurate detection** without relying on asynchronous state updates

---

## Changes Made

- **NavBar.tsx**
  - Updated `showOnClickMenu()` to use direct media query checks
  - Removed state-based hover detection

- **NavItem.tsx**
  - Updated `onClick` prop to explicitly accept `React.MouseEvent`

---


## Screen Recording

🎥 **Attached screen recording demonstrates:**

- **Before Fix**
  -  For browser Developer Tools
   

https://github.com/user-attachments/assets/5e6e8814-d465-4737-9fbf-19128b38d276


  -  For Full-screen
  

https://github.com/user-attachments/assets/563bee57-0ea0-49f9-b395-3731d3d4a3f7



- **After Fix**
  - Click “Tools” → dropdown opens immediately without navigation
   

https://github.com/user-attachments/assets/f848aeeb-84a8-4fbd-92a3-bf90a1916fb7



---

## Related Issue

Closes **#4975**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Navigation menus now detect whether your device supports hover and adapt click behavior accordingly—clicks open menus on touch/non-hover devices while hover activation remains on pointer-capable devices, improving consistency across input types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->