### PR TITLE
fix: update inconsistent mailto links from asyncapi.io to asyncapi.com

### DIFF
--- a/components/FinancialSummary/ContactUs.tsx
+++ b/components/FinancialSummary/ContactUs.tsx
@@ -26,10 +26,10 @@ export default function ContactUs() {
               <span>
                 <TextLink
                   className='text-base font-semibold text-violet'
-                  href='mailto:info@asyncapi.io'
+                  href='mailto:info@asyncapi.com'
                   target='_blank'
                 >
-                  info@asyncapi.io
+                  info@asyncapi.com
                 </TextLink>
               </span>
             </Paragraph>
@@ -37,7 +37,7 @@ export default function ContactUs() {
         </div>
       </div>
       <div className='flex justify-center'>
-        <Button text='Contact Us' href='mailto:info@asyncapi.io' target='_blank' />
+        <Button text='Contact Us' href='mailto:info@asyncapi.com' target='_blank' />
       </div>
     </div>
   );

--- a/cypress/fixtures/footerPageData.json
+++ b/cypress/fixtures/footerPageData.json
@@ -18,7 +18,7 @@
     { "href": "https://www.twitch.tv/asyncapi", "text": "Twitch" }
   ],
   "newsLinks": [
-    { "href": "mailto:press@asyncapi.io", "text": "Email Us" }
+    { "href": "mailto:press@asyncapi.com", "text": "Email Us" }
   ],
   "netlifyLink": "https://netlify.com"
 }

--- a/cypress/fixtures/footerPageData.json
+++ b/cypress/fixtures/footerPageData.json
@@ -18,7 +18,7 @@
     { "href": "https://www.twitch.tv/asyncapi", "text": "Twitch" }
   ],
   "newsLinks": [
-    { "href": "mailto:press@asyncapi.com", "text": "Email Us" }
+    { "href": "mailto:info@asyncapi.com", "text": "Email Us" }
   ],
   "netlifyLink": "https://netlify.com"
 }

--- a/pages/[lang]/index.tsx
+++ b/pages/[lang]/index.tsx
@@ -184,7 +184,7 @@ export default function HomePage() {
           </Heading>
           <Paragraph className='mx-auto mt-3 max-w-2xl pb-4 sm:mt-4'>
             {t('sponsors.supportedByPretext')}
-            <TextLink href='mailto:info@asyncapi.io' target='_blank'>
+            <TextLink href='mailto:info@asyncapi.com' target='_blank'>
               {t('sponsors.supportedByLink')}
             </TextLink>{' '}
             {t('sponsors.supportedByPosttext')}

--- a/scripts/build-rss.ts
+++ b/scripts/build-rss.ts
@@ -69,7 +69,7 @@ export async function rssFeed(type: BlogPostTypes, rssTitle: string, desc: strin
     rss.channel.description = desc;
     rss.channel.language = 'en-gb';
     rss.channel.copyright = 'Made with :love: by the AsyncAPI Initiative.';
-    rss.channel.webMaster = 'info@asyncapi.io (AsyncAPI Initiative)';
+    rss.channel.webMaster = 'info@asyncapi.com (AsyncAPI Initiative)';
     rss.channel.pubDate = new Date().toUTCString();
     rss.channel.generator = 'next.js';
     rss.channel.item = [];


### PR DESCRIPTION
## Summary

Updates all mailto links from `info@asyncapi.io` / `press@asyncapi.io` to `info@asyncapi.com` / `press@asyncapi.com` to match the current website domain.

## Changes

- `components/FinancialSummary/ContactUs.tsx` — Updated 3 references (`mailto:` href and display text)
- `pages/[lang]/index.tsx` — Updated TextLink href on the home page
- `scripts/build-rss.ts` — Updated RSS channel webMaster email
- `cypress/fixtures/footerPageData.json` — Updated test fixture email

### Note
`.github/workflows/scripts/mailchimp/index.js` also contains `info@asyncapi.io` (line 45, `reply_to` field) but could not be included in this PR due to PAT workflow file push restrictions. It should be updated separately.

Fixes #5139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated contact email addresses across the site and related outputs from the .io domain to the .com domain. This includes the contact section, footer/news links, sponsor “supported by” link, and RSS feed webmaster contact so all visible email links now use info@asyncapi.com.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->