### PR TITLE
docs(i18n): fix config filename references in ADDING_TRANSLATIONS.md

### DIFF
--- a/ADDING_TRANSLATIONS.md
+++ b/ADDING_TRANSLATIONS.md
@@ -102,7 +102,7 @@ The process for adding translations to a page that is not yet available in any e
   - Skip to `Step 3` in case you haven't created new `JSON` files.
 
 **2. Modify the i18n configuration**
-  - Navigate to the `next-i18next-static-site.config.js` file in the root of the project folder.
+  - Navigate to the `next-i18next.config.cjs` file in the root of the project folder.
   - Add the name of the newly added `JSON` file to the `namespaces` array.
 
 **3. Add the static site functions**
@@ -252,7 +252,7 @@ If you want to add a new locale like `fr` to serve pages in the French locale on
   - Copy the existing `JSON` files present in the `en` folder. Change the values of those translation keys according to the new localization.
 
 **2. Modify i18n configuration**
-  - Navigate to the `next-i18next.config.js` file in the root of the project folder.
+  - Navigate to the `next-i18next.config.cjs` file in the root of the project folder.
   - Add the name of the newly added `locale` to the `languages` array.
 
 **3. Configure i18n routing**
@@ -278,9 +278,9 @@ If you have added the 'fr' locale and translated the 'tools/cli' page, clicking 
 +  ┃ ┗ tools.json
 ```
 
-- Change the `next-i18next.config.js` config.
+- Change the `next-i18next.config.cjs` config.
 
-`next-i18next.config.js`
+`next-i18next.config.cjs`
 ```diff
 module.exports = {
     i18n: {

--- a/ADDING_TRANSLATIONS.md
+++ b/ADDING_TRANSLATIONS.md
@@ -158,8 +158,8 @@ After adding a new internationalized page, test it to sure the page is being ser
   ```diff
   module.exports = {
       i18n: {
-          languages: ["en", "de"],
-          defaultLanguage: "en",
+          locales: ["en", "de"],
+          defaultLocale: "en",
   -       namespaces: ["landing-page", "common", "tools"],
   +       namespaces: ["landing-page", "common", "tools", "newsletter"],
           defaultNamespace: "landing-page",
@@ -253,7 +253,7 @@ If you want to add a new locale like `fr` to serve pages in the French locale on
 
 **2. Modify i18n configuration**
   - Navigate to the `next-i18next.config.cjs` file in the root of the project folder.
-  - Add the name of the newly added `locale` to the `languages` array.
+  - Add the name of the newly added `locale` to the `locales` array.
 
 **3. Configure i18n routing**
 After adding a new internationalized page, ensure it is being served on the website when someone visits.
@@ -284,9 +284,9 @@ If you have added the 'fr' locale and translated the 'tools/cli' page, clicking 
 ```diff
 module.exports = {
     i18n: {
--       languages: ["en", "de"],
-+       languages: ["en", "de", "fr"],
-        defaultLanguage: "en",
+-       locales: ["en", "de"],
++       locales: ["en", "de", "fr"],
+        defaultLocale: "en",
         namespaces: ["landing-page", "common", "tools"],
         defaultNamespace: "landing-page",
     },


### PR DESCRIPTION
## Summary

Fixes #5111

The `ADDING_TRANSLATIONS.md` guide referenced two different (incorrect) filenames for the i18n configuration file, causing confusion for contributors.

## Problem

- "Adding translations to a new page" section referenced: `next-i18next-static-site.config.js`
- "Adding a new locale" section referenced: `next-i18next.config.js`
- The actual file in the repository is: `next-i18next.config.cjs`

## Changes

Updated all 4 filename references in `ADDING_TRANSLATIONS.md` to consistently use `next-i18next.config.cjs`.

## Why this matters

Contributors following the guide to add translations or new locales would navigate to the wrong file, leading to confusion or setup failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the translation contribution guide to reference the renamed i18n configuration and updated code examples.
  * Replaced old i18n option names with the current keys (e.g., locale list and default locale).
  * Updated example locale list to include French and clarified where to add new translation namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->