### PR TITLE
fix: update inconsistent mailto link to use asyncapi.com

### DIFF
--- a/pages/[lang]/index.tsx
+++ b/pages/[lang]/index.tsx
@@ -184,7 +184,7 @@ export default function HomePage() {
           </Heading>
           <Paragraph className='mx-auto mt-3 max-w-2xl pb-4 sm:mt-4'>
             {t('sponsors.supportedByPretext')}
-            <TextLink href='mailto:info@asyncapi.io' target='_blank'>
+            <TextLink href='mailto:info@asyncapi.com' target='_blank'>
               {t('sponsors.supportedByLink')}
             </TextLink>{' '}
             {t('sponsors.supportedByPosttext')}


### PR DESCRIPTION
## Description
Fix inconsistent mailto link on the home page.

The **Supported by** section was using `info@asyncapi.io` while the footer **Email Us** link uses `info@asyncapi.com`.

## Changes
- Updated `pages/[lang]/index.tsx` line 187: `mailto:info@asyncapi.io` → `mailto:info@asyncapi.com`

## Screenshot Reference
As reported in the issue, the two links were pointing to different email addresses causing confusion.

Closes #5139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated sponsor contact email address to ensure users can reach the correct support channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->