### PR TITLE
fix: link fixed in 000-onboarding/introduction in markdown

### DIFF
--- a/markdown/docs/community/000-onboarding/index.md
+++ b/markdown/docs/community/000-onboarding/index.md
@@ -6,7 +6,7 @@ weight: 2
 
 The AsyncAPI technical writer onboarding guide teaches new community members how to contribute to our documentation effectively. 
 
-> For a comprehensive understanding of the various ways you can contribute to the AsyncAPI Initiative, please consult the [AsyncAPI contributing guidelines](../010-contribution-guidelines)
+> For a comprehensive understanding of the various ways you can contribute to the AsyncAPI Initiative, please consult the [AsyncAPI contributing guidelines](../community/010-contribution-guidelines)
 
 The goal is providing docs contributors with the necessary tools and knowledge to:
 


### PR DESCRIPTION
**Description**

- Fixed the broken link to the contribution guidelines on the onboarding page:
  https://www.asyncapi.com/docs/community/000-onboarding
- Updated the outdated URL (`/docs/010-contribution-guidelines`) to the correct and current documentation path (`/docs/community/010-contribution-guidelines`).
- Verified that the updated link no longer returns a 404 error.

**Related issue(s)**
 Resolves #5183 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated onboarding documentation with improved link paths and formatting to enhance navigation clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->