### PR TITLE
fix: fix failing Slack e2e tests

### DIFF
--- a/cypress/slackworkspace.cy.js
+++ b/cypress/slackworkspace.cy.js
@@ -5,6 +5,7 @@ describe('Slack workspace tests', () => {
 
   beforeEach(() => {
     slackPage.visitSlack();
+    slackPage.waitForPageLoad();
   });
 
   it('Should show all login methods when the Slack invite link is active', () => {


### PR DESCRIPTION
**Description**

- Added `waitForPageLoad()` in `beforeEach` to ensure the page 
  is fully loaded before running tests
- This fixes the flaky test caused by Slack page not being 
  ready when assertions ran

**Related issue(s)**
Fixes #5281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by ensuring the page reaches a ready state before test execution, reducing test flakiness and improving CI/CD stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->