### PR TITLE
a11y(tools): replace div+onClick with semantic button elements (#5223)

### DIFF
--- a/components/tools/Filters.tsx
+++ b/components/tools/Filters.tsx
@@ -140,9 +140,9 @@ export default function Filters({ setOpenFilter }: FiltersProps) {
                 setRead={setReadMore}
               />
             </div>
-            <div className='mb-0 flex cursor-pointer gap-0.5 text-xs hover:underline' onClick={undoChanges}>
+            <button type='button' className='mb-0 flex cursor-pointer gap-0.5 bg-transparent text-xs hover:underline' onClick={undoChanges}>
               Undo Changes
-            </div>
+            </button>
           </div>
           <div className='flex gap-2' data-testid='Applied-filters'>
             <div

--- a/components/tools/ToolsDashboard.tsx
+++ b/components/tools/ToolsDashboard.tsx
@@ -176,31 +176,33 @@ export default function ToolsDashboard() {
         <div className='my-10 flex flex-wrap justify-between gap-4 lg:flex-nowrap'>
           <div className='flex h-auto w-[47%] gap-5 lg:w-1/5'>
             <div className='relative h-auto w-full' ref={filterRef as React.LegacyRef<HTMLDivElement>}>
-              <div
+              <button
+                type='button'
                 className='flex h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-gray-300 px-4 py-1 text-sm text-gray-700 shadow hover:border-gray-600 hover:shadow-md'
                 onClick={() => setOpenFilter(!openFilter)}
                 data-testid='ToolsDashboard-Filters-Click'
               >
                 <FilterIcon />
-                <div>Filter</div>
-              </div>
+                <span>Filter</span>
+              </button>
               {openFilter && (
-                <button className='absolute top-16 z-20 min-w-[20rem]'>
+                <div className='absolute top-16 z-20 min-w-[20rem]' role='menu'>
                   <Filters setOpenFilter={setOpenFilter} />
-                </button>
+                </div>
               )}
             </div>
           </div>
           <div className='flex h-auto w-[47%] gap-5 lg:w-1/5'>
             <div className='relative h-auto w-full' ref={categoryRef as React.LegacyRef<HTMLDivElement>}>
-              <div
+              <button
+                type='button'
                 className='flex h-14 w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-gray-300 px-4 py-1 text-sm text-gray-700 shadow hover:border-gray-600 hover:shadow-md'
                 onClick={() => setopenCategory(!openCategory)}
                 data-testid='ToolsDashboard-category'
               >
-                <div>Jump to Category</div>
+                <span>Jump to Category</span>
                 <ArrowDown className={`my-auto ${openCategory ? 'rotate-180' : ''}`} />
-              </div>
+              </button>
               {openCategory && (
                 <div className='absolute right-52 top-16 z-20'>
                   <CategoryDropdown setopenCategory={setopenCategory} />


### PR DESCRIPTION
## Problem

**Fixes #5223**

The `/tools` page Filter and Jump to Category controls use `<div onClick>` instead of `<button>`, causing:
- No keyboard focus visibility
- Inconsistent Enter/Space key activation
- Screen readers not announcing them as interactive controls
- Invalid HTML: filter popup wrapped in `<button>` containing other interactive elements

## Changes

### `components/tools/ToolsDashboard.tsx`
| Element | Before | After |
|---------|--------|-------|
| Filter trigger | `<div className=... onClick={...}>` | **`<button type=button ...>`** |
| Filter popup wrapper | `<button><Filters/></button>` | **`<div role=menu>`** (non-interactive) |
| Jump to Category | `<div className=... onClick={...}>` | **`<button type=button ...>`** |
| Text wrappers | `<div>Filter</div>` | **`<span>Filter</span>`** |

### `components/tools/Filters.tsx`
| Element | Before | After |
|---------|--------|-------|
| Undo Changes | `<div className=... onClick={undoChanges}>` | **`<button type=button ...>`** |

## Accessibility Impact
- ✅ Controls now receive proper keyboard focus with visible outline
- ✅ Enter/Space keys activate controls natively
- ✅ Screen readers announce as buttons, not generic text
- ✅ Valid HTML: no nested interactive elements
- ✅ All existing styling and behavior preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved semantic HTML structure and accessibility in filter and dashboard components by updating interactive elements for better standards compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->