### PR TITLE
fix(accessibility): add missing aria-label to icon-only buttons for screen reader support

### DIFF
--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -57,7 +57,7 @@ export default function Modal({ title, children, onModalClose = () => {} }: IMod
       <div className='relative m-auto overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:w-full sm:max-w-4xl sm:p-6'>
         <div className='mb-6 flex justify-between'>
           <h1 className='mr-4 truncate text-lg font-bold'>{title}</h1>
-          <button onClick={() => onModalClose()} data-testid='Modal-close'>
+          <button onClick={() => onModalClose()} data-testid='Modal-close' aria-label="Close modal">
             <svg
               xmlns='http://www.w3.org/2000/svg'
               fill='none'

--- a/components/buttons/ScrollButton.tsx
+++ b/components/buttons/ScrollButton.tsx
@@ -31,6 +31,7 @@ function ScrollButton() {
         <button
           className='rounded-full bg-white shadow-md transition-all duration-300 ease-in-out hover:scale-110 hover:bg-[#8851FB]'
           onClick={scrollUp}
+          aria-label="Scroll to top"
         >
           <img src={scrollImage} alt='scroll to top' />
         </button>

--- a/components/navigation/MobileNavMenu.tsx
+++ b/components/navigation/MobileNavMenu.tsx
@@ -74,6 +74,7 @@ export default function MobileNavMenu({
                   onClick={onClickClose}
                   type='button'
                   className='inline-flex items-center justify-center rounded-md p-2 text-gray-400 transition duration-150 ease-in-out hover:bg-gray-100 hover:text-gray-500 focus:bg-gray-100 focus:text-gray-500 focus:outline-none'
+                  aria-label="Close menu"
                 >
                   <svg className='size-6' stroke='currentColor' fill='none' viewBox='0 0 24 24'>
                     <path strokeLinecap='round' strokeLinejoin='round' strokeWidth='2' d='M6 18L18 6M6 6l12 12' />

--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -167,6 +167,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
             onClick={() => setMobileMenuOpen(true)}
             type='button'
             className='inline-flex items-center justify-center rounded-md p-2 text-gray-400 transition duration-150 ease-in-out hover:bg-gray-100 hover:text-gray-500 focus:bg-gray-100 focus:text-gray-500 focus:outline-none'
+            aria-label="Open mobile menu"
           >
             <svg className='size-6' stroke='currentColor' fill='none' viewBox='0 0 24 24'>
               <title>Menu</title>

--- a/components/tools/ToolsDashboard.tsx
+++ b/components/tools/ToolsDashboard.tsx
@@ -222,7 +222,7 @@ export default function ToolsDashboard() {
               onChange={(e) => setSearchName(e.target.value)}
             />
             {searchName && (
-              <button className='my-auto h-fit rounded-full p-2 hover:bg-gray-100' onClick={() => setSearchName('')}>
+              <button className='my-auto h-fit rounded-full p-2 hover:bg-gray-100' onClick={() => setSearchName('')} aria-label="Clear search">
                 <img src='/img/illustrations/icons/close-icon.svg' alt='close' width='10' />
               </button>
             )}


### PR DESCRIPTION
This PR adds missing `aria-label` attributes to icon-only buttons to improve screen reader support.

Closes asyncapi/website#5143

**Changes made:**
- Added `aria-label="Scroll to top"` in `ScrollButton.tsx`
- Added `aria-label="Close modal"` in `Modal.tsx`
- Added `aria-label="Open mobile menu"` in `NavBar.tsx`
- Added `aria-label="Clear search"` in `ToolsDashboard.tsx`
- Added `aria-label="Close menu"` in `MobileNavMenu.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added accessibility labels to interactive elements across the platform. Improvements include descriptive labels for modal close buttons, mobile navigation menu controls (open and close), scroll-to-top functionality, and search clearing options. These enhancements significantly improve the user experience for individuals using screen readers and assistive technology devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->