### PR TITLE
fix: move state update from useMemo to useEffect in ToolsDashboard

### DIFF
--- a/components/tools/ToolsDashboard.tsx
+++ b/components/tools/ToolsDashboard.tsx
@@ -135,9 +135,6 @@ export default function ToolsDashboard() {
         return isLanguageTool && isTechnologyTool && isSearchTool && isAsyncAPITool && isPaidTool;
       });
 
-      if (tempToolsList[category].toolsList.length) {
-        // checkToolsList is computed via useEffect below
-      }
     });
 
     Object.keys(tempToolsList).map((category) => {

--- a/components/tools/ToolsDashboard.tsx
+++ b/components/tools/ToolsDashboard.tsx
@@ -82,7 +82,7 @@ export default function ToolsDashboard() {
     }
 
     // checkToolsList is initially made false to check whether any tools are present according to the filters.
-    setCheckToolsList(false);
+    // checkToolsList is computed via useEffect below
 
     // Each tool selected is then traversed to check against each filter variable (only if the filter is applied),
     // whether they match with the filter applied or not.
@@ -136,7 +136,7 @@ export default function ToolsDashboard() {
       });
 
       if (tempToolsList[category].toolsList.length) {
-        setCheckToolsList(true);
+        // checkToolsList is computed via useEffect below
       }
     });
 
@@ -148,6 +148,15 @@ export default function ToolsDashboard() {
 
     return tempToolsList;
   }, [isPaid, isAsyncAPIOwner, languages, technologies, categories, searchName]);
+
+  // Update checkToolsList based on filtered results (moved from useMemo to avoid side effects)
+  useEffect(() => {
+    const hasTools = Object.keys(toolsList).some(
+      (category) => toolsList[category]?.toolsList?.length > 0
+    );
+    setCheckToolsList(hasTools);
+  }, [toolsList]);
+
 
   // useEffect to scroll to the opened category when url has category as element id
   useEffect(() => {


### PR DESCRIPTION
## Description

Fixes #4847

Moved `setCheckToolsList` state updates from inside `useMemo` to a dedicated `useEffect` hook.

### Problem
`useMemo` should only be used for memoized calculations, not side effects like state updates. Calling `setCheckToolsList` inside `useMemo` can cause unexpected re-renders.

### Solution
- Removed `setCheckToolsList(false)` and `setCheckToolsList(true)` from the `useMemo` callback
- Added a `useEffect` that watches `toolsList` and computes whether any tools exist
- Component behavior remains identical

### Changes
- `components/tools/ToolsDashboard.tsx`: Moved state update to `useEffect`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the tools dashboard's state and update logic to prevent unstable render-time updates and ensure the dashboard reliably reflects when tool categories contain items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->