### PR TITLE
feat(design): replace 'Copied!' text with check icon in code block

### DIFF
--- a/components/editor/CodeBlock.tsx
+++ b/components/editor/CodeBlock.tsx
@@ -1,7 +1,6 @@
+import { CheckIcon } from '@heroicons/react/outline';
 import React, { useState } from 'react';
 import Highlight from 'react-syntax-highlighter';
-
-import { CheckIcon } from '@heroicons/react/outline';
 
 import Caption from '../Caption';
 import IconClipboard from '../icons/Clipboard';

--- a/components/editor/CodeBlock.tsx
+++ b/components/editor/CodeBlock.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
 import { CheckIcon } from '@heroicons/react/outline';
+import React, { useState } from 'react';
 import Highlight from 'react-syntax-highlighter';
 
 import Caption from '../Caption';

--- a/components/editor/CodeBlock.tsx
+++ b/components/editor/CodeBlock.tsx
@@ -1,5 +1,5 @@
-import { CheckIcon } from '@heroicons/react/outline';
 import React, { useState } from 'react';
+import { CheckIcon } from '@heroicons/react/outline';
 import Highlight from 'react-syntax-highlighter';
 
 import Caption from '../Caption';

--- a/components/editor/CodeBlock.tsx
+++ b/components/editor/CodeBlock.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import Highlight from 'react-syntax-highlighter';
 
+import { CheckIcon } from '@heroicons/react/outline';
+
 import Caption from '../Caption';
 import IconClipboard from '../icons/Clipboard';
 
@@ -335,7 +337,7 @@ export default function CodeBlock({
             >
               {showIsCopied && (
                 <span className='mr-2 inline-block pl-2 pt-1' data-testid='clicked-text'>
-                  Copied!
+                  <CheckIcon className='-mt-0.5 inline-block size-5 md:size-6 text-teal-600 dark:text-teal-400 flex-shrink-0' />
                 </span>
               )}
               <span className='inline-block pt-1'>


### PR DESCRIPTION
### Summary

**Replaced the 'Copied!' text from the installation guide box with a check sign**

Original Behaviour:
<img width="682" height="199" alt="Before" src="https://github.com/user-attachments/assets/4e12b251-7911-4b91-a1ef-059ff4b390c6" />

Changed Behaviour:
<img width="617" height="156" alt="After" src="https://github.com/user-attachments/assets/54be6733-f606-4d9d-be15-47c6081a20e6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the copy-to-clipboard confirmation in code blocks: the textual "Copied!" confirmation has been replaced with a check icon for a cleaner visual confirmation. Placement, sizing, copy behavior, and timing remain unchanged so users experience the same copy flow with an improved visual cue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->