### PR TITLE
fix: refactor GA/GTM initialization to avoid duplicate analytics events

### DIFF
--- a/components/Head.tsx
+++ b/components/Head.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import { useContext } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 import ReactGA from 'react-ga';
 import TagManager from 'react-gtm-module';
 
@@ -50,12 +50,21 @@ export default function HeadComponent({
 
   const currTitle = title ? `${title} | ${permTitle}` : permTitle;
 
-  // enable google analytics
-  if (typeof window !== 'undefined' && window.location.hostname.includes('asyncapi.com')) {
-    TagManager.initialize({ gtmId: 'GTM-T58BTVQ' });
-    ReactGA.initialize('UA-109278936-1');
+  const gaInitialized = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.location.hostname.includes('asyncapi.com')) {
+      return;
+    }
+
+    if (!gaInitialized.current) {
+      TagManager.initialize({ gtmId: 'GTM-T58BTVQ' });
+      ReactGA.initialize('UA-109278936-1');
+      gaInitialized.current = true;
+    }
+
     ReactGA.pageview(window.location.pathname + window.location.search);
-  }
+  }, [path]);
 
   return (
     <Head>


### PR DESCRIPTION
## Description

This PR refactors how Google Analytics (ReactGA) and Google Tag Manager (GTM) are handled in `HeadComponent`.

### What changed
- Moved GA and GTM initialization out of the render phase and into `useEffect`.
- Ensured analytics initialization runs only once to prevent duplicate setup during re-renders.
- Updated pageview tracking to trigger only when the route changes instead of on every render.
- Preserved existing hostname checks to ensure analytics only runs on `asyncapi.com`.

## Related issue(s)

Resolves #5016 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Google Analytics initialization to execute once per page lifecycle with host-based security validation, improving efficiency and tracking reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->