### PR TITLE
fix: update test ambassadors

### DIFF
--- a/cypress/ambassadors.cy.js
+++ b/cypress/ambassadors.cy.js
@@ -19,11 +19,11 @@ describe('Ambassadors Page', () => {
   it('verifies social links for selected Ambassadors', () => {
     const ambassadors = [
       {
-        name: 'Quetzalli Writes',
+        name: 'Giri Venkatesan',
         links: {
-          github: 'https://www.github.com/quetzalliwrites',
-          twitter: 'https://www.twitter.com/QuetzalliWrites',
-          linkedin: 'https://www.linkedin.com/in/quetzalli-writes'
+          github: 'https://www.github.com/gvensan',
+          twitter: 'https://www.twitter.com/giri_venkatesan',
+          linkedin: 'https://www.linkedin.com/in/girivenkatesan'
         }
       },
       {


### PR DESCRIPTION
**Description**
Update test ambassadors by removing Quetzalli because she's no longer an ambassador. 
This was resulting in failure of https://github.com/asyncapi/website/actions/runs/23397789310/job/68063925292
- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated ambassador profile test data to verify accuracy of social link information and identity details in ambassador verification tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->