### PR TITLE
chore: remove leftover console.log statements from production files

### DIFF
--- a/netlify/edge-functions/serve-definitions.ts
+++ b/netlify/edge-functions/serve-definitions.ts
@@ -56,7 +56,6 @@ export default async (request: Request, context: Context) => {
         default:
           // Notifying NR of the error.
           metricName = "asyncapi.jsonschema.download.error";
-          console.log(`Error downloading JSON Schema file: ${  response.status  } ${  response.statusText}`);
           break;
       }
     }

--- a/netlify/functions/save-discussion-background/index.ts
+++ b/netlify/functions/save-discussion-background/index.ts
@@ -57,7 +57,6 @@ async function handleDialogSubmission(payload: any) {
   try {
     const discussion = await Slack.getSlackDiscussion(channelId, threadTS);
 
-    console.log('got the following discussion', discussion);
     const categoryId = payload.submission.category;
 
     if (!discussion) return;
@@ -79,7 +78,6 @@ async function handleDialogSubmission(payload: any) {
         }
       }
     }
-    console.log(payload);
     const message = `Thanks to <@${payload.user.id}>, this discussion has been preserved here: ${discussionURL}`;
 
     await Slack.postReplyInThread(message, channelId, threadTS);


### PR DESCRIPTION
Fixes #5131

## Description
This PR removes leftover `console.log` debugging statements from production Netlify functions.  
These logs were useful during development but are no longer necessary in runtime code.

## Changes
- Removed debug logging from:
  - netlify/functions/save-discussion-background/index.ts
  - netlify/edge-functions/serve-definitions.ts
- Only standalone logging statements were removed; no runtime logic was modified.

## Verification
- Verified via repository-wide search that no `console.log`, `console.debug`, or `console.info` statements remain in production files.
- Confirmed changes using `git diff` to ensure no unintended modifications were introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed debug console logging statements from internal functions to reduce unnecessary console output. All functionality and error handling mechanisms remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->