### PR TITLE
fix: double border outline

### DIFF
--- a/components/form/Select.tsx
+++ b/components/form/Select.tsx
@@ -31,7 +31,7 @@ export default function Select({ className = '', onChange = () => {}, options, s
       data-testid='Select-form'
       onChange={handleOnChange}
       className={twMerge(
-        `form-select h-full pl-2 pr-8 inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-indigo-500 ${className}`
+        `form-select h-full pl-2 pr-8 inline-flex justify-center rounded-md border border-gray-300 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 shadow-sm px-4 py-2 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none ${className}`
       )}
       value={selected}
     >


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Fixes the double border on filters dropdown on blog page

**Before**
<img width="830" height="474" alt="image" src="https://github.com/user-attachments/assets/1e9664d6-928f-48ae-97d2-a8b85f252857" />


**After**
<img width="1275" height="836" alt="image" src="https://github.com/user-attachments/assets/b5a69a0a-5945-40e8-b577-659bebc169e2" />


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

Fixes - #5102 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Simplified focus state styling on select form controls: replaced the prominent multi-layer focus ring with a subtler focus outline to create a cleaner, more consistent visual appearance across forms. Padding, borders, hover styles and interactive behavior remain unchanged, so selection and change handling continue to work as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->