### PR TITLE
fix(#5143): add aria-label to icon-only buttons

### DIFF
--- a/components/tools/FiltersDisplay.tsx
+++ b/components/tools/FiltersDisplay.tsx
@@ -46,8 +46,9 @@ export default function FiltersDisplay({ checkedOptions = [], setCheckedOptions 
                   className='mt-[-2px] rounded-full p-1 hover:bg-gray-100'
                   onClick={(event) => handleClickOption(event, items, checkedOptions, setCheckedOptions)}
                   data-testid='Filters-Display-Button'
+                  aria-label={`Remove ${items} filter`}
                 >
-                  <img src='/img/illustrations/icons/close-icon.svg' alt='close' width='10' />
+                  <img src='/img/illustrations/icons/close-icon.svg' alt='' width='10' />
                 </button>
               </div>
             );

--- a/components/tools/ToolsDashboard.tsx
+++ b/components/tools/ToolsDashboard.tsx
@@ -222,8 +222,12 @@ export default function ToolsDashboard() {
               onChange={(e) => setSearchName(e.target.value)}
             />
             {searchName && (
-              <button className='my-auto h-fit rounded-full p-2 hover:bg-gray-100' onClick={() => setSearchName('')}>
-                <img src='/img/illustrations/icons/close-icon.svg' alt='close' width='10' />
+              <button
+                className='my-auto h-fit rounded-full p-2 hover:bg-gray-100'
+                onClick={() => setSearchName('')}
+                aria-label='Clear search'
+              >
+                <img src='/img/illustrations/icons/close-icon.svg' alt='' width='10' />
               </button>
             )}
           </div>


### PR DESCRIPTION
Fixes #5143 - Accessibility: Icon-only buttons

## Changes ✅
**ToolsDashboard.tsx**
```jsx
// Before
<button className='my-auto h-fit...' onClick={() => setSearchName('')}>
  <img src='/close-icon.svg' />
</button>

// After  
<button aria-label='Clear search' className='my-auto h-fit...' onClick={() => setSearchName('')}>
  <img src='/close-icon.svg' />
</button>



**FiltersDisplay.tsx**

// Before
<button className='mt-[-2px]...' onClick={...}>
  <img src='/close-icon.svg' />
</button>

// After
<button aria-label={`Remove ${items} filter`} className='mt-[-2px]...'>
  <img src='/close-icon.svg' />
</button>

## Testing
✅ Screen readers announce buttons correctly  
✅ Keyboard navigation works  
✅ No visual changes  

Preview: http://localhost:3000/tools

Interested in GSoC 2026! cc @codxbrexx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  - Enhanced screen reader support with clearer, more descriptive labels on filter removal and search clearing controls for improved user navigation
  - Refined image descriptions and alt text across interactive controls to better support accessibility standards and compliance requirements
  - Strengthened overall compatibility with assistive technologies for a more inclusive user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->