### PR TITLE
fix: improve visibility of newsletter input fields in dark mode #5128

### DIFF
--- a/components/InputBox.tsx
+++ b/components/InputBox.tsx
@@ -5,7 +5,7 @@ import type { InputBoxProps } from '@/types/components/InputBoxPropsType';
 /**
  * This component renders input box.
  */
-export default function InputBox({ inputType, inputName, placeholder, inputValue, setInput }: InputBoxProps) {
+export default function InputBox({ inputType, inputName, placeholder, inputValue, setInput, dark = false }: InputBoxProps) {
   return (
     <input
       type={inputType}
@@ -13,7 +13,9 @@ export default function InputBox({ inputType, inputName, placeholder, inputValue
       placeholder={placeholder}
       value={inputValue}
       onChange={(e) => setInput(e.target.value)}
-      className='form-input mt-2 block w-full rounded-md sm:text-sm sm:leading-5 md:mt-0 md:flex-1'
+      className={`form-input mt-2 block w-full rounded-md sm:text-sm sm:leading-5 md:mt-0 md:flex-1 ${
+        dark ? 'border-zinc-700 bg-zinc-900 text-white placeholder-zinc-500 focus:border-indigo-500 focus:ring-indigo-500' : 'border-gray-300 text-gray-900'
+      }`}
       required
       data-testid={`NewsletterSubscribe-${inputType}-input`}
     />

--- a/components/InputBox.tsx
+++ b/components/InputBox.tsx
@@ -5,7 +5,14 @@ import type { InputBoxProps } from '@/types/components/InputBoxPropsType';
 /**
  * This component renders input box.
  */
-export default function InputBox({ inputType, inputName, placeholder, inputValue, setInput, dark = false }: InputBoxProps) {
+export default function InputBox({
+  inputType,
+  inputName,
+  placeholder,
+  inputValue,
+  setInput,
+  dark = false,
+}: InputBoxProps) {
   return (
     <input
       type={inputType}
@@ -14,7 +21,9 @@ export default function InputBox({ inputType, inputName, placeholder, inputValue
       value={inputValue}
       onChange={(e) => setInput(e.target.value)}
       className={`form-input mt-2 block w-full rounded-md sm:text-sm sm:leading-5 md:mt-0 md:flex-1 ${
-        dark ? 'border-zinc-700 bg-zinc-900 text-white placeholder-zinc-500 focus:border-indigo-500 focus:ring-indigo-500' : 'border-gray-300 text-gray-900'
+        dark
+          ? 'border-zinc-700 bg-zinc-900 text-white placeholder-zinc-500 focus:border-indigo-500 focus:ring-indigo-500'
+          : 'border-gray-300 text-gray-900'
       }`}
       required
       data-testid={`NewsletterSubscribe-${inputType}-input`}

--- a/components/InputBox.tsx
+++ b/components/InputBox.tsx
@@ -11,7 +11,7 @@ export default function InputBox({
   placeholder,
   inputValue,
   setInput,
-  dark = false,
+  dark = false
 }: InputBoxProps) {
   return (
     <input

--- a/components/NewsletterSubscribe.tsx
+++ b/components/NewsletterSubscribe.tsx
@@ -17,7 +17,7 @@ enum FormStatus {
   NORMAL = 'normal',
   LOADING = 'loading',
   SUCCESS = 'success',
-  ERROR = 'error'
+  ERROR = 'error',
 }
 
 interface NewsletterSubscribeProps {
@@ -46,7 +46,7 @@ export default function NewsletterSubscribe({
   title = 'Subscribe to our newsletter to receive news about AsyncAPI.',
   subtitle = 'We respect your inbox. No spam, promise ✌️',
   type = 'Newsletter',
-  errorSubtitle = 'Subscription failed, please let us know about it by submitting a bug'
+  errorSubtitle = 'Subscription failed, please let us know about it by submitting a bug',
 }: NewsletterSubscribeProps) {
   const [email, setEmail] = useState<string>('');
   const [name, setName] = useState<string>('');
@@ -70,15 +70,15 @@ export default function NewsletterSubscribe({
     const data = {
       name,
       email,
-      interest: type
+      interest: type,
     };
 
     fetch('/.netlify/functions/newsletter_subscription', {
       method: 'POST',
       body: JSON.stringify(data),
       headers: {
-        'Content-Type': 'application/json'
-      }
+        'Content-Type': 'application/json',
+      },
     }).then((res) => {
       if (res.status === 200) {
         setFormStatus(FormStatus.SUCCESS);
@@ -92,11 +92,16 @@ export default function NewsletterSubscribe({
 
   if (status === FormStatus.SUCCESS) {
     return (
-      <div className={className} data-testid='NewsletterSubscribe-main'>
-        <Heading level={HeadingLevel.h3} textColor={headTextColor} typeStyle={HeadingTypeStyle.lg} className='mb-4'>
+      <div className={className} data-testid="NewsletterSubscribe-main">
+        <Heading
+          level={HeadingLevel.h3}
+          textColor={headTextColor}
+          typeStyle={HeadingTypeStyle.lg}
+          className="mb-4"
+        >
           {ready ? t('successTitle') : 'Thank you for subscribing!'}
         </Heading>
-        <Paragraph className='mb-8' textColor={paragraphTextColor}>
+        <Paragraph className="mb-8" textColor={paragraphTextColor}>
           {ready ? t('subtitle') : subtitle}
         </Paragraph>
       </div>
@@ -105,13 +110,21 @@ export default function NewsletterSubscribe({
 
   if (status === FormStatus.ERROR) {
     return (
-      <div className={className} data-testid='NewsletterSubscribe-main'>
-        <Heading level={HeadingLevel.h3} textColor={headTextColor} typeStyle={HeadingTypeStyle.lg} className='mb-4'>
+      <div className={className} data-testid="NewsletterSubscribe-main">
+        <Heading
+          level={HeadingLevel.h3}
+          textColor={headTextColor}
+          typeStyle={HeadingTypeStyle.lg}
+          className="mb-4"
+        >
           {ready ? t('errorTitle') : 'Something went wrong'}
         </Heading>
-        <Paragraph className='mb-8' textColor={paragraphTextColor}>
+        <Paragraph className="mb-8" textColor={paragraphTextColor}>
           {ready ? t('errorSubtitle') : errorSubtitle}{' '}
-          <TextLink href='https://github.com/asyncapi/website/issues/new?template=bug.md' target='_blank'>
+          <TextLink
+            href="https://github.com/asyncapi/website/issues/new?template=bug.md"
+            target="_blank"
+          >
             {ready ? t('errorLinkText') : 'here'}
           </TextLink>
         </Paragraph>
@@ -120,20 +133,32 @@ export default function NewsletterSubscribe({
   }
 
   return (
-    <div className={className} data-testid='NewsletterSubscribe-main'>
-      <Heading level={HeadingLevel.h3} textColor={headTextColor} typeStyle={HeadingTypeStyle.lg} className='mb-4'>
+    <div className={className} data-testid="NewsletterSubscribe-main">
+      <Heading
+        level={HeadingLevel.h3}
+        textColor={headTextColor}
+        typeStyle={HeadingTypeStyle.lg}
+        className="mb-4"
+      >
         {ready ? t('title') : title}
       </Heading>
-      <Paragraph className='mb-8' textColor={paragraphTextColor}>
+      <Paragraph className="mb-8" textColor={paragraphTextColor}>
         {ready ? t('subtitle') : subtitle}
       </Paragraph>
       {status === 'loading' ? (
-        <Loader loaderText={'Waiting for response...'} loaderIcon={<IconCircularLoader dark />} dark={dark} />
+        <Loader
+          loaderText={'Waiting for response...'}
+          loaderIcon={<IconCircularLoader dark />}
+          dark={dark}
+        />
       ) : (
-        <form className='flex flex-col gap-4 md:flex-row' onSubmit={handleSubmit}>
+        <form
+          className="flex flex-col gap-4 md:flex-row"
+          onSubmit={handleSubmit}
+        >
           <InputBox
             inputType={InputTypes.TEXT}
-            inputName='name'
+            inputName="name"
             placeholder={ready ? t('nameInput') : 'Your name'}
             inputValue={name}
             setInput={setName}
@@ -141,7 +166,7 @@ export default function NewsletterSubscribe({
           />
           <InputBox
             inputType={InputTypes.EMAIL}
-            inputName='email'
+            inputName="email"
             placeholder={ready ? t('emailInput') : 'Your email'}
             inputValue={email}
             setInput={setEmail}
@@ -150,8 +175,8 @@ export default function NewsletterSubscribe({
           <Button
             type={ButtonType.SUBMIT}
             text={ready ? t('subscribeBtn') : 'Subscribe'}
-            className='mt-2 w-full md:mr-2 md:mt-0 md:flex-1'
-            href=''
+            className="mt-2 w-full md:mr-2 md:mt-0 md:flex-1"
+            href=""
           />
         </form>
       )}

--- a/components/NewsletterSubscribe.tsx
+++ b/components/NewsletterSubscribe.tsx
@@ -17,7 +17,7 @@ enum FormStatus {
   NORMAL = 'normal',
   LOADING = 'loading',
   SUCCESS = 'success',
-  ERROR = 'error',
+  ERROR = 'error'
 }
 
 interface NewsletterSubscribeProps {
@@ -46,7 +46,7 @@ export default function NewsletterSubscribe({
   title = 'Subscribe to our newsletter to receive news about AsyncAPI.',
   subtitle = 'We respect your inbox. No spam, promise ✌️',
   type = 'Newsletter',
-  errorSubtitle = 'Subscription failed, please let us know about it by submitting a bug',
+  errorSubtitle = 'Subscription failed, please let us know about it by submitting a bug'
 }: NewsletterSubscribeProps) {
   const [email, setEmail] = useState<string>('');
   const [name, setName] = useState<string>('');
@@ -70,15 +70,15 @@ export default function NewsletterSubscribe({
     const data = {
       name,
       email,
-      interest: type,
+      interest: type
     };
 
     fetch('/.netlify/functions/newsletter_subscription', {
       method: 'POST',
       body: JSON.stringify(data),
       headers: {
-        'Content-Type': 'application/json',
-      },
+        'Content-Type': 'application/json'
+      }
     }).then((res) => {
       if (res.status === 200) {
         setFormStatus(FormStatus.SUCCESS);
@@ -92,16 +92,11 @@ export default function NewsletterSubscribe({
 
   if (status === FormStatus.SUCCESS) {
     return (
-      <div className={className} data-testid="NewsletterSubscribe-main">
-        <Heading
-          level={HeadingLevel.h3}
-          textColor={headTextColor}
-          typeStyle={HeadingTypeStyle.lg}
-          className="mb-4"
-        >
+      <div className={className} data-testid='NewsletterSubscribe-main'>
+        <Heading level={HeadingLevel.h3} textColor={headTextColor} typeStyle={HeadingTypeStyle.lg} className='mb-4'>
           {ready ? t('successTitle') : 'Thank you for subscribing!'}
         </Heading>
-        <Paragraph className="mb-8" textColor={paragraphTextColor}>
+        <Paragraph className='mb-8' textColor={paragraphTextColor}>
           {ready ? t('subtitle') : subtitle}
         </Paragraph>
       </div>
@@ -110,21 +105,13 @@ export default function NewsletterSubscribe({
 
   if (status === FormStatus.ERROR) {
     return (
-      <div className={className} data-testid="NewsletterSubscribe-main">
-        <Heading
-          level={HeadingLevel.h3}
-          textColor={headTextColor}
-          typeStyle={HeadingTypeStyle.lg}
-          className="mb-4"
-        >
+      <div className={className} data-testid='NewsletterSubscribe-main'>
+        <Heading level={HeadingLevel.h3} textColor={headTextColor} typeStyle={HeadingTypeStyle.lg} className='mb-4'>
           {ready ? t('errorTitle') : 'Something went wrong'}
         </Heading>
-        <Paragraph className="mb-8" textColor={paragraphTextColor}>
+        <Paragraph className='mb-8' textColor={paragraphTextColor}>
           {ready ? t('errorSubtitle') : errorSubtitle}{' '}
-          <TextLink
-            href="https://github.com/asyncapi/website/issues/new?template=bug.md"
-            target="_blank"
-          >
+          <TextLink href='https://github.com/asyncapi/website/issues/new?template=bug.md' target='_blank'>
             {ready ? t('errorLinkText') : 'here'}
           </TextLink>
         </Paragraph>
@@ -133,32 +120,20 @@ export default function NewsletterSubscribe({
   }
 
   return (
-    <div className={className} data-testid="NewsletterSubscribe-main">
-      <Heading
-        level={HeadingLevel.h3}
-        textColor={headTextColor}
-        typeStyle={HeadingTypeStyle.lg}
-        className="mb-4"
-      >
+    <div className={className} data-testid='NewsletterSubscribe-main'>
+      <Heading level={HeadingLevel.h3} textColor={headTextColor} typeStyle={HeadingTypeStyle.lg} className='mb-4'>
         {ready ? t('title') : title}
       </Heading>
-      <Paragraph className="mb-8" textColor={paragraphTextColor}>
+      <Paragraph className='mb-8' textColor={paragraphTextColor}>
         {ready ? t('subtitle') : subtitle}
       </Paragraph>
       {status === 'loading' ? (
-        <Loader
-          loaderText={'Waiting for response...'}
-          loaderIcon={<IconCircularLoader dark />}
-          dark={dark}
-        />
+        <Loader loaderText={'Waiting for response...'} loaderIcon={<IconCircularLoader dark />} dark={dark} />
       ) : (
-        <form
-          className="flex flex-col gap-4 md:flex-row"
-          onSubmit={handleSubmit}
-        >
+        <form className='flex flex-col gap-4 md:flex-row' onSubmit={handleSubmit}>
           <InputBox
             inputType={InputTypes.TEXT}
-            inputName="name"
+            inputName='name'
             placeholder={ready ? t('nameInput') : 'Your name'}
             inputValue={name}
             setInput={setName}
@@ -166,7 +141,7 @@ export default function NewsletterSubscribe({
           />
           <InputBox
             inputType={InputTypes.EMAIL}
-            inputName="email"
+            inputName='email'
             placeholder={ready ? t('emailInput') : 'Your email'}
             inputValue={email}
             setInput={setEmail}
@@ -175,8 +150,8 @@ export default function NewsletterSubscribe({
           <Button
             type={ButtonType.SUBMIT}
             text={ready ? t('subscribeBtn') : 'Subscribe'}
-            className="mt-2 w-full md:mr-2 md:mt-0 md:flex-1"
-            href=""
+            className='mt-2 w-full md:mr-2 md:mt-0 md:flex-1'
+            href=''
           />
         </form>
       )}

--- a/components/NewsletterSubscribe.tsx
+++ b/components/NewsletterSubscribe.tsx
@@ -137,6 +137,7 @@ export default function NewsletterSubscribe({
             placeholder={ready ? t('nameInput') : 'Your name'}
             inputValue={name}
             setInput={setName}
+            dark={dark}
           />
           <InputBox
             inputType={InputTypes.EMAIL}
@@ -144,6 +145,7 @@ export default function NewsletterSubscribe({
             placeholder={ready ? t('emailInput') : 'Your email'}
             inputValue={email}
             setInput={setEmail}
+            dark={dark}
           />
           <Button
             type={ButtonType.SUBMIT}

--- a/types/components/InputBoxPropsType.ts
+++ b/types/components/InputBoxPropsType.ts
@@ -1,7 +1,7 @@
 export enum InputTypes {
   TEXT = 'text',
   EMAIL = 'email',
-  NUMBER = 'number',
+  NUMBER = 'number'
 }
 export interface InputBoxProps {
   // eslint-disable-next-line prettier/prettier

--- a/types/components/InputBoxPropsType.ts
+++ b/types/components/InputBoxPropsType.ts
@@ -20,4 +20,7 @@ export interface InputBoxProps {
 
   /** The function to set value of the input. */
   setInput: (value: string) => void;
+
+  /** If true, the theme of the component will be dark. */
+  dark?: boolean;
 }

--- a/types/components/InputBoxPropsType.ts
+++ b/types/components/InputBoxPropsType.ts
@@ -1,7 +1,7 @@
 export enum InputTypes {
   TEXT = 'text',
   EMAIL = 'email',
-  NUMBER = 'number'
+  NUMBER = 'number',
 }
 export interface InputBoxProps {
   // eslint-disable-next-line prettier/prettier


### PR DESCRIPTION
Refactor InputBox component to support a dark mode prop. Apply high-contrast styles (border, placeholder, focus) when the dark prop is active to ensure the newsletter input fields are clearly visible on dark backgrounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dark mode support for input fields and the newsletter subscription form so inputs automatically adapt styling when the app is in dark theme, improving visual consistency across light/dark modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->