### PR TITLE
docs: standardize AsyncAPI Slack invite links

### DIFF
--- a/markdown/docs/community/060-meetings-and-communication/docs-community.md
+++ b/markdown/docs/community/060-meetings-and-communication/docs-community.md
@@ -6,7 +6,7 @@ weight: 20
  [Schedule your own docs meetings](MEETINGS_ORGANIZATION).
 
 ## AsyncAPI Slack workspace and docs channels
-Join the [AsyncAPI documentation Slack channel](https://asyncapi.com/slack-invite/enQtNjUxNTY1NTU1MDk0NS1mYjNhODFhZDI3ZDRjODA1ZWRkZTZlYmM4ZTNjNzZjNTg5NTBiYjNmNTkwYzRlYzY4ZjQ4M2RhMDYzMjI3N2U5) to meet other technical writers:
+Join the [AsyncAPI documentation Slack channel](https://asyncapi.com/slack-invite) to meet other technical writers:
 
 - **#13_docs:** A space for all technical writers to start discussions, ask questions, share new ideas, and request `good first issues.`
 

--- a/markdown/docs/community/060-meetings-and-communication/docs-community.md
+++ b/markdown/docs/community/060-meetings-and-communication/docs-community.md
@@ -6,7 +6,7 @@ weight: 20
  [Schedule your own docs meetings](MEETINGS_ORGANIZATION).
 
 ## AsyncAPI Slack workspace and docs channels
-Join the [AsyncAPI documentation Slack channel](https://join.slack.com/share/enQtNjUxNTY1NTU1MDk0NS1mYjNhODFhZDI3ZDRjODA1ZWRkZTZlYmM4ZTNjNzZjNTg5NTBiYjNmNTkwYzRlYzY4ZjQ4M2RhMDYzMjI3N2U5) to meet other technical writers:
+Join the [AsyncAPI documentation Slack channel](https://asyncapi.com/slack-invite/enQtNjUxNTY1NTU1MDk0NS1mYjNhODFhZDI3ZDRjODA1ZWRkZTZlYmM4ZTNjNzZjNTg5NTBiYjNmNTkwYzRlYzY4ZjQ4M2RhMDYzMjI3N2U5) to meet other technical writers:
 
 - **#13_docs:** A space for all technical writers to start discussions, ask questions, share new ideas, and request `good first issues.`
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Standardized Slack invite links across docs.
- Replaced old Slack invite URLs with the canonical `https://asyncapi.com/slack-invite`.
- Prevents expired/temporary Slack invite links.

**Related issue(s)**
- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the AsyncAPI Slack workspace invite link in the community meetings and communication documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->