### PR TITLE
enhc: enchanced the look of Governance Board overview sections by adding borders and shadows

### DIFF
--- a/pages/community/board.tsx
+++ b/pages/community/board.tsx
@@ -8,7 +8,7 @@ export default function Board() {
   return (
     <CommunityLayout membership={Membership.BOARD}>
       <div className='mx-auto my-0 grid max-w-xl lg:max-w-screen-xl lg:grid-cols-3 lg:gap-8' data-testid='GB-content'>
-        <div>
+        <div className='rounded-md border border-gray-200 p-4 text-center shadow-md'>
           <h3 className='text-primary-800 mb-2 font-semibold lg:text-center lg:text-2xl'>
             What is the Governance Board?
           </h3>
@@ -27,7 +27,7 @@ export default function Board() {
             .
           </p>
         </div>
-        <div>
+        <div className='rounded-md border border-gray-200 p-4 text-center shadow-md'>
           <h3 className='text-primary-800 mb-2 font-semibold lg:text-center lg:text-2xl'>
             How can I become a Board Member?
           </h3>
@@ -46,7 +46,7 @@ export default function Board() {
             .
           </p>
         </div>
-        <div>
+        <div className='rounded-md border border-gray-200 p-4 text-center shadow-md'>
           <h3 className='text-primary-800 mb-2 font-semibold lg:text-center lg:text-2xl'>
             What are the responsibilities of a board member?
           </h3>


### PR DESCRIPTION


<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- The fix was pretty straight forward I just copied the card layout of the Board Members section and replicated the same for the cards above. It looks clean and blends with the rest of the layout and especially card styles.
<img width="1901" height="957" alt="image" src="https://github.com/user-attachments/assets/f5fd379a-9b8a-497c-9b9c-1bb15aa027e1" />


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Resolves #5135 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual design of three informational sections on the community board with rounded corners, borders, padding, centered text alignment, and drop shadows for better visual distinction and interface consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->