### PR TITLE
fix: memory leak and layout shift issue

### DIFF
--- a/pages/finance.tsx
+++ b/pages/finance.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import AsyncAPISummary from '../components/FinancialSummary/AsyncAPISummary';
 import BarChartComponent from '../components/FinancialSummary/BarChartComponent';
@@ -16,21 +16,24 @@ import Container from '../components/layout/Container';
  * bar chart, success stories, and contact us components.
  */
 export default function FinancialSummary() {
-  const [windowWidth, setWindowWidth] = useState<number>(0);
+  // Initialize as null to avoid hydration/layout shift
+  const [windowWidth, setWindowWidth] = useState<number | null>(null);
+   const handleResize = () => {
+    console.log("resized")
+      setWindowWidth(window.innerWidth);
+    };
 
-  const handleResizeRef = useRef<() => void>(null!);
-
-  handleResizeRef.current = () => {
-    setWindowWidth(window.innerWidth);
-  };
-
-  // Handle window resize event to update the window width state value for responsive design purposes
+  // Properly scoped resize handler with correct cleanup
   useEffect(() => {
-    handleResizeRef.current!();
-    window.addEventListener('resize', handleResizeRef.current!);
+
+
+    // Set initial width on mount
+    handleResize();
+
+    window.addEventListener('resize', handleResize);
 
     return () => {
-      window.removeEventListener('resize', handleResizeRef.current!);
+      window.removeEventListener('resize', handleResize);
     };
   }, []);
 
@@ -41,8 +44,9 @@ export default function FinancialSummary() {
     <>
       <Head>
         <title>{title}</title>
-        <meta name='description' content={description} />
+        <meta name="description" content={description} />
       </Head>
+
       <AsyncAPISummary />
       <SponsorshipTiers />
       <OtherFormsComponent />
@@ -53,7 +57,18 @@ export default function FinancialSummary() {
     </>
   );
 
+  // Avoid rendering until window size is known (prevents CLS)
+  if (windowWidth === null) {
+    return null; // or a skeleton/loading placeholder
+  }
+
   const shouldUseContainer = windowWidth > 1700;
 
-  return <div>{shouldUseContainer ? <Container wide>{renderComponents()}</Container> : renderComponents()}</div>;
+  return (
+    <div className="w-full">
+  <div className="2xl:container 2xl:mx-auto 2xl:px-8">
+    {renderComponents()}
+  </div>
+</div>
+  );
 }


### PR DESCRIPTION
<!--
Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.


**Description**
Issue no : #5114
- Fixes a memory leak on the Finance page by ensuring the same resize handler reference is used for both `addEventListener` and `removeEventListener`.
- Prevents duplicate `resize` listeners from being attached when navigating away from and back to the page.
- Removes JavaScript-driven layout switching and uses CSS breakpoints instead, eliminating layout shift after hydration.

**Related issue(s)**

- Fixes #<issue-number>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced the finance page's layout stability through improved window resize event handling, ensuring consistent and reliable rendering when users resize their browser window or visit at different viewport widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->