### PR TITLE
docs: add AI-facing documentation and enhance CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,33 @@
 language: "en-US"
 reviews:
   high_level_summary: true
+  auto_review:
+    enabled: true
+  path_instructions:
+    - path: "components/**"
+      instructions: |
+        Ensure components use functional React patterns with explicit TypeScript
+        prop interfaces. Props must be destructured in the function signature.
+        All styling must use Tailwind CSS classes - no inline styles or CSS modules.
+        Translatable text must use the useTranslation hook from @/utils/i18n.
+    - path: "pages/**"
+      instructions: |
+        Page components must follow Next.js conventions. Check for proper
+        static generation support since the site uses static export (output: 'export').
+        Ensure i18n routing works with the [lang] parameter.
+    - path: "scripts/**"
+      instructions: |
+        Scripts must be written in TypeScript. Verify proper error handling
+        and that generated output files are not committed manually.
+    - path: "markdown/**"
+      instructions: |
+        Ensure MDX content has valid frontmatter. Blog posts must have required
+        fields (title, date, type, authors, etc.). Check for broken links
+        and proper image references.
+    - path: "public/locales/**"
+      instructions: |
+        Translation files must maintain consistent keys across all locales
+        (en, de, zh_cn). Do not remove existing translation keys.
   tools:
     markdownlint:
       enabled: true

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,63 @@
+# AsyncAPI Website - Cursor Rules
+
+## Project Overview
+This is the AsyncAPI website built with Next.js 15, TypeScript (strict), and Tailwind CSS 3. It uses static export and deploys on Netlify.
+
+## Contribution Rules
+- Open an issue first before submitting a PR (unless fixing a typo or obvious error).
+- One PR per change. Do not bundle unrelated changes.
+- Reference the related issue in the PR description (e.g., `Closes #1234`).
+- PR titles MUST follow Conventional Commits:
+  - `fix:` bug fix
+  - `feat:` new feature
+  - `docs:` documentation only
+  - `chore:` cleanup, deps, config
+  - `test:` test changes
+  - `refactor:` restructure without behavior change
+- Titles must use imperative mood and be self-descriptive.
+
+## Before Submitting
+Run these commands and ensure they pass:
+- `npm run lint` - ESLint
+- `npm run test` - Jest unit tests
+- `npm run test:e2e` - Cypress E2E (recommended)
+
+## Code Style
+- 2 spaces indentation, single quotes, semicolons required
+- No trailing commas
+- Max line length: 120 characters
+- LF line endings (Unix)
+- Use `@/` path alias for project root imports
+- Use `import type` for type-only imports
+- Prefix unused variables with `_`
+- No console/debugger/alert in production code
+- Import order enforced by eslint-plugin-simple-import-sort
+
+## Project Structure
+- pages/ → Next.js routes ([lang]/ for i18n)
+- components/ → React components (TypeScript interfaces for props)
+- markdown/ → MDX content (blog, docs)
+- scripts/ → Build scripts (TypeScript)
+- config/ → Data files, JSON schemas
+- types/ → TypeScript type definitions
+- utils/ → Shared utilities
+- context/ → React Context providers
+- tests/ → Jest tests
+- cypress/ → E2E tests
+- public/locales/ → i18n translations (en, de, zh_cn)
+- netlify/ → Edge functions
+
+## Component Patterns
+- Functional components with explicit TypeScript prop interfaces
+- Destructure props in function signature
+- Use Tailwind CSS classes for styling (no inline styles, no CSS modules)
+- Use `useTranslation` from `@/utils/i18n` for translatable text
+- Storybook stories: Meta/StoryObj pattern from @storybook/react
+
+## Do Not
+- Modify auto-generated files (dashboard.json, roadmap.json, meetings.json) by hand
+- Commit .env or credential files
+- Add new dependencies without justification
+- Use `any` type in TypeScript
+- Skip or disable ESLint rules without maintainer approval
+- Bundle multiple unrelated changes in one PR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,100 @@
+# AI Agent Guidelines for AsyncAPI Website
+
+> This file is automatically read by AI coding assistants (OpenAI Codex, GitHub Copilot, CodeRabbit, and others). It supplements [CONTRIBUTING.md](./CONTRIBUTING.md) with machine-readable project rules.
+
+## Contribution Workflow
+
+- **Always open an issue first** and get it approved before submitting a PR, unless the change is a typo or an obvious error.
+- **One PR = one change.** Do not bundle multiple fixes, features, or refactors into a single PR.
+- If an issue already exists for the work, reference it in the PR description (e.g., `Closes #1234`).
+- Issues and PRs without activity from the creator within 14 days will be automatically closed.
+
+## PR Title Format (Required)
+
+PR titles **must** follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification. The CI will block merging if the title does not conform.
+
+Use one of these prefixes:
+
+| Prefix       | When to use                          |
+|--------------|--------------------------------------|
+| `fix:`       | Bug fix                              |
+| `feat:`      | New feature                          |
+| `docs:`      | Documentation-only change            |
+| `chore:`     | Cleanup, dependency bumps, config    |
+| `test:`      | Adding or updating tests             |
+| `refactor:`  | Code restructuring without behavior change |
+
+- Write titles in **imperative mood** (e.g., `fix: resolve broken link in docs`, not `fix: fixed broken link`).
+- Keep titles clear, concise, and self-descriptive.
+
+## Pre-Submission Checklist
+
+Before opening a PR, ensure the following pass locally:
+
+```bash
+npm run lint        # ESLint checks
+npm run lint:fix    # Auto-fix linting issues
+npm run test        # Jest unit tests
+npm run test:e2e    # Cypress end-to-end tests (optional but recommended)
+```
+
+## Tech Stack
+
+- **Framework:** Next.js 15 with static export (`output: 'export'`)
+- **Language:** TypeScript (strict mode)
+- **Styling:** Tailwind CSS 3 with custom theme (see `tailwind.config.ts`)
+- **Content:** MDX for blog posts and documentation (in `markdown/` directory)
+- **Testing:** Jest (unit/script tests), Cypress (E2E)
+- **Deployment:** Netlify (static site + edge functions)
+- **Internationalization:** i18next with next-i18next (locales: `en`, `de`, `zh_cn`)
+- **Component docs:** Storybook 8
+
+## Project Structure
+
+```
+pages/            # Next.js page routes (includes [lang]/ for i18n)
+components/       # Reusable React/TypeScript UI components
+markdown/         # Blog posts, docs, and about content (MDX/MD)
+scripts/          # Build and data-generation scripts (TypeScript)
+config/           # JSON schemas, data files, finance configs
+types/            # TypeScript type definitions
+utils/            # Shared utility functions
+context/          # React Context providers
+styles/           # Global CSS and Tailwind imports
+tests/            # Jest test files
+cypress/          # Cypress E2E test files
+public/           # Static assets, images, i18n locale JSON files
+netlify/          # Netlify edge functions
+.github/          # GitHub Actions workflows
+```
+
+## Code Style Rules
+
+- **Indentation:** 2 spaces (no tabs)
+- **Quotes:** Single quotes
+- **Semicolons:** Required
+- **Trailing commas:** None
+- **Max line length:** 120 characters (URLs and classNames are exempt)
+- **Line endings:** LF (Unix-style)
+- **Imports:** Use `type` keyword for type-only imports (`import type { Foo } from '...'`)
+- **Path aliases:** Use `@/` prefix to reference project root (e.g., `@/components/Button`)
+- **Unused variables:** Prefix with `_` if intentionally unused (e.g., `_event`)
+- **No console/debugger/alert** statements in production code
+- **Import sorting:** Enforced by `eslint-plugin-simple-import-sort`
+
+## Component Conventions
+
+- Use **functional components** with explicit TypeScript interfaces for props.
+- Destructure props in the function signature.
+- Use **Tailwind CSS classes** for all styling; avoid inline styles and CSS modules.
+- For translatable text, use `useTranslation` hook from `@/utils/i18n`.
+- Storybook stories use the `Meta`/`StoryObj` pattern from `@storybook/react`.
+
+## What NOT To Do
+
+- Do not modify auto-generated files (`dashboard.json`, `roadmap.json`, `meetings.json`, etc.) by hand.
+- Do not commit `.env` or credential files.
+- Do not add new dependencies without justification in the PR description.
+- Do not change multiple unrelated things in one PR.
+- Do not skip or disable ESLint rules without maintainer approval.
+- Do not use `any` type in TypeScript; use proper types or `unknown`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# AsyncAPI Website - Claude Instructions
+
+This is the AsyncAPI website repository, built with Next.js 15, TypeScript, and Tailwind CSS.
+
+## Contribution Rules
+
+- Open an issue first and get it approved before submitting a PR (unless fixing a typo or obvious error).
+- One PR per change. Do not bundle unrelated changes.
+- Reference the issue in the PR description (e.g., `Closes #1234`).
+
+## PR Title Format
+
+PR titles must follow Conventional Commits. Use one of these prefixes:
+
+- `fix:` for bug fixes
+- `feat:` for new features
+- `docs:` for documentation changes
+- `chore:` for cleanup, dependency updates, config changes
+- `test:` for test additions/updates
+- `refactor:` for restructuring without behavior change
+
+Titles must be imperative mood, clear, and descriptive. CI blocks merge on non-conforming titles.
+
+## Commands
+
+```bash
+npm run dev          # Start dev server (localhost:3000)
+npm run build        # Production build
+npm run lint         # Run ESLint
+npm run lint:fix     # Auto-fix lint issues
+npm run test         # Run Jest tests
+npm run test:e2e     # Run Cypress E2E tests
+npm run dev:storybook # Start Storybook (localhost:6006)
+```
+
+## Code Style
+
+- 2 spaces, single quotes, semicolons required, no trailing commas
+- Max line length: 120 characters
+- LF line endings
+- Use `@/` path alias for imports from project root
+- Use `import type` for type-only imports
+- Prefix intentionally unused variables with `_`
+- No `console`, `debugger`, or `alert` in production code
+- Import sorting enforced by eslint-plugin-simple-import-sort
+
+## Architecture
+
+- `pages/` - Next.js routes (includes `[lang]/` for i18n)
+- `components/` - React components with TypeScript prop interfaces
+- `markdown/` - MDX content (blog, docs)
+- `scripts/` - Build/generation scripts in TypeScript
+- `config/` - Data files, JSON schemas
+- `types/` - TypeScript type definitions
+- `utils/` - Shared utilities
+- `context/` - React Context providers
+- `tests/` - Jest tests
+- `cypress/` - E2E tests
+- `public/locales/` - i18n translation files (en, de, zh_cn)
+- `netlify/` - Edge functions
+
+## Conventions
+
+- Functional components with explicit TypeScript interfaces for props
+- Destructure props in function signatures
+- Tailwind CSS for all styling; no inline styles or CSS modules
+- Use `useTranslation` hook from `@/utils/i18n` for translatable text
+- Storybook stories: use `Meta`/`StoryObj` pattern
+- Static export: `output: 'export'` in next.config.mjs
+- Node.js version: 20.11.0 (see .nvmrc)
+
+## Do Not
+
+- Modify auto-generated files (dashboard.json, roadmap.json, meetings.json) by hand
+- Commit .env or credential files
+- Add dependencies without justification
+- Use `any` type; use proper types or `unknown`
+- Skip or disable ESLint rules without maintainer approval
+- Bundle multiple unrelated changes in one PR


### PR DESCRIPTION
# Closes #5205

## Summary

This PR introduces AI-facing documentation files to help AI coding assistants (Cursor, GitHub Copilot, Claude, OpenAI Codex) understand AsyncAPI project rules **before** generating code or PRs. It also enhances the existing CodeRabbit configuration with directory-specific review instructions.

### Problem

Contributors increasingly use AI coding tools to generate PRs. These tools have no awareness of project-specific rules like:
- Opening an issue before submitting a PR
- Following Conventional Commits for PR titles
- Keeping PRs focused on a single change
- Project-specific patterns (Next.js/TypeScript/Tailwind conventions)

This results in PRs that are technically functional but miss process requirements, wasting time for both contributors and maintainers.

### Solution

Added three AI-facing documentation files and enhanced CodeRabbit config:

| File | Purpose |
|------|---------|
| `AGENTS.md` | Read by OpenAI Codex-based tools and auto-detected by CodeRabbit as review criteria |
| `CLAUDE.md` | Picked up by Claude when working in the repository |
| `.cursorrules` | Read by the Cursor IDE |
| `.coderabbit.yaml` (updated) | Added `path_instructions` for directory-specific review guidance |

### What each file covers

- **Contribution workflow** - open issue first, one PR = one change, reference issues
- **PR title format** - Conventional Commits specification with all valid prefixes
- **Pre-submission checklist** - `npm run lint`, `npm run test`, `npm run test:e2e`
- **Tech stack** - Next.js 15, TypeScript (strict), Tailwind CSS 3, i18next, Storybook, Cypress
- **Project structure** - directory layout and purpose of each folder
- **Code style rules** - derived from `.eslintrc`, `.editorconfig`, `tsconfig.json`
- **Component conventions** - functional components, prop interfaces, Tailwind-only styling
- **Anti-patterns** - what NOT to do (no `any` type, no auto-generated file edits, etc.)

### CodeRabbit enhancements

Added `path_instructions` in `.coderabbit.yaml` for:
- `components/**` - enforce functional React patterns, TypeScript interfaces, Tailwind styling
- `pages/**` - Next.js conventions, static export compatibility, i18n routing
- `scripts/**` - TypeScript requirement, error handling, no manual generated file commits
- `markdown/**` - valid MDX frontmatter, required blog post fields, link/image validation
- `public/locales/**` - translation key consistency across locales (en, de, zh_cn)

### Why this approach works on both sides

As discussed in #5205, `AGENTS.md` serves **double duty**:
1. **Editor-side**: AI tools read it locally while writing code, catching rule violations before a PR is even opened
2. **PR review-side**: CodeRabbit [auto-detects](https://docs.coderabbit.ai/knowledge-base/code-guidelines) `AGENTS.md` and uses it as review criteria, this works regardless of how the PR was created (even via github.com UI)

### Note on trial run

As @animeshk923 mentioned in the issue discussion:

> "We need a trial run to see how CodeRabbit performs on new active PRs"

The `path_instructions` and `AGENTS.md` auto-detection by CodeRabbit should be validated on a few real incoming PRs after this is merged. The implementation is ready for that trial - maintainers can observe CodeRabbit's behavior on new PRs and fine-tune the instructions based on results. If any `path_instructions` are too noisy or not specific enough, they can be adjusted iteratively without affecting the core AI-facing docs.

### Important notes

- These files **supplement** `CONTRIBUTING.md`, they do not replace it
- All rules in these files are derived from existing configs and `CONTRIBUTING.md` - no new rules were invented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contributor guidelines for developers and AI agents, including project conventions, code style requirements, and contribution workflow.

* **Chores**
  * Added code review configuration with path-specific review instructions to ensure consistent quality standards across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->