### PR TITLE
Enable URL-based pagination and improve blog SEO

### DIFF
--- a/components/navigation/Filter.tsx
+++ b/components/navigation/Filter.tsx
@@ -35,8 +35,17 @@ export default function Filter({ data, onFilter, checks, className }: FilterProp
   }, [route]);
 
   useEffect(() => {
-    onFilterApply(data, onFilter, routeQuery);
-  }, [routeQuery]);
+    // Filter routeQuery to only include keys defined in 'checks'
+    const validKeys = checks.map((c) => c.name);
+    const filteredQuery: Record<string, any> = {};
+    Object.keys(routeQuery).forEach((key) => {
+      if (validKeys.includes(key)) {
+        filteredQuery[key] = routeQuery[key];
+      }
+    });
+
+    onFilterApply(data, onFilter, filteredQuery);
+  }, [routeQuery, checks, data, onFilter]);
 
   return checks.map((check) => {
     let selected = '';
@@ -70,6 +79,10 @@ export default function Filter({ data, onFilter, checks, className }: FilterProp
             // Remove a specific filter upon clicking Select Placeholder option
             delete newQuery[check.name];
           }
+
+          // Reset pagination when filter changes
+          delete newQuery.page;
+
           if (newQuery) {
             const queryParams = new URLSearchParams(newQuery as { [key: string]: string }).toString();
 

--- a/components/navigation/Pagination.tsx
+++ b/components/navigation/Pagination.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+
+interface PaginationProps {
+    currentPage: number;
+    totalPages: number;
+    onPageChange: (page: number) => void;
+    className?: string;
+}
+
+/**
+ * @description Pagination component to navigate through pages of content.
+ * @param {number} currentPage - The current active page number (1-based).
+ * @param {number} totalPages - The total number of pages.
+ * @param {function} onPageChange - Callback function when a page is selected.
+ * @param {string} className - Optional CSS class for the container.
+ */
+export default function Pagination({ currentPage, totalPages, onPageChange, className = '' }: PaginationProps) {
+    if (totalPages <= 1) return null;
+
+    const getPageNumbers = () => {
+        const pageNumbers = [];
+        const maxPagesToShow = 5;
+
+        if (totalPages <= maxPagesToShow) {
+            for (let i = 1; i <= totalPages; i++) {
+                pageNumbers.push(i);
+            }
+        } else {
+            // Always include first, last, and pages around current
+            const leftSide = Math.max(2, currentPage - 1);
+            const rightSide = Math.min(totalPages - 1, currentPage + 1);
+
+            pageNumbers.push(1);
+            if (leftSide > 2) pageNumbers.push('...');
+
+            for (let i = leftSide; i <= rightSide; i++) {
+                pageNumbers.push(i);
+            }
+
+            if (rightSide < totalPages - 1) pageNumbers.push('...');
+            pageNumbers.push(totalPages);
+        }
+        return pageNumbers;
+    };
+
+    return (
+        <div className={`flex justify-center items-center space-x-2 mt-8 ${className}`}>
+            <button
+                type="button"
+                onClick={() => onPageChange(currentPage - 1)}
+                disabled={currentPage === 1}
+                className={`px-3 py-1 rounded-md border transition-colors duration-200 ${currentPage === 1
+                        ? 'text-gray-400 border-gray-200 cursor-not-allowed'
+                        : 'text-gray-700 border-gray-300 hover:bg-gray-100'
+                    }`}
+                aria-label="Previous Page"
+            >
+                Previous
+            </button>
+
+            {getPageNumbers().map((page, index) => (
+                <button
+                    key={index}
+                    type="button"
+                    onClick={() => typeof page === 'number' && onPageChange(page)}
+                    disabled={page === '...'}
+                    className={`px-3 py-1 rounded-md border transition-colors duration-200 ${page === currentPage
+                            ? 'bg-primary-500 text-white border-primary-500'
+                            : page === '...'
+                                ? 'text-gray-500 border-transparent cursor-default'
+                                : 'text-gray-700 border-gray-300 hover:bg-gray-100'
+                        }`}
+                    aria-current={page === currentPage ? 'page' : undefined}
+                >
+                    {page}
+                </button>
+            ))}
+
+            <button
+                type="button"
+                onClick={() => onPageChange(currentPage + 1)}
+                disabled={currentPage === totalPages}
+                className={`px-3 py-1 rounded-md border transition-colors duration-200 ${currentPage === totalPages
+                        ? 'text-gray-400 border-gray-200 cursor-not-allowed'
+                        : 'text-gray-700 border-gray-300 hover:bg-gray-100'
+                    }`}
+                aria-label="Next Page"
+            >
+                Next
+            </button>
+        </div>
+    );
+}

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -1,9 +1,10 @@
 import { useRouter } from 'next/router';
+import Head from 'next/head';
 import React, { useContext, useEffect, useState } from 'react';
 
 import Empty from '@/components/illustrations/Empty';
+
 import GenericLayout from '@/components/layout/GenericLayout';
-import Loader from '@/components/Loader';
 import BlogPostItem from '@/components/navigation/BlogPostItem';
 import Filter from '@/components/navigation/Filter';
 import Heading from '@/components/typography/Heading';
@@ -13,6 +14,7 @@ import BlogContext from '@/context/BlogContext';
 import type { IBlogPost } from '@/types/post';
 import { HeadingLevel, HeadingTypeStyle } from '@/types/typography/Heading';
 import { ParagraphTypeStyle } from '@/types/typography/Paragraph';
+import Pagination from '@/components/navigation/Pagination';
 
 /**
  * @description The BlogIndexPage is the blog index page of the website.
@@ -24,19 +26,29 @@ export default function BlogIndexPage() {
   const [posts, setPosts] = useState<IBlogPost[]>(
     navItems
       ? navItems.sort((i1: IBlogPost, i2: IBlogPost) => {
-          const i1Date = new Date(i1.date);
-          const i2Date = new Date(i2.date);
+        const i1Date = new Date(i1.date);
+        const i2Date = new Date(i2.date);
 
-          if (i1.featured && !i2.featured) return -1;
-          if (!i1.featured && i2.featured) return 1;
+        if (i1.featured && !i2.featured) return -1;
+        if (!i1.featured && i2.featured) return 1;
 
-          return i2Date.getTime() - i1Date.getTime();
-        })
+        return i2Date.getTime() - i1Date.getTime();
+      })
       : []
   );
-  const [isClient, setIsClient] = useState(false);
 
-  const onFilter = (data: IBlogPost[]) => setPosts(data);
+  const [currentPage, setCurrentPage] = useState(1);
+  const postsPerPage = 9;
+
+  const onFilter = (data: IBlogPost[]) => {
+    setPosts(data);
+  };
+
+  const indexOfLastPost = currentPage * postsPerPage;
+  const indexOfFirstPost = indexOfLastPost - postsPerPage;
+  const currentPosts = posts.slice(indexOfFirstPost, indexOfLastPost);
+  const totalPages = Math.ceil(posts.length / postsPerPage);
+
   const toFilter = [
     {
       name: 'type'
@@ -59,12 +71,45 @@ export default function BlogIndexPage() {
   const description = 'Find the latest and greatest stories from our community';
   const image = '/img/social/blog.webp';
 
+  const baseUrl = process.env.NEXT_PUBLIC_DEPLOY_PRIME_URL || process.env.NEXT_PUBLIC_DEPLOY_URL || 'http://localhost:3000';
+
   useEffect(() => {
-    setIsClient(true);
-  }, []);
+    if (!router.isReady) return;
+    const pageParam = router.query.page;
+    const page = parseInt(pageParam as string, 10);
+
+    if (!pageParam) {
+      if (currentPage !== 1) setCurrentPage(1);
+      return;
+    }
+
+    if (isNaN(page) || page < 1) {
+      const newQuery = { ...router.query };
+      delete newQuery.page;
+      router.replace({
+        pathname: router.pathname,
+        query: newQuery,
+      }, undefined, { shallow: true });
+      return;
+    }
+
+    if (page !== currentPage) {
+      setCurrentPage(page);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [router.isReady, router.query.page, currentPage]);
 
   return (
     <GenericLayout title='Blog' description={description} image={image} wide>
+      <Head>
+        {currentPage > 1 && (
+          <link rel="prev" href={`${baseUrl}${router.pathname}?page=${currentPage - 1}`} />
+        )}
+        {currentPage < totalPages && (
+          <link rel="next" href={`${baseUrl}${router.pathname}?page=${currentPage + 1}`} />
+        )}
+        <link rel="canonical" href={`${baseUrl}${router.pathname}${currentPage > 1 ? `?page=${currentPage}` : ''}`} />
+      </Head>
       <div className='relative px-4 pb-20 pt-8 sm:px-6 lg:px-8 lg:pb-28 lg:pt-12' id='main-content'>
         <div className='absolute inset-0'>
           <div className='h-1/3 bg-white sm:h-2/3'></div>
@@ -120,18 +165,28 @@ export default function BlogIndexPage() {
                 <p className='mx-auto mt-3 max-w-2xl text-xl leading-7 text-gray-500'>No post matches your filter</p>
               </div>
             )}
-            {Object.keys(posts).length > 0 && isClient && (
-              <ul className='mx-auto mt-12 grid max-w-lg gap-5 lg:max-w-none lg:grid-cols-3'>
-                {posts.map((post, index) => (
-                  <BlogPostItem key={index} post={post} />
-                ))}
-              </ul>
+            {Object.keys(posts).length > 0 && (
+              <>
+                <ul className='mx-auto mt-12 grid max-w-lg gap-5 lg:max-w-none lg:grid-cols-3'>
+                  {currentPosts.map((post, index) => (
+                    <BlogPostItem key={index} post={post} />
+                  ))}
+                </ul>
+                <div className='mt-10'>
+                  <Pagination
+                    currentPage={currentPage}
+                    totalPages={totalPages}
+                    onPageChange={(page) => {
+                      router.push({
+                        pathname: router.pathname,
+                        query: { ...router.query, page },
+                      }, undefined, { shallow: true });
+                    }}
+                  />
+                </div>
+              </>
             )}
-            {Object.keys(posts).length > 0 && !isClient && (
-              <div className='h-screen w-full'>
-                <Loader loaderText='Loading Blogs' className='mx-auto my-60' pulsating />
-              </div>
-            )}
+
           </div>
         </div>
       </div>


### PR DESCRIPTION
Closes #5105

## Description
This PR refactors the Blog index page to use URL-based pagination instead of client-side-only state.

Users can now bookmark and share paginated blog pages (e.g. /blog?page=2), and blog content is rendered using SSR to improve SEO and performance.

## Key Changes
- Synced pagination state with the `page` URL query parameter
- Updated pagination navigation to use router-based URL changes
- Reset pagination when filters are applied
- Enabled SSR for blog list rendering
- Added pagination-aware SEO meta tags (canonical, prev, next)
- Handled invalid page values by redirecting to page 1
- Improved UX by scrolling to top on page changes

## How to Test
1. Open `/blog`
2. Navigate using pagination and observe URL updates
3. Refresh or open the URL in a new tab
4. Apply filters and confirm pagination resets
5. Try invalid page values (e.g. ?page=abc)

## Notes
This change is backward compatible and does not introduce breaking changes.
Happy to update the implementation based on maintainer feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination controls to the blog page with dynamic page numbers that collapse with ellipses when many pages exist.
  * Pagination state is now preserved in the URL, allowing direct links to specific pages.
  * Added SEO metadata including canonical and adjacent page links.

* **Bug Fixes**
  * Pagination resets automatically when filters are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->