### PR TITLE
fix(ui): resolve Copilot PR reviews for newsletter and loader contrast

### DIFF
--- a/components/Loader.tsx
+++ b/components/Loader.tsx
@@ -35,7 +35,7 @@ export default function Loader({
   return (
     <div className={twMerge(`w-fit flex gap-4 m-auto items-center ${pulsating ? 'animate-pulse ' : ''} ${className}`)}>
       {loaderIcon}
-      <div className={`my-2 ${dark ? 'text-white' : 'text-black'}`}>{loaderText}</div>
+      <div className={`my-2 ${dark ? 'text-white' : 'text-black dark:text-white'}`}>{loaderText}</div>
     </div>
   );
 }

--- a/pages/community/tsc.tsx
+++ b/pages/community/tsc.tsx
@@ -189,7 +189,8 @@ export default function TSC() {
               type='TSC Voting'
               title='Get notified when TSC is voting'
               subtitle="You'll receive an email whenever someone requests the TSC to vote"
-              className='text-white'
+              className='text-center'
+              dark
             />
           </div>
         </div>


### PR DESCRIPTION

Issue was that the text was black
Before 
<img width="1269" height="373" alt="Screenshot 2026-05-16 at 9 09 15 PM" src="https://github.com/user-attachments/assets/3589cf4d-ddde-45c5-a366-1a382cb7f52c" />

after
<img width="1483" height="478" alt="Screenshot 2026-05-12 at 10 03 52 PM" src="https://github.com/user-attachments/assets/096ce81a-4b8c-45d8-81c5-f7a0cfe9e60c" />



The loader was not visible 
before 

<img width="1512" height="982" alt="Screenshot 2026-05-16 at 9 11 15 PM" src="https://github.com/user-attachments/assets/8d44808f-2619-4552-b938-39adac06a606" />

after


<img width="1512" height="982" alt="Screenshot 2026-05-16 at 9 12 05 PM" src="https://github.com/user-attachments/assets/3b22d5d9-d946-45ca-b64e-1074f2a067fc" />


ref : https://github.com/asyncapi/website/pull/5399#issuecomment-4432183162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved dark-mode support for loader text so it now switches colors appropriately between light and dark themes.
  * Updated the TSC community newsletter CTA styling (text centered) and enabled dark-theme styling for the CTA to improve contrast.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->