### PR TITLE
fix(DocsNav): correct useEffect dependency and state update pattern

### DIFF
--- a/components/navigation/DocsNav.tsx
+++ b/components/navigation/DocsNav.tsx
@@ -65,18 +65,18 @@ const serializedBuckets: SerializedBuckets = buckets.reduce(
  * @param {Function} [props.onClick=() => {}] - The function to be called when the navigation item is clicked.
  */
 export default function DocsNav({ item, active, onClick = () => {} }: DocsNavProps) {
+  const slug = item.item.slug;
   const subCategories = item.children;
   const bucket = serializedBuckets[item.item.rootSectionId];
-  const [openSubCategory, setOpenSubCategory] = useState(active.startsWith(item.item.slug));
-
+  const [openSubCategory, setOpenSubCategory] = useState(active.startsWith(slug));
   const onClickHandler = () => {
-    setOpenSubCategory(!openSubCategory);
+    setOpenSubCategory(prev =>!prev);
     onClick();
   };
 
   useEffect(() => {
-    setOpenSubCategory(active.startsWith(item.item.slug));
-  }, [active]);
+    setOpenSubCategory(active.startsWith(slug));
+  }, [active, slug]);
 
   return (
     <li className='mb-4' key={item.item.title} data-testid='DocsNav-item'>
@@ -84,7 +84,7 @@ export default function DocsNav({ item, active, onClick = () => {} }: DocsNavPro
         <DocsArrow
           isDropDown={Object.values(subCategories).length > 0}
           activeDropDownItem={openSubCategory}
-          onClick={() => setOpenSubCategory(!openSubCategory)}
+          onClick={() => setOpenSubCategory(prev => !prev)}
         />
         <DocsNavItem
           {...item.item}


### PR DESCRIPTION
**Description**

- Fixed missing dependency in `useEffect` in `DocsNav.tsx` (`item.item.slug` was not included)
- Added functional state update (`prev => !prev`) to prevent stale closure issues
- This change ensures `openSubCategory` state stays in sync when either `active` or `slug` changes.
   Previously, `slug` was not included in dependencies, which could lead to stale UI state when navigating between sections.

**Related issue(s)**
Fixes #5248 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved navigation component state management with more efficient update patterns.
  * Enhanced navigation item rendering with refined prop passing for better component composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->