### PR TITLE
fix: animate navbar dropdown chevrons on hover

### DIFF
--- a/components/InputBox.tsx
+++ b/components/InputBox.tsx
@@ -5,7 +5,7 @@ import type { InputBoxProps } from '@/types/components/InputBoxPropsType';
 /**
  * This component renders input box.
  */
-export default function InputBox({ inputType, inputName, placeholder, inputValue, setInput }: InputBoxProps) {
+export default function InputBox({ inputType, inputName, placeholder, inputValue, setInput, dark = false }: InputBoxProps) {
   return (
     <input
       type={inputType}
@@ -13,7 +13,9 @@ export default function InputBox({ inputType, inputName, placeholder, inputValue
       placeholder={placeholder}
       value={inputValue}
       onChange={(e) => setInput(e.target.value)}
-      className='form-input mt-2 block w-full rounded-md sm:text-sm sm:leading-5 md:mt-0 md:flex-1'
+      className={`form-input mt-2 block w-full rounded-md sm:text-sm sm:leading-5 md:mt-0 md:flex-1 ${
+        dark ? 'border-zinc-700 bg-zinc-900 text-white placeholder-zinc-500 focus:border-indigo-500 focus:ring-indigo-500' : 'border-gray-300 text-gray-900'
+      }`}
       required
       data-testid={`NewsletterSubscribe-${inputType}-input`}
     />

--- a/components/InputBox.tsx
+++ b/components/InputBox.tsx
@@ -5,7 +5,14 @@ import type { InputBoxProps } from '@/types/components/InputBoxPropsType';
 /**
  * This component renders input box.
  */
-export default function InputBox({ inputType, inputName, placeholder, inputValue, setInput, dark = false }: InputBoxProps) {
+export default function InputBox({
+  inputType,
+  inputName,
+  placeholder,
+  inputValue,
+  setInput,
+  dark = false,
+}: InputBoxProps) {
   return (
     <input
       type={inputType}
@@ -14,7 +21,9 @@ export default function InputBox({ inputType, inputName, placeholder, inputValue
       value={inputValue}
       onChange={(e) => setInput(e.target.value)}
       className={`form-input mt-2 block w-full rounded-md sm:text-sm sm:leading-5 md:mt-0 md:flex-1 ${
-        dark ? 'border-zinc-700 bg-zinc-900 text-white placeholder-zinc-500 focus:border-indigo-500 focus:ring-indigo-500' : 'border-gray-300 text-gray-900'
+        dark
+          ? 'border-zinc-700 bg-zinc-900 text-white placeholder-zinc-500 focus:border-indigo-500 focus:ring-indigo-500'
+          : 'border-gray-300 text-gray-900'
       }`}
       required
       data-testid={`NewsletterSubscribe-${inputType}-input`}

--- a/components/InputBox.tsx
+++ b/components/InputBox.tsx
@@ -11,7 +11,7 @@ export default function InputBox({
   placeholder,
   inputValue,
   setInput,
-  dark = false,
+  dark = false
 }: InputBoxProps) {
   return (
     <input

--- a/components/NewsletterSubscribe.tsx
+++ b/components/NewsletterSubscribe.tsx
@@ -17,7 +17,7 @@ enum FormStatus {
   NORMAL = 'normal',
   LOADING = 'loading',
   SUCCESS = 'success',
-  ERROR = 'error'
+  ERROR = 'error',
 }
 
 interface NewsletterSubscribeProps {
@@ -46,7 +46,7 @@ export default function NewsletterSubscribe({
   title = 'Subscribe to our newsletter to receive news about AsyncAPI.',
   subtitle = 'We respect your inbox. No spam, promise ✌️',
   type = 'Newsletter',
-  errorSubtitle = 'Subscription failed, please let us know about it by submitting a bug'
+  errorSubtitle = 'Subscription failed, please let us know about it by submitting a bug',
 }: NewsletterSubscribeProps) {
   const [email, setEmail] = useState<string>('');
   const [name, setName] = useState<string>('');
@@ -70,15 +70,15 @@ export default function NewsletterSubscribe({
     const data = {
       name,
       email,
-      interest: type
+      interest: type,
     };
 
     fetch('/.netlify/functions/newsletter_subscription', {
       method: 'POST',
       body: JSON.stringify(data),
       headers: {
-        'Content-Type': 'application/json'
-      }
+        'Content-Type': 'application/json',
+      },
     }).then((res) => {
       if (res.status === 200) {
         setFormStatus(FormStatus.SUCCESS);
@@ -92,11 +92,16 @@ export default function NewsletterSubscribe({
 
   if (status === FormStatus.SUCCESS) {
     return (
-      <div className={className} data-testid='NewsletterSubscribe-main'>
-        <Heading level={HeadingLevel.h3} textColor={headTextColor} typeStyle={HeadingTypeStyle.lg} className='mb-4'>
+      <div className={className} data-testid="NewsletterSubscribe-main">
+        <Heading
+          level={HeadingLevel.h3}
+          textColor={headTextColor}
+          typeStyle={HeadingTypeStyle.lg}
+          className="mb-4"
+        >
           {ready ? t('successTitle') : 'Thank you for subscribing!'}
         </Heading>
-        <Paragraph className='mb-8' textColor={paragraphTextColor}>
+        <Paragraph className="mb-8" textColor={paragraphTextColor}>
           {ready ? t('subtitle') : subtitle}
         </Paragraph>
       </div>
@@ -105,13 +110,21 @@ export default function NewsletterSubscribe({
 
   if (status === FormStatus.ERROR) {
     return (
-      <div className={className} data-testid='NewsletterSubscribe-main'>
-        <Heading level={HeadingLevel.h3} textColor={headTextColor} typeStyle={HeadingTypeStyle.lg} className='mb-4'>
+      <div className={className} data-testid="NewsletterSubscribe-main">
+        <Heading
+          level={HeadingLevel.h3}
+          textColor={headTextColor}
+          typeStyle={HeadingTypeStyle.lg}
+          className="mb-4"
+        >
           {ready ? t('errorTitle') : 'Something went wrong'}
         </Heading>
-        <Paragraph className='mb-8' textColor={paragraphTextColor}>
+        <Paragraph className="mb-8" textColor={paragraphTextColor}>
           {ready ? t('errorSubtitle') : errorSubtitle}{' '}
-          <TextLink href='https://github.com/asyncapi/website/issues/new?template=bug.md' target='_blank'>
+          <TextLink
+            href="https://github.com/asyncapi/website/issues/new?template=bug.md"
+            target="_blank"
+          >
             {ready ? t('errorLinkText') : 'here'}
           </TextLink>
         </Paragraph>
@@ -120,20 +133,32 @@ export default function NewsletterSubscribe({
   }
 
   return (
-    <div className={className} data-testid='NewsletterSubscribe-main'>
-      <Heading level={HeadingLevel.h3} textColor={headTextColor} typeStyle={HeadingTypeStyle.lg} className='mb-4'>
+    <div className={className} data-testid="NewsletterSubscribe-main">
+      <Heading
+        level={HeadingLevel.h3}
+        textColor={headTextColor}
+        typeStyle={HeadingTypeStyle.lg}
+        className="mb-4"
+      >
         {ready ? t('title') : title}
       </Heading>
-      <Paragraph className='mb-8' textColor={paragraphTextColor}>
+      <Paragraph className="mb-8" textColor={paragraphTextColor}>
         {ready ? t('subtitle') : subtitle}
       </Paragraph>
       {status === 'loading' ? (
-        <Loader loaderText={'Waiting for response...'} loaderIcon={<IconCircularLoader dark />} dark={dark} />
+        <Loader
+          loaderText={'Waiting for response...'}
+          loaderIcon={<IconCircularLoader dark />}
+          dark={dark}
+        />
       ) : (
-        <form className='flex flex-col gap-4 md:flex-row' onSubmit={handleSubmit}>
+        <form
+          className="flex flex-col gap-4 md:flex-row"
+          onSubmit={handleSubmit}
+        >
           <InputBox
             inputType={InputTypes.TEXT}
-            inputName='name'
+            inputName="name"
             placeholder={ready ? t('nameInput') : 'Your name'}
             inputValue={name}
             setInput={setName}
@@ -141,7 +166,7 @@ export default function NewsletterSubscribe({
           />
           <InputBox
             inputType={InputTypes.EMAIL}
-            inputName='email'
+            inputName="email"
             placeholder={ready ? t('emailInput') : 'Your email'}
             inputValue={email}
             setInput={setEmail}
@@ -150,8 +175,8 @@ export default function NewsletterSubscribe({
           <Button
             type={ButtonType.SUBMIT}
             text={ready ? t('subscribeBtn') : 'Subscribe'}
-            className='mt-2 w-full md:mr-2 md:mt-0 md:flex-1'
-            href=''
+            className="mt-2 w-full md:mr-2 md:mt-0 md:flex-1"
+            href=""
           />
         </form>
       )}

--- a/components/NewsletterSubscribe.tsx
+++ b/components/NewsletterSubscribe.tsx
@@ -17,7 +17,7 @@ enum FormStatus {
   NORMAL = 'normal',
   LOADING = 'loading',
   SUCCESS = 'success',
-  ERROR = 'error',
+  ERROR = 'error'
 }
 
 interface NewsletterSubscribeProps {
@@ -46,7 +46,7 @@ export default function NewsletterSubscribe({
   title = 'Subscribe to our newsletter to receive news about AsyncAPI.',
   subtitle = 'We respect your inbox. No spam, promise ✌️',
   type = 'Newsletter',
-  errorSubtitle = 'Subscription failed, please let us know about it by submitting a bug',
+  errorSubtitle = 'Subscription failed, please let us know about it by submitting a bug'
 }: NewsletterSubscribeProps) {
   const [email, setEmail] = useState<string>('');
   const [name, setName] = useState<string>('');
@@ -70,15 +70,15 @@ export default function NewsletterSubscribe({
     const data = {
       name,
       email,
-      interest: type,
+      interest: type
     };
 
     fetch('/.netlify/functions/newsletter_subscription', {
       method: 'POST',
       body: JSON.stringify(data),
       headers: {
-        'Content-Type': 'application/json',
-      },
+        'Content-Type': 'application/json'
+      }
     }).then((res) => {
       if (res.status === 200) {
         setFormStatus(FormStatus.SUCCESS);
@@ -92,16 +92,11 @@ export default function NewsletterSubscribe({
 
   if (status === FormStatus.SUCCESS) {
     return (
-      <div className={className} data-testid="NewsletterSubscribe-main">
-        <Heading
-          level={HeadingLevel.h3}
-          textColor={headTextColor}
-          typeStyle={HeadingTypeStyle.lg}
-          className="mb-4"
-        >
+      <div className={className} data-testid='NewsletterSubscribe-main'>
+        <Heading level={HeadingLevel.h3} textColor={headTextColor} typeStyle={HeadingTypeStyle.lg} className='mb-4'>
           {ready ? t('successTitle') : 'Thank you for subscribing!'}
         </Heading>
-        <Paragraph className="mb-8" textColor={paragraphTextColor}>
+        <Paragraph className='mb-8' textColor={paragraphTextColor}>
           {ready ? t('subtitle') : subtitle}
         </Paragraph>
       </div>
@@ -110,21 +105,13 @@ export default function NewsletterSubscribe({
 
   if (status === FormStatus.ERROR) {
     return (
-      <div className={className} data-testid="NewsletterSubscribe-main">
-        <Heading
-          level={HeadingLevel.h3}
-          textColor={headTextColor}
-          typeStyle={HeadingTypeStyle.lg}
-          className="mb-4"
-        >
+      <div className={className} data-testid='NewsletterSubscribe-main'>
+        <Heading level={HeadingLevel.h3} textColor={headTextColor} typeStyle={HeadingTypeStyle.lg} className='mb-4'>
           {ready ? t('errorTitle') : 'Something went wrong'}
         </Heading>
-        <Paragraph className="mb-8" textColor={paragraphTextColor}>
+        <Paragraph className='mb-8' textColor={paragraphTextColor}>
           {ready ? t('errorSubtitle') : errorSubtitle}{' '}
-          <TextLink
-            href="https://github.com/asyncapi/website/issues/new?template=bug.md"
-            target="_blank"
-          >
+          <TextLink href='https://github.com/asyncapi/website/issues/new?template=bug.md' target='_blank'>
             {ready ? t('errorLinkText') : 'here'}
           </TextLink>
         </Paragraph>
@@ -133,32 +120,20 @@ export default function NewsletterSubscribe({
   }
 
   return (
-    <div className={className} data-testid="NewsletterSubscribe-main">
-      <Heading
-        level={HeadingLevel.h3}
-        textColor={headTextColor}
-        typeStyle={HeadingTypeStyle.lg}
-        className="mb-4"
-      >
+    <div className={className} data-testid='NewsletterSubscribe-main'>
+      <Heading level={HeadingLevel.h3} textColor={headTextColor} typeStyle={HeadingTypeStyle.lg} className='mb-4'>
         {ready ? t('title') : title}
       </Heading>
-      <Paragraph className="mb-8" textColor={paragraphTextColor}>
+      <Paragraph className='mb-8' textColor={paragraphTextColor}>
         {ready ? t('subtitle') : subtitle}
       </Paragraph>
       {status === 'loading' ? (
-        <Loader
-          loaderText={'Waiting for response...'}
-          loaderIcon={<IconCircularLoader dark />}
-          dark={dark}
-        />
+        <Loader loaderText={'Waiting for response...'} loaderIcon={<IconCircularLoader dark />} dark={dark} />
       ) : (
-        <form
-          className="flex flex-col gap-4 md:flex-row"
-          onSubmit={handleSubmit}
-        >
+        <form className='flex flex-col gap-4 md:flex-row' onSubmit={handleSubmit}>
           <InputBox
             inputType={InputTypes.TEXT}
-            inputName="name"
+            inputName='name'
             placeholder={ready ? t('nameInput') : 'Your name'}
             inputValue={name}
             setInput={setName}
@@ -166,7 +141,7 @@ export default function NewsletterSubscribe({
           />
           <InputBox
             inputType={InputTypes.EMAIL}
-            inputName="email"
+            inputName='email'
             placeholder={ready ? t('emailInput') : 'Your email'}
             inputValue={email}
             setInput={setEmail}
@@ -175,8 +150,8 @@ export default function NewsletterSubscribe({
           <Button
             type={ButtonType.SUBMIT}
             text={ready ? t('subscribeBtn') : 'Subscribe'}
-            className="mt-2 w-full md:mr-2 md:mt-0 md:flex-1"
-            href=""
+            className='mt-2 w-full md:mr-2 md:mt-0 md:flex-1'
+            href=''
           />
         </form>
       )}

--- a/components/NewsletterSubscribe.tsx
+++ b/components/NewsletterSubscribe.tsx
@@ -137,6 +137,7 @@ export default function NewsletterSubscribe({
             placeholder={ready ? t('nameInput') : 'Your name'}
             inputValue={name}
             setInput={setName}
+            dark={dark}
           />
           <InputBox
             inputType={InputTypes.EMAIL}
@@ -144,6 +145,7 @@ export default function NewsletterSubscribe({
             placeholder={ready ? t('emailInput') : 'Your email'}
             inputValue={email}
             setInput={setEmail}
+            dark={dark}
           />
           <Button
             type={ButtonType.SUBMIT}

--- a/components/icons/NavItemDropdown.tsx
+++ b/components/icons/NavItemDropdown.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
 
+interface NavItemDropdownProps {
+  isOpen?: boolean;
+}
+
 /* eslint-disable max-len */
 /**
  * @description Icons for asyncapi website
  */
-const NavItemDropdown = () => (
+const NavItemDropdown = ({ isOpen = false }: NavItemDropdownProps) => (
   <span className='inline-block'>
     <svg
-      className='size-5 text-gray-400 transition duration-150 ease-in-out group-hover:text-gray-500 group-focus:text-gray-500'
+      className={`size-5 text-gray-400 transition duration-150 ease-in-out group-hover:text-gray-500 group-focus:text-gray-500 ${
+        isOpen ? 'rotate-180' : ''
+      }`}
       fill='currentColor'
       viewBox='0 0 20 20'
     >

--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -186,6 +186,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
               onClick={() => showOnClickMenu('learning')}
               onMouseEnter={() => showMenu('learning')}
               hasDropdown
+              isOpen={open === 'learning'}
             />
             {open === 'learning' && <LearningPanel />}
           </div>
@@ -197,6 +198,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
               onClick={() => showOnClickMenu('tooling')}
               onMouseEnter={() => showMenu('tooling')}
               hasDropdown
+              isOpen={open === 'tooling'}
             />
             {open === 'tooling' && <ToolsPanel />}
           </div>
@@ -208,6 +210,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
               onClick={() => showOnClickMenu('community')}
               onMouseEnter={() => showMenu('community')}
               hasDropdown
+              isOpen={open === 'community'}
             />
             {open === 'community' && <CommunityPanel />}
           </div>

--- a/components/navigation/NavItem.tsx
+++ b/components/navigation/NavItem.tsx
@@ -11,6 +11,7 @@ interface NavItemProps {
   onClick?: () => void;
   onMouseEnter?: () => void;
   hasDropdown?: boolean;
+  isOpen?: boolean;
   className?: string;
 }
 
@@ -22,6 +23,7 @@ interface NavItemProps {
  * @param {Function} [props.onClick] - Event handler for click event.
  * @param {Function} [props.onMouseEnter] - Event handler for mouse enter event.
  * @param {boolean} [props.hasDropdown=false] - Indicates if the navigation item has a dropdown menu.
+ * @param {boolean} [props.isOpen=false] - Indicates if the dropdown menu is open.
  * @param {string} [props.className=''] - Additional CSS classes for styling.
  */
 export default function NavItem({
@@ -31,6 +33,7 @@ export default function NavItem({
   onClick = () => {},
   onMouseEnter = () => {},
   hasDropdown = false,
+  isOpen = false,
   className = ''
 }: NavItemProps) {
   const router = useRouter();
@@ -68,7 +71,7 @@ export default function NavItem({
         data-testid='NavItem-Link'
       >
         <span>{text}</span>
-        {hasDropdown && <NavItemDropdown />}
+        {hasDropdown && <NavItemDropdown isOpen={isOpen} />}
       </Link>
     );
   }
@@ -76,7 +79,7 @@ export default function NavItem({
   return (
     <button type='button' {...attrs} className={`${attrs.className} text-gray-700`}>
       <span>{text}</span>
-      {hasDropdown && <NavItemDropdown />}
+      {hasDropdown && <NavItemDropdown isOpen={isOpen} />}
     </button>
   );
 }

--- a/types/components/InputBoxPropsType.ts
+++ b/types/components/InputBoxPropsType.ts
@@ -1,7 +1,7 @@
 export enum InputTypes {
   TEXT = 'text',
   EMAIL = 'email',
-  NUMBER = 'number',
+  NUMBER = 'number'
 }
 export interface InputBoxProps {
   // eslint-disable-next-line prettier/prettier

--- a/types/components/InputBoxPropsType.ts
+++ b/types/components/InputBoxPropsType.ts
@@ -20,4 +20,7 @@ export interface InputBoxProps {
 
   /** The function to set value of the input. */
   setInput: (value: string) => void;
+
+  /** If true, the theme of the component will be dark. */
+  dark?: boolean;
 }

--- a/types/components/InputBoxPropsType.ts
+++ b/types/components/InputBoxPropsType.ts
@@ -1,7 +1,7 @@
 export enum InputTypes {
   TEXT = 'text',
   EMAIL = 'email',
-  NUMBER = 'number'
+  NUMBER = 'number',
 }
 export interface InputBoxProps {
   // eslint-disable-next-line prettier/prettier


### PR DESCRIPTION
This PR implements rotation for the navbar dropdown chevrons. When a menu item (Docs, Tools, Community) is hovered or active, the chevron now rotates 180 degrees to indicate the menu is open.

- Updated NavItemDropdown to accept an 'isOpen' prop.
- Updated NavItem to propagate the 'isOpen' state.
- Updated NavBar to pass the 'open' state to each NavItem.
- Applied Tailwind's 'rotate-180' class for the animation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dark mode styling support for input boxes in the newsletter subscription form.
  * Improved navigation dropdown indicators with visual feedback (rotation animation) to show open/closed states.

* **Style**
  * Enhanced UI with conditional dark theme application for input components and navigation elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->