### PR TITLE
docs: add descriptive alt text to 2025 Annual Review images

### DIFF
--- a/markdown/blog/2025-annual-summary.md
+++ b/markdown/blog/2025-annual-summary.md
@@ -32,6 +32,7 @@ In 2025, we welcomed **1857** new joiners and have a total of **7964** members.
   src="/img/posts/2025-blog-banner/Joiners vs. Year.webp"
   caption="New members on Slack each year."
   className="text-center"
+  altOnly="Bar chart showing AsyncAPI Slack workspace new member growth: 384 in 2019, 987 in 2020, 1589 in 2021, 1623 in 2022, 1830 in 2023, 1820 in 2024, and 1857 in 2025"
 />
 
 Our weekly activity reduced by 19% this year, with the intention of reducing noise in channels by disabling some workflow notifications and pausing certain channels. Also, we ran one mentorship program instead of multiple as we did in previous years, and had fewer active working groups.
@@ -40,6 +41,7 @@ Our weekly activity reduced by 19% this year, with the intention of reducing noi
   src="/img/posts/2025-blog-banner/Average and Median.webp"
   caption="Weekly Slack activity over the years."
   className="text-center"
+  altOnly="Line chart displaying weekly Slack activity metrics with average and median messages posted per week from 2019 to 2025, showing a 19 percent decrease in 2025"
 />
 
 ## Social Media 
@@ -54,6 +56,7 @@ We also have some analytics recorded dating back to 2023.
   src="/img/posts/2025-blog-banner/Audience and Engagement.webp"
   caption="Audience and Engagement analytics from Buffer."
   className="text-center"
+  altOnly="Dashboard showing Buffer social media analytics with audience growth and engagement metrics for LinkedIn and X Twitter platforms"
 />
 
 ### LinkedIn
@@ -64,6 +67,7 @@ We gained **945** followers on LinkedIn in 2025, bringing our overall following 
   src="/img/posts/2025-blog-banner/Followers vs. Year.webp"
   caption="Yearly followers on LinkedIn."
   className="text-center"
+  altOnly="Bar chart showing LinkedIn follower growth by year, with 945 new followers gained in 2025 for a total of 4928 followers"
 />
 
 ### YouTube
@@ -73,6 +77,7 @@ We had **272** new subscribers to our YouTube channel this year, bringing our to
   src="/img/posts/2025-blog-banner/YouTube stats.webp"
   caption="YouTube stats over the last few years."
   className="text-center"
+  altOnly="Chart displaying YouTube channel statistics including 272 new subscribers in 2025 for a total of 1983 subscribers, with views and watch time showing a 29 percent decrease"
 />
 
 ### Newsletter
@@ -82,6 +87,7 @@ The community summary newsletter continues to grow and still serves the communit
   src="/img/posts/2025-blog-banner/open vs clicks.webp"
   caption="Newsletter Analytics."
   className="text-center"
+  altOnly="Chart comparing newsletter open rates and click rates, showing 41 percent average open rate and 4.7 percent click rate with 22.7 percent overall engagement"
 />
 
 The number of new users referred to the AsyncAPI through our monthly newsletter increased, though session time dropped slightly.
@@ -90,6 +96,7 @@ The number of new users referred to the AsyncAPI through our monthly newsletter 
   src="/img/posts/2025-blog-banner/referred-Newsletter.webp"
   caption="Website visits referred by the Newsletter."
   className="text-center"
+  altOnly="Analytics chart showing website traffic and session duration for users referred through the AsyncAPI monthly newsletter"
 />
 
 ## Google Analytics
@@ -99,6 +106,7 @@ The overall site performance declined this year, with users by 4.4%, sessions by
   src="/img/posts/2025-blog-banner/Visits.webp"
   caption="Website visits each year."
   className="text-center"
+  altOnly="Line chart showing AsyncAPI website performance metrics by year, with users declining 4.4 percent, sessions declining 9.1 percent, and pageviews declining 15.8 percent in 2025"
 />
 
 The contributing factor leading to the drop in analytics is due to several factors, including users blocking tracking, privacy tools, and browser extensions. This trend affects the traffic recorded, and user behaviour data does not fully reflect the actual audience, as they’re excluded from the analytics reports.
@@ -111,6 +119,7 @@ We saw a 6.9% increase in impressions in Google Search Console, although we had 
   src="/img/posts/2025-blog-banner/Search Console.webp"
   caption="Website analytics from Search Console."
   className="text-center"
+  altOnly="Google Search Console analytics showing 6.9 percent increase in impressions with a decrease in clicks for AsyncAPI website"
 />
 
 ## GitHub
@@ -120,6 +129,7 @@ We use LF Insights to get detailed analytics for all our repos across the org on
   src="/img/posts/2025-blog-banner/Active contributors.webp"
   caption="Active contributors on GitHub."
   className="text-center"
+  altOnly="Chart showing 1131 active contributors across AsyncAPI GitHub repositories in 2025"
 />
 
 We also improved issue resolution across the project, with the average issue now taking just one month to close, a clear sign of our maintainers' responsiveness.
@@ -128,6 +138,7 @@ We also improved issue resolution across the project, with the average issue now
   src="/img/posts/2025-blog-banner/Issues resolution.webp"
   caption="Issue resolution stats."
   className="text-center"
+  altOnly="Analytics chart displaying GitHub issue resolution times, showing average issue closure time reduced to one month"
 />
 
 In the past year, a total of **2,770** pull requests were opened, and **2,390** were merged, highlighting the pace of development and community contributions.
@@ -136,6 +147,7 @@ In the past year, a total of **2,770** pull requests were opened, and **2,390** 
   src="/img/posts/2025-blog-banner/Pull requests.webp"
   caption="Pull requests resolution stats."
   className="text-center"
+  altOnly="Chart showing 2770 pull requests opened and 2390 merged across AsyncAPI repositories in 2025"
 />
 
 The AsyncAPI community is driven by contributors and maintainers who dedicate their time and expertise outside their regular jobs. Kudos to everyone for your commitment and impact!
@@ -144,6 +156,7 @@ The AsyncAPI community is driven by contributors and maintainers who dedicate th
   src="/img/posts/2025-blog-banner/outside work hours.webp"
   caption="Stats showing contributions made outside work hours."
   className="text-center"
+  altOnly="Visualization showing AsyncAPI community contribution patterns, highlighting that contributors dedicate time outside regular work hours"
 />
 
 
@@ -154,6 +167,7 @@ AsyncAPI's top packages are hosted under the Node Package Manager. The package d
   src="/img/posts/2025-blog-banner/NPM.webp"
   caption="Total downloads of AsyncAPI NPM packages."
   className="text-center"
+  altOnly="Chart showing NPM package download statistics with asyncapi spec package reaching 54 million downloads in 2025"
 />
 
 


### PR DESCRIPTION
**Description**

- Added descriptive `altOnly` attributes to all 14 images in the 2025 Annual Review blog post
- Each alt text describes the chart content (data points, trends, key statistics) for screen reader users
- Improves WCAG 2.1 accessibility compliance (Success Criterion 1.1.1 - Text Alternatives)
- Alt text now provides meaningful descriptions instead of falling back to captions

**Related issue(s)**
Fixes #5022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced accessibility of the 2025 annual summary blog post by adding descriptive alternative text to multiple charts and visualizations, including data from Slack, social media, YouTube, newsletters, analytics, GitHub, and NPM. This improves the experience for users with screen readers and those unable to view images directly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->