### PR TITLE
fix: make tools dashboard filter controls keyboard accessible

### DIFF
--- a/components/tools/ToolsDashboard.tsx
+++ b/components/tools/ToolsDashboard.tsx
@@ -180,33 +180,39 @@ export default function ToolsDashboard() {
         <div className='my-10 flex flex-wrap justify-between gap-4 lg:flex-nowrap'>
           <div className='flex h-auto w-[47%] gap-5 lg:w-1/5'>
             <div className='relative h-auto w-full' ref={filterRef as React.LegacyRef<HTMLDivElement>}>
-              <div
+              <button
+                type='button'
                 className='flex h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-gray-300 px-4 py-1 text-sm text-gray-700 shadow hover:border-gray-600 hover:shadow-md'
                 onClick={() => setOpenFilter(!openFilter)}
+                aria-expanded={openFilter}
+                aria-controls='tools-filter-panel'
                 data-testid='ToolsDashboard-Filters-Click'
               >
                 <FilterIcon />
-                <div>Filter</div>
-              </div>
+                <span>Filter</span>
+              </button>
               {openFilter && (
-                <button className='absolute top-16 z-20 min-w-[20rem]'>
+                <div id='tools-filter-panel' className='absolute top-16 z-20 min-w-[20rem]'>
                   <Filters setOpenFilter={setOpenFilter} />
-                </button>
+                </div>
               )}
             </div>
           </div>
           <div className='flex h-auto w-[47%] gap-5 lg:w-1/5'>
             <div className='relative h-auto w-full' ref={categoryRef as React.LegacyRef<HTMLDivElement>}>
-              <div
+              <button
+                type='button'
                 className='flex h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-gray-300 px-4 py-1 text-sm text-gray-700 shadow hover:border-gray-600 hover:shadow-md'
                 onClick={() => setopenCategory(!openCategory)}
+                aria-expanded={openCategory}
+                aria-controls='tools-category-panel'
                 data-testid='ToolsDashboard-category'
               >
-                <div>Jump to Category</div>
+                <span>Jump to Category</span>
                 <ArrowDown className={`my-auto ${openCategory ? 'rotate-180' : ''}`} />
-              </div>
+              </button>
               {openCategory && (
-                <div className='absolute right-52 top-16 z-20'>
+                <div id='tools-category-panel' className='absolute right-52 top-16 z-20'>
                   <CategoryDropdown setopenCategory={setopenCategory} />
                 </div>
               )}
@@ -229,10 +235,14 @@ export default function ToolsDashboard() {
           </div>
         </div>
         {isFiltered && (
-          <div className='mt-4 flex cursor-pointer items-center text-gray-600 hover:text-black' onClick={clearFilters}>
+          <button
+            type='button'
+            className='mt-4 flex items-center text-gray-600 hover:text-black'
+            onClick={clearFilters}
+          >
             <Cross />
             <span className='ml-3'>Clear Filters</span>
-          </div>
+          </button>
         )}
         <div className='mt-0'>
           {checkToolsList ? (

--- a/components/tools/ToolsDashboard.tsx
+++ b/components/tools/ToolsDashboard.tsx
@@ -203,11 +203,13 @@ export default function ToolsDashboard() {
                 <FilterIcon />
                 <span className='font-medium'>Filter</span>
               </button>
-              {openFilter && (
-                <div id='tools-filter-panel' className='absolute top-16 z-20 min-w-[20rem]'>
-                  <Filters setOpenFilter={setOpenFilter} />
-                </div>
-              )}
+              <div
+                id='tools-filter-panel'
+                hidden={!openFilter}
+                className={`absolute top-16 z-20 min-w-[20rem] ${openFilter ? '' : 'hidden'}`}
+              >
+                <Filters setOpenFilter={setOpenFilter} />
+              </div>
             </div>
           </div>
           <div className='flex h-auto w-[47%] gap-5 lg:w-1/5'>
@@ -225,11 +227,13 @@ export default function ToolsDashboard() {
                   className={`my-auto transition-transform duration-300 ${openCategory ? 'rotate-180' : ''}`}
                 />
               </button>
-              {openCategory && (
-                <div id='tools-category-panel' className='absolute right-52 top-16 z-20'>
-                  <CategoryDropdown setopenCategory={setopenCategory} />
-                </div>
-              )}
+              <div
+                id='tools-category-panel'
+                hidden={!openCategory}
+                className={`absolute right-52 top-16 z-20 ${openCategory ? '' : 'hidden'}`}
+              >
+                <CategoryDropdown setopenCategory={setopenCategory} />
+              </div>
             </div>
           </div>
           <div className='flex h-14 w-full rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-dark-card bg-white px-4 py-1 text-sm text-gray-700 dark:text-gray-300 shadow-md dark:shadow-lg hover:border-gray-400 dark:hover:border-gray-500 focus-within:border-gray-500 dark:focus-within:border-gray-400 focus-within:shadow-lg transition-all duration-300 lg:w-4/5'>

--- a/components/tools/ToolsDashboard.tsx
+++ b/components/tools/ToolsDashboard.tsx
@@ -196,15 +196,17 @@ export default function ToolsDashboard() {
                 type='button'
                 className='flex h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-dark-card bg-white px-4 py-1 text-sm text-gray-700 dark:text-gray-300 shadow-md dark:shadow-lg hover:border-gray-400 dark:hover:border-gray-500 hover:shadow-lg transition-all duration-300 hover:scale-[1.02]'
                 onClick={() => setOpenFilter(!openFilter)}
+                aria-expanded={openFilter}
+                aria-controls='tools-filter-panel'
                 data-testid='ToolsDashboard-Filters-Click'
               >
                 <FilterIcon />
                 <span className='font-medium'>Filter</span>
               </button>
               {openFilter && (
-                <button className='absolute top-16 z-20 min-w-[20rem]'>
+                <div id='tools-filter-panel' className='absolute top-16 z-20 min-w-[20rem]'>
                   <Filters setOpenFilter={setOpenFilter} />
-                </button>
+                </div>
               )}
             </div>
           </div>
@@ -214,6 +216,8 @@ export default function ToolsDashboard() {
                 type='button'
                 className='flex h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-dark-card bg-white px-4 py-1 text-sm text-gray-700 dark:text-gray-300 shadow-md dark:shadow-lg hover:border-gray-400 dark:hover:border-gray-500 hover:shadow-lg transition-all duration-300 hover:scale-[1.02]'
                 onClick={() => setopenCategory(!openCategory)}
+                aria-expanded={openCategory}
+                aria-controls='tools-category-panel'
                 data-testid='ToolsDashboard-category'
               >
                 <span className='font-medium'>Jump to Category</span>
@@ -222,7 +226,7 @@ export default function ToolsDashboard() {
                 />
               </button>
               {openCategory && (
-                <div className='absolute right-52 top-16 z-20'>
+                <div id='tools-category-panel' className='absolute right-52 top-16 z-20'>
                   <CategoryDropdown setopenCategory={setopenCategory} />
                 </div>
               )}


### PR DESCRIPTION
**Description**

  - fixes accessibility and semantic markup issues in Tools Dashboard controls on `/tools`
  - replaces non-semantic clickable `div` triggers with semantic `<button type="button">` for:
    - `Filter`
    - `Jump to Category`
  - replaces invalid nested interactive markup:
    - changes wrapper around `<Filters />` from `<button>` to `<div>`
  - improves toggle semantics by adding:
    - `aria-expanded`
    - `aria-controls`
  - updates `Clear Filters` to use a keyboard-accessible button control

  ### Why this change
  The previous implementation relied on clickable `div` elements and included a `button` wrapping interactive children. This can cause inconsistent keyboard behavior and accessibility issues for assistive
  technologies.

  ### Testing done
  - [x] `npm run lint` (existing repo warnings only)
  - [x] `npm run test -- --runInBand` (all test suites passed locally)
  - [x] manual keyboard test on `/tools`:
    - Tab navigation reaches controls
    - Enter/Space toggles Filter and Jump to Category as expected

  ### Scope
  - changed file:
    - `components/tools/ToolsDashboard.tsx`
  - no functional changes outside Tools Dashboard filter/category interaction semantics

  **Related issue(s)**

  Fixes #5223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tools Dashboard accessibility by adding explicit ARIA attributes to Filter and Category toggles so panel states are announced reliably.
  * Clarified panel/container structure for expanded Filter and Category views to reinforce accessible relationships.
  * Enhanced keyboard navigation and screen reader interaction for filter and category controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->