### PR TITLE
fix: apply maintainer-reviewed text changes 

### DIFF
--- a/components/community/ToolingsShowcase.tsx
+++ b/components/community/ToolingsShowcase.tsx
@@ -57,11 +57,10 @@ export default function ToolingsShowcase() {
                 typeStyle={HeadingTypeStyle.xl}
                 className='text-gray-900 dark:text-dark-heading font-bold mb-4'
               >
-                Checkout Our Collection of Toolings
+                Check out our Tools collection
               </Heading>
               <Paragraph typeStyle={ParagraphTypeStyle.lg} className='text-gray-700 dark:text-gray-300 leading-relaxed'>
-                Discover various AsyncAPI tools to optimize your journey! These tools are made by the community, for the
-                community.
+                Discover community-made AsyncAPI tools to optimize your journey
               </Paragraph>
             </div>
 

--- a/components/navigation/BlogPostItem.tsx
+++ b/components/navigation/BlogPostItem.tsx
@@ -135,7 +135,7 @@ const BlogPostItem = ({ post, className = '', id = '' }: BlogPostItemProps, ref:
                 </div>
                 <div className='text-right'>
                   <Paragraph typeStyle={ParagraphTypeStyle.sm} className='text-xs text-gray-500 dark:text-gray-400'>
-                    {post.readingTime} minutes to read
+                    {post.readingTime} min read
                   </Paragraph>
                 </div>
               </div>

--- a/components/navigation/BlogPostItem.tsx
+++ b/components/navigation/BlogPostItem.tsx
@@ -135,7 +135,7 @@ const BlogPostItem = ({ post, className = '', id = '' }: BlogPostItemProps, ref:
                 </div>
                 <div className='text-right'>
                   <Paragraph typeStyle={ParagraphTypeStyle.sm} className='text-xs text-gray-500 dark:text-gray-400'>
-                    {post.readingTime} min
+                    {post.readingTime} minutes to read
                   </Paragraph>
                 </div>
               </div>

--- a/pages/casestudies/index.tsx
+++ b/pages/casestudies/index.tsx
@@ -43,7 +43,7 @@ export default function CaseStudies() {
 
   return (
     <GenericLayout
-      title='Real Stories, Real Impact'
+      title='Case Studies'
       description='Discover how leading companies use AsyncAPI to transform their API architecture, streamline development, and accelerate innovation.'
       image='/img/social/case-studies.webp'
       wide
@@ -59,7 +59,7 @@ export default function CaseStudies() {
             </div>
 
             <Heading level={HeadingLevel.h1} typeStyle={HeadingTypeStyle.xl} className='mb-6'>
-              Real Stories, Real Impact
+              Case Studies
             </Heading>
 
             <Paragraph className='text-lg text-gray-600 dark:text-gray-400 mb-8 max-w-3xl mx-auto'>

--- a/pages/community/events-and-updates.tsx
+++ b/pages/community/events-and-updates.tsx
@@ -47,7 +47,7 @@ export default function EventsAndUpdates() {
         <Container wide className='relative z-10 py-20 text-center' data-testid='EventsAndUpdates-Hero'>
           <div className='mx-auto max-w-4xl'>
             <div className='mb-6 inline-block rounded-full bg-cyan-100 px-5 py-2 text-sm font-medium text-cyan-600'>
-              Find out what&apos;s New
+              Find out what&apos;s new
             </div>
             <Heading level={HeadingLevel.h1} typeStyle={HeadingTypeStyle.xl} className='mb-6 text-gray-900'>
               Events & Updates

--- a/pages/community/index.tsx
+++ b/pages/community/index.tsx
@@ -45,7 +45,7 @@ export default function CommunityIndexPage() {
                 typeStyle={HeadingTypeStyle.lg}
                 className='text-gray-900 dark:text-dark-heading font-bold'
               >
-                Contribute To Hot Issues
+                Explore and Contribute to Hot Issues
               </Heading>
               <Paragraph typeStyle={ParagraphTypeStyle.md} className='text-gray-700 dark:text-gray-300'>
                 Discover over 100s of interesting issues, suitable for new and existing contributors.
@@ -243,7 +243,7 @@ export default function CommunityIndexPage() {
                 Community Goal
               </Heading>
               <Paragraph typeStyle={ParagraphTypeStyle.sm} className='text-purple-800 dark:text-purple-200'>
-                Help us improve our 2026 AsyncAPI community building and maintenance goals.
+                Help us in achieving our 2026 AsyncAPI community building and maintenance goals.
               </Paragraph>
             </a>
 

--- a/pages/community/tsc.tsx
+++ b/pages/community/tsc.tsx
@@ -108,7 +108,6 @@ export default function TSC() {
           </div>
         </div>
       </div>
-
       {/* Info Cards Section */}
       <div className='bg-white dark:bg-dark-background pt-8 pb-16 sm:pt-10 sm:pb-20'>
         <div className='mx-auto max-w-7xl px-4 sm:px-6 lg:px-8'>

--- a/pages/community/tsc.tsx
+++ b/pages/community/tsc.tsx
@@ -72,7 +72,7 @@ export default function TSC() {
 
   return (
     <GenericLayout
-      title='Technical Steering Committee'
+      title='Technical Steering Committee (TSC)'
       description='Meet the current AsyncAPI TSC members and learn how you can become one.'
       image={image}
       wide
@@ -82,7 +82,7 @@ export default function TSC() {
         <div className='mx-auto max-w-7xl px-4 sm:px-6 lg:px-8'>
           <div className='text-center'>
             <h1 className='text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-gray-900 dark:text-white mb-6'>
-              Technical Steering Committee
+              Technical Steering Committee (TSC)
             </h1>
             <p className='mx-auto max-w-3xl text-lg text-gray-600 dark:text-gray-400 mb-10'>
               Meet the dedicated maintainers and contributors who guide the AsyncAPI Initiative forward, making
@@ -215,7 +215,7 @@ export default function TSC() {
               <input
                 type='text'
                 aria-label='Search TSC members'
-                placeholder='Search members by name or GitHub handle...'
+                placeholder='Search TSC members by name or GitHub handle...'
                 value={searchTerm}
                 onChange={(e) => {
                   setSearchTerm(e.target.value);
@@ -287,7 +287,9 @@ export default function TSC() {
           {/* Members Grid */}
           {filteredMembers.length === 0 ? (
             <div className='text-center py-12'>
-              <p className='text-gray-600 dark:text-gray-400 text-lg'>No members found for this filter</p>
+              <p className='text-gray-600 dark:text-gray-400 text-lg'>
+                No TSC members found for the selected filter(s)
+              </p>
             </div>
           ) : (
             <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-12'>

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -539,12 +539,12 @@ export default function RoadmapPage() {
               <GoalCardRoadmapPage
                 icon={IconCode}
                 title='Unified API Specifications'
-                description='AsyncAPI seamlessly integrates with OpenAPI, GraphQL, and gRPC—no need to reinvent the wheel. Our docs embrace, not replace, existing specifications.'
+                description='AsyncAPI seamlessly integrates with OpenAPI, GraphQL, and gRPC. Our docs support existing specifications.'
               />
               <GoalCardRoadmapPage
                 icon={IconLightning}
                 title='Effortless API Development'
-                description='Build your first API in minutes—no prior AsyncAPI knowledge needed. Just add a goal as frictionless user experience. Your idea to production, across all frameworks.'
+                description='Build your first API in minutes—no prior AsyncAPI knowledge needed.'
               />
               <GoalCardRoadmapPage
                 icon={IconGear}

--- a/pages/tools/index.tsx
+++ b/pages/tools/index.tsx
@@ -88,11 +88,11 @@ export default function ToolsIndex() {
                 </div>
                 <div className='flex items-center gap-2 px-4 py-2 rounded-lg bg-white/50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 backdrop-blur-sm'>
                   <IconCommunityDriven className='w-5 h-5 text-blue-600 dark:text-blue-400' />
-                  <span className='font-medium text-gray-700 dark:text-gray-300'>Community Driven</span>
+                  <span className='font-medium text-gray-700 dark:text-gray-300'>Community-Driven</span>
                 </div>
                 <div className='flex items-center gap-2 px-4 py-2 rounded-lg bg-white/50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 backdrop-blur-sm'>
                   <IconProductionReady className='w-5 h-5 text-purple-600 dark:text-purple-400' />
-                  <span className='font-medium text-gray-700 dark:text-gray-300'>Production Ready</span>
+                  <span className='font-medium text-gray-700 dark:text-gray-300'>Production-Ready</span>
                 </div>
               </div>
             </div>

--- a/public/locales/de/landing-page.json
+++ b/public/locales/de/landing-page.json
@@ -6,7 +6,7 @@
         "body_pretext": "Open-Source-Tools zur einfachen Erstellung und Wartung Ihrer ereignisgesteuerten Architektur. Alle basieren auf der AsyncAPI-Spezifikation, der ",
         "body_boldtext": "Industriestandard",
         "body_posttext": " zur Definition asynchroner APIs.",
-        "community_btn": "sluit je aan bij onze gemeenschap",
+        "community_btn": "Treten Sie unserer Gemeinschaft bei",
         "search_btn": "Schnellsuche...",
         "slogan_text": "Wir sind stolz darauf, Teil der",
         "slogan_link": "Linux Foundation"
@@ -75,7 +75,7 @@
     },
     "events": {
         "title": "Unsere Gemeinschafts-Events",
-        "description":"AsyncAPI organiseert wekelijks verschillende bijeenkomsten. Deze richten zich op verschillende onderwerpen, soms puur technisch en soms over community-building. Kies er een en doe mee!",
-        "meetingTitle":"Lees meer over onze bijeenkomsten."
+        "description":"AsyncAPI veranstaltet jede Woche verschiedene Treffen. Sie konzentrieren sich auf verschiedene Themen, manchmal rein technisch und manchmal zum Aufbau der Gemeinschaft. Wählen Sie eins aus und machen Sie mit!",
+        "meetingTitle":"Erfahren Sie mehr über unsere Treffen."
     }
 }

--- a/public/locales/en/landing-page.json
+++ b/public/locales/en/landing-page.json
@@ -12,8 +12,8 @@
         "slogan_link": "Linux Foundation"
     },
     "features": {
-        "title": "What You Can use AsyncAPI For",
-        "description": "One of our main goals is to improve the current state of Event Driven Architecture (EDA))",
+        "title": "What you can use AsyncAPI for",
+        "description": "One of our main goals is to improve the current state of Event Driven Architecture (EDA)",
 
         "specification.name": "Specification",
         "specification.description": "Allows you to define the interfaces of asynchronous APIs and is protocol agnostic.",
@@ -44,7 +44,7 @@
     },
     "sneakpeek": {
         "title": "Sneak Peek Into The Real Process",
-        "description": "One of our main goals is to improve the current state of Event Driven Architecture (EDA))"
+        "description": "One of our main goals is to improve the current state of Event Driven Architecture (EDA)"
     },
     "adopters": {
         "title": "Adopted by the world leading brands",
@@ -53,10 +53,10 @@
     },
     "community": {
         "title": "Join our great community!",
-        "subtitle": "We're a group of amazing folks who share a great passion for AsyncAPI and event-driven architectures. We extend a warm welcome to anyone who wants to join our Slack workspace. Whether you have questions about using AsyncAPI, want to be a part of our community or simply want to say hello 👋, we'd love to have you! 🙂",
+        "subtitle": "We're a community of passionate folks who love AsyncAPI and event-driven architectures. Join our Slack workspace if you have questions about AsyncAPI, want to be part of our community, or just want to say hello.",
         "slackCTATitle": "Join our Slack workspace",
         "slackCTADesc": "We welcome everyone to join our Slack workspace. If you have a question on how to use AsyncAPI, want to contribute, or simply want to say hello 👋, you're welcome to join us. We're nice people 🙂",
-        "slackCTABtn": "Join us on Slack!",
+        "slackCTABtn": "Join us on Slack",
         "meetingTitle": "Join our public meetings",
         "meetingDesc": "AsyncAPI hosts different meetings every week. They are focused on different topics, sometimes purely technical and sometimes about community building. Pick one and join us!",
         "meetingLink": "Learn more about our meetings."


### PR DESCRIPTION
## Description

As part of the [website redesign](https://github.com/asyncapi/website/issues/5103), we have some text changes in our newly redesigned website as seen in [PR #5253](https://github.com/asyncapi/website/pull/5253). This PR addresses [this comment](https://github.com/asyncapi/website/issues/5103#issuecomment-4306387216) by improving those texts according to our charter and community guidelines as suggested by maintainers in the [review sheet](https://docs.google.com/spreadsheets/d/1X5T2ccCrLZAw-wVEDQsl4vn0ufCDpV8WYmkj_VAJBx0/edit?gid=0#gid=0).

Changes based on feedback from Anthony, Lukasz, Christine, and Prince.


### Conflicts and concerns from the review sheet

Not changed in this PR — listing for discussion:

**TSC page (`tsc.tsx`):**

1. Button text `"Learn How to Join"` / `"View Members"` — Anthony: *"ambiguous button text. Learn how to Join members? Learn how to View Members? If I need to learn how to view members, the current navigation flow is definitely broken."*

**Community page (`community/index.tsx`):**

2. `"Join the conversation with over 10k+ developers from literally everywhere"` — Anthony: *"Join the conversation with 10+ developers from around the world."*

3. `"Discover over 100s of interesting issues"` — Anthony: *"Find hundreds of interesting issues for new and existing contributors."*

4. `"Never Get Left Behind"` — Anthony: *"Stay in touch with the latest news and activities happening in the community."*

5. `"Community heartbeat"` — Anthony: *"without context, it's hard to grasp what heartbeat means. There is already used phrase 'pulse of our community', keep it consistent."*

6. `"Meet Folks Redefining the Initiative"` — Anthony: *"How it differs from the formulation about TSC?"*

7. `"Track Initiative Spending with Budget Analysis"` — Anthony: *"Track Initiative spending with Budget Analysis"* (lowercase 's' in spending)

**Events & Updates page (`events-and-updates.tsx`):**

8. `"Everything You Need"` — Anthony: *"Everything you need for what?"*

9. Section descriptions for `"Latest Updates"`, `"Global Community"`, `"Videos & Live Streams"` — Anthony raised consistency concerns with other pages' descriptions.

**Landing page (`pages/[lang]/index.tsx` and locale files):**

10. Testimonials section replaced with `"Our Community Events"` — Anthony: *"testimonials === community events?"*

11. Meeting description text — Anthony: *"Text in cell c47 sounds more natural."* (applies to both the component and locale file)

12. Hero CTA button changed from `"Read the docs"` to `"Join our community"` — Anthony: *"Read the docs is not the same as joining the community."* (affects both `Hero.tsx` and `en/landing-page.json`)

13. subHeader split into 2 locale keys: `"Event-Driven"` + `"Architectures (EDA)"` — Anthony: *"leave the original text."* (applies to both EN and DE locales, merging back would need a component change too)

14. Navigation dropdown descriptions for Events & Newsroom — Anthony: *"What about text in cells C37, C38, C43?"* (consistency with events-and-updates page)

**Roadmap page (`roadmap.tsx`):**

15. `"400% Community Growth"` — Anthony: *"400% growth in what timeframe? or since when?"*

**Case Studies page (`casestudies/index.tsx`):**

16. Case studies intro and submission text — Anthony suggests rewrites: *"Learn AsyncAPI through documentation focused on recommendations and best practices, as well as real-life case studies"* and *"Submit your case study using our template. For more details, read our FAQ."* Also: *"the last phrase about time-consuming procedure feels incomplete."*

**Ambassadors page (`ambassadors/index.tsx`):**

17. Page uses both `"Join"` and `"Become"` — Anthony: *"join or become? Let's use only one."* Also suggests `"Join AsyncAPI Ambassadors"` instead of `"Join these AsyncAPI Ambassadors"`.


