### PR TITLE
fix:react hook dependency and linting warns

### DIFF
--- a/components/campaigns/AnnouncementHero.tsx
+++ b/components/campaigns/AnnouncementHero.tsx
@@ -21,7 +21,7 @@ interface IAnnouncementHeroProps {
 export default function AnnouncementHero({ className = '', small = false }: IAnnouncementHeroProps) {
   const [activeIndex, setActiveIndex] = useState(0);
 
-  const visibleBanners = useMemo(() => banners.filter((banner) => shouldShowBanner(banner.cfpDeadline)), [banners]);
+  const visibleBanners = useMemo(() => banners.filter((banner) => shouldShowBanner(banner.cfpDeadline)), []);
   const numberOfVisibleBanners = visibleBanners.length;
 
   const goToPrevious = () => {

--- a/components/dashboard/table/Filters.tsx
+++ b/components/dashboard/table/Filters.tsx
@@ -39,7 +39,7 @@ function useOutsideAlerter(ref: RefObject<any>, setOpen: (open: boolean) => void
       // Unbind the event listener on clean up
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [ref]);
+  }, [setOpen, ref]);
 }
 
 /**

--- a/components/navigation/DocsNav.tsx
+++ b/components/navigation/DocsNav.tsx
@@ -76,7 +76,7 @@ export default function DocsNav({ item, active, onClick = () => {} }: DocsNavPro
 
   useEffect(() => {
     setOpenSubCategory(active.startsWith(item.item.slug));
-  }, [active]);
+  }, [active, item.item.slug]);
 
   return (
     <li className='mb-4' key={item.item.title} data-testid='DocsNav-item'>

--- a/components/tools/ToolsCard.tsx
+++ b/components/tools/ToolsCard.tsx
@@ -32,7 +32,7 @@ export default function ToolsCard({ toolData }: ToolsCardProp) {
     if (descriptionRef.current) {
       setIsTruncated(descriptionRef.current?.scrollHeight! > descriptionRef.current?.clientHeight!);
     }
-  }, [descriptionRef.current]);
+  }, []);
 
   let onGit = false;
 

--- a/components/tools/ToolsDashboard.tsx
+++ b/components/tools/ToolsDashboard.tsx
@@ -163,7 +163,7 @@ export default function ToolsDashboard() {
         document.documentElement.style.scrollPaddingTop = '0';
       }
     }
-  }, []);
+  }, [toolsList]);
   // Function to update the list of tools according to the current filters applied
   const clearFilters = () => {
     setOpenFilter(false);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
This PR resolves multiple `react-hooks/exhaustive-deps`  ESLint warnings across the codebase by aligning hook dependency arrays with React’s hook semantics.

- Removed invalid dependencies involving static imports like using  banner as dep in file AnnouncementHero.tsx
- Added missing dependencies in DocsNav.tsx , ToolsDashboard.tsx, Filters.tsx
- Removed stable dependencies like refs(do not trigger re-renders so pointless using as dep) which were used as dep in ToolsCard.tsx

**Test Result**
<img width="1027" height="303" alt="Screenshot From 2026-02-10 18-32-19" src="https://github.com/user-attachments/assets/95f684e2-d855-40e1-8cc7-1d332aab0052" />



**Related issue(s)**
<!-- `Fixes: #5070 ` -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation state synchronization when switching between different sections
  * Corrected outside-click detection behavior in filters
  * Improved description truncation state handling

* **Refactoring**
  * Optimized component re-rendering behavior for better performance and state consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #5070 