### PR TITLE
fix: use consistent info@asyncapi.com mailto links

### DIFF
--- a/components/DemoAnimation.tsx
+++ b/components/DemoAnimation.tsx
@@ -368,7 +368,7 @@ export default function DemoAnimation({ className = '' }: IDemoAnimationProps) {
                     </div>
                     <div className={transitionClassNames(showEmail)}>
                       <span className='text-teal-400'>&nbsp;&nbsp;&quot;email&quot;</span>:{' '}
-                      <span className='text-white'>&quot;info@asyncapi.io&quot;</span>
+                      <span className='text-white'>&quot;info@asyncapi.com&quot;</span>
                     </div>
                     <div>{'}'}</div>
                   </div>

--- a/components/FinancialSummary/ContactUs.tsx
+++ b/components/FinancialSummary/ContactUs.tsx
@@ -26,10 +26,10 @@ export default function ContactUs() {
               <span>
                 <TextLink
                   className='text-base font-semibold text-violet'
-                  href='mailto:info@asyncapi.io'
+                  href='mailto:info@asyncapi.com'
                   target='_blank'
                 >
-                  info@asyncapi.io
+                  info@asyncapi.com
                 </TextLink>
               </span>
             </Paragraph>
@@ -37,7 +37,7 @@ export default function ContactUs() {
         </div>
       </div>
       <div className='flex justify-center'>
-        <Button text='Contact Us' href='mailto:info@asyncapi.io' target='_blank' />
+        <Button text='Contact Us' href='mailto:info@asyncapi.com' target='_blank' />
       </div>
     </div>
   );

--- a/pages/[lang]/index.tsx
+++ b/pages/[lang]/index.tsx
@@ -184,7 +184,7 @@ export default function HomePage() {
           </Heading>
           <Paragraph className='mx-auto mt-3 max-w-2xl pb-4 sm:mt-4'>
             {t('sponsors.supportedByPretext')}
-            <TextLink href='mailto:info@asyncapi.io' target='_blank'>
+            <TextLink href='mailto:info@asyncapi.com' target='_blank'>
               {t('sponsors.supportedByLink')}
             </TextLink>{' '}
             {t('sponsors.supportedByPosttext')}


### PR DESCRIPTION
Fixes #5139

This PR updates the inconsistent `mailto:info@asyncapi.io` links to use the correct domain `info@asyncapi.com`.

Changes made:
- Updated the link under the *Supported by* heading (`pages/[lang]/index.tsx`)
- Updated the link in the Contact Us component (`components/FinancialSummary/ContactUs.tsx`)
- Updated the Demo Animation mock file display to match the correct domain (`components/DemoAnimation.tsx`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the public contact email from info@asyncapi.io to info@asyncapi.com across the site — visible contact links, the demo code example display, mailto buttons, and the sponsor acknowledgement link now use the new address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->