### PR TITLE
fix: update community goal from 2024 to 2026 and remove swag cards

### DIFF
--- a/pages/community/index.tsx
+++ b/pages/community/index.tsx
@@ -246,6 +246,8 @@ export default function CommunityIndexPage() {
                 Help us improve our 2026 AsyncAPI community building and maintenance goals.
               </Paragraph>
             </a>
+
+            {/* commenting this out because we have closed our swags store */}
             {/* Swags & Goodies Card
             <a
               href='https://www.store.asyncapi.com/'

--- a/pages/community/index.tsx
+++ b/pages/community/index.tsx
@@ -224,7 +224,7 @@ export default function CommunityIndexPage() {
           <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8'>
             {/* Community Goal Card */}
             <a
-              href='https://github.com/orgs/asyncapi/discussions/948'
+              href='https://github.com/asyncapi/community/blob/master/docs/030-project-vision-strategy-goals/2026_Community_Goals.md'
               target='_blank'
               rel='noopener noreferrer'
               className='relative group bg-gradient-to-br from-purple-50 to-purple-100 dark:from-purple-900/20 dark:to-purple-800/20 rounded-2xl p-8 shadow-lg hover:shadow-xl transition-all border border-purple-200 dark:border-purple-700 hover:scale-[1.02] cursor-pointer'
@@ -246,32 +246,6 @@ export default function CommunityIndexPage() {
                 Help us improve our 2024 AsyncAPI community building and maintenance goals.
               </Paragraph>
             </a>
-
-            {/* Swags & Goodies Card */}
-            <a
-              href='https://www.store.asyncapi.com/'
-              target='_blank'
-              rel='noopener noreferrer'
-              className='relative group bg-gradient-to-br from-pink-50 to-pink-100 dark:from-pink-900/20 dark:to-pink-800/20 rounded-2xl p-8 shadow-lg hover:shadow-xl transition-all border border-pink-200 dark:border-pink-700 hover:scale-[1.02] cursor-pointer'
-            >
-              <div className='absolute top-6 right-6'>
-                <IconExternalLink className='w-8 h-8 text-pink-400 dark:text-pink-300 group-hover:text-pink-500 dark:group-hover:text-pink-200 transition-colors' />
-              </div>
-              <div className='mb-6'>
-                <IconBadgeCheckmark className='w-12 h-12 text-pink-600 dark:text-pink-400' />
-              </div>
-              <Heading
-                level={HeadingLevel.h3}
-                typeStyle={HeadingTypeStyle.md}
-                className='text-pink-900 dark:text-pink-100 font-bold mb-3'
-              >
-                Swags & Goodies
-              </Heading>
-              <Paragraph typeStyle={ParagraphTypeStyle.sm} className='text-pink-800 dark:text-pink-200'>
-                Explore our swag collection of AsyncAPI-themed t-shirts and goodies.
-              </Paragraph>
-            </a>
-
             {/* Finance Card */}
             <Link
               href='/finance'

--- a/pages/community/index.tsx
+++ b/pages/community/index.tsx
@@ -246,6 +246,31 @@ export default function CommunityIndexPage() {
                 Help us improve our 2026 AsyncAPI community building and maintenance goals.
               </Paragraph>
             </a>
+            {/* Swags & Goodies Card
+            <a
+              href='https://www.store.asyncapi.com/'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='relative group bg-gradient-to-br from-pink-50 to-pink-100 dark:from-pink-900/20 dark:to-pink-800/20 rounded-2xl p-8 shadow-lg hover:shadow-xl transition-all border border-pink-200 dark:border-pink-700 hover:scale-[1.02] cursor-pointer'
+            >
+              <div className='absolute top-6 right-6'>
+                <IconExternalLink className='w-8 h-8 text-pink-400 dark:text-pink-300 group-hover:text-pink-500 dark:group-hover:text-pink-200 transition-colors' />
+              </div>
+              <div className='mb-6'>
+                <IconBadgeCheckmark className='w-12 h-12 text-pink-600 dark:text-pink-400' />
+              </div>
+              <Heading
+                level={HeadingLevel.h3}
+                typeStyle={HeadingTypeStyle.md}
+                className='text-pink-900 dark:text-pink-100 font-bold mb-3'
+              >
+                Swags & Goodies
+              </Heading>
+              <Paragraph typeStyle={ParagraphTypeStyle.sm} className='text-pink-800 dark:text-pink-200'>
+                Explore our swag collection of AsyncAPI-themed t-shirts and goodies.
+              </Paragraph>
+            </a> */}
+
             {/* Finance Card */}
             <Link
               href='/finance'

--- a/pages/community/index.tsx
+++ b/pages/community/index.tsx
@@ -243,7 +243,7 @@ export default function CommunityIndexPage() {
                 Community Goal
               </Heading>
               <Paragraph typeStyle={ParagraphTypeStyle.sm} className='text-purple-800 dark:text-purple-200'>
-                Help us improve our 2024 AsyncAPI community building and maintenance goals.
+                Help us improve our 2026 AsyncAPI community building and maintenance goals.
               </Paragraph>
             </a>
             {/* Finance Card */}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->


**Description**
fix : https://github.com/asyncapi/website/issues/5103#issuecomment-4441814899
changes the community goal to 2026 and redirect url to https://github.com/asyncapi/community/blob/master/docs/030-project-vision-strategy-goals/2026_Community_Goals.md
<img width="1313" height="582" alt="Screenshot 2026-05-14 at 7 11 45 PM" src="https://github.com/user-attachments/assets/7d2e91a8-a846-4415-94ed-0900d6152c77" />

before ->
<img width="757" height="370" alt="Screenshot 2026-05-14 at 7 34 09 PM" src="https://github.com/user-attachments/assets/c6a576b8-b3a2-477e-9cc0-b2f1b4436dbf" />

--
redirect url was -> https://github.com/orgs/asyncapi/discussions/948



<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->