### PR TITLE
style(navbar): rotate dropdown icons when menu is open

### DIFF
--- a/components/icons/NavItemDropdown.tsx
+++ b/components/icons/NavItemDropdown.tsx
@@ -4,8 +4,8 @@ import React from 'react';
 /**
  * @description Icons for asyncapi website
  */
-const NavItemDropdown = () => (
-  <span className='inline-block'>
+const NavItemDropdown = ({ isOpen = false }: { isOpen?: boolean }) => (
+  <span className={`inline-block transition-transform duration-200 ${isOpen ? '-rotate-180' : ''}`}>
     <svg
       className='size-5 text-gray-400 transition duration-150 ease-in-out group-hover:text-gray-500 group-focus:text-gray-500'
       fill='currentColor'

--- a/components/navigation/MobileNavMenu.tsx
+++ b/components/navigation/MobileNavMenu.tsx
@@ -88,7 +88,7 @@ export default function MobileNavMenu({
               <Link href='/docs' className='flex cursor-pointer'>
                 Docs
               </Link>
-              <NavItemDropdown />
+              <NavItemDropdown isOpen={open === 'learning'} />
             </h4>
             {open === 'learning' && <MenuBlocks items={learningItems} />}
           </div>
@@ -98,7 +98,7 @@ export default function MobileNavMenu({
               <Link href='/tools' className='flex cursor-pointer'>
                 Tools
               </Link>
-              <NavItemDropdown />
+              <NavItemDropdown isOpen={open === 'tooling'} />
             </h4>
             {open === 'tooling' && <MenuBlocks items={toolingItems} />}
           </div>
@@ -107,7 +107,7 @@ export default function MobileNavMenu({
               <Link href='/community' className='flex cursor-pointer'>
                 Community
               </Link>
-              <NavItemDropdown />
+              <NavItemDropdown isOpen={open === 'community'} />
             </h4>
             {open === 'community' && <MenuBlocks items={communityItems} />}
           </div>
@@ -116,7 +116,7 @@ export default function MobileNavMenu({
               <div>
                 <h4 className='mb-4 flex justify-between font-medium text-gray-800'>
                   <a className='cursor-pointer'>Others</a>
-                  <NavItemDropdown />
+                  <NavItemDropdown isOpen={open === 'others'} />
                 </h4>
                 {open === 'others' &&
                   otherItems.map((item: MenuItem, index: number) => (
@@ -141,7 +141,7 @@ export default function MobileNavMenu({
                   <a className='flex cursor-pointer items-center gap-x-2'>
                     Language <IconLanguage />
                   </a>
-                  <NavItemDropdown />
+                  <NavItemDropdown isOpen={open === 'language'} />
                 </h4>
                 {open === 'language' &&
                   uniqueLangs.map((lang) => (

--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -186,6 +186,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
               onClick={() => showOnClickMenu('learning')}
               onMouseEnter={() => showMenu('learning')}
               hasDropdown
+              isOpen={open === 'learning'}
             />
             {open === 'learning' && <LearningPanel />}
           </div>
@@ -197,6 +198,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
               onClick={() => showOnClickMenu('tooling')}
               onMouseEnter={() => showMenu('tooling')}
               hasDropdown
+              isOpen={open === 'tooling'}
             />
             {open === 'tooling' && <ToolsPanel />}
           </div>
@@ -208,6 +210,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
               onClick={() => showOnClickMenu('community')}
               onMouseEnter={() => showMenu('community')}
               hasDropdown
+              isOpen={open === 'community'}
             />
             {open === 'community' && <CommunityPanel />}
           </div>

--- a/components/navigation/NavItem.tsx
+++ b/components/navigation/NavItem.tsx
@@ -11,6 +11,7 @@ interface NavItemProps {
   onClick?: () => void;
   onMouseEnter?: () => void;
   hasDropdown?: boolean;
+  isOpen?: boolean;
   className?: string;
 }
 
@@ -31,6 +32,7 @@ export default function NavItem({
   onClick = () => {},
   onMouseEnter = () => {},
   hasDropdown = false,
+  isOpen = false,
   className = ''
 }: NavItemProps) {
   const router = useRouter();
@@ -68,7 +70,7 @@ export default function NavItem({
         data-testid='NavItem-Link'
       >
         <span>{text}</span>
-        {hasDropdown && <NavItemDropdown />}
+        {hasDropdown && <NavItemDropdown isOpen={isOpen} />}
       </Link>
     );
   }
@@ -76,7 +78,7 @@ export default function NavItem({
   return (
     <button type='button' {...attrs} className={`${attrs.className} text-gray-700`}>
       <span>{text}</span>
-      {hasDropdown && <NavItemDropdown />}
+      {hasDropdown && <NavItemDropdown isOpen={isOpen} />}
     </button>
   );
 }


### PR DESCRIPTION
This PR rotates the navigation dropdown icons (chevrons) by 180 degrees when the menu is active/open to clearly signal the menu state.

Closes asyncapi/website#4984

**Changes made:**
- Updated `NavItemDropdown` component to accept an `isOpen` prop and apply a `-rotate-180` Tailwind class when true.
- Updated `NavItem` to accept and pass down the `isOpen` prop to the dropdown icon.
- Updated `NavBar.tsx` and `MobileNavMenu.tsx` to pass the active state (`isOpen={open === '<menu>'}`) down to the `NavItem` and `NavItemDropdown` components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Navigation dropdown indicators now dynamically rotate to visually reflect when menu sections are open or closed. This enhancement provides clearer visual feedback across all navigation menus, improving user experience and navigation clarity throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->