### PR TITLE
fix(blog): remove broken link to missing GitHub workflow in shai-hulud postmortem

### DIFF
--- a/markdown/blog/shai-hulud-postmortem.md
+++ b/markdown/blog/shai-hulud-postmortem.md
@@ -97,7 +97,7 @@ Regardless of how much we prepare, security incidents can still occur. This inci
 
 - Have backup maintainers with publishing rights and revoking rights for tokens to reduce single points of failure.
 - Token rotation and limited scope tokens should be enforced. The NPM token we were using was three years old and has now been revoked.
-- Got to know about a [workflow with unsecured context](https://github.com/asyncapi/cli/blob/master/.github/workflows/auto-changeset.yml) in GitHub Actions. Although it is not the root cause here, we have fixed it to avoid any future risks in [PR #1909](https://github.com/asyncapi/cli/pull/1909)
+- Got to know about a workflow with unsecured context in GitHub Actions. Although it is not the root cause here, we have fixed it to avoid any future risks in [PR #1909](https://github.com/asyncapi/cli/pull/1909)
 
 
 **If you have any further questions or need assistance, please do not hesitate to reach out to us at [security@asyncapi.com](mailto:security@asyncapi.com)**


### PR DESCRIPTION
### Describe the bug
The link labeled "workflow with unsecured context" in the [Shai Hulud postmortem blog post](https://www.asyncapi.com/blog/shai-hulud-postmortem) points to a GitHub Actions workflow URL that returns a 404. The workflow file was removed from the asyncapi/cli repository.

### Proposed fix
Removes the hyperlink while keeping the descriptive text, as the workflow file no longer exists.

Fixes #4970

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a blog postmortem entry in the lessons learned section to simplify security-related references while preserving the key security discussion points.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5432?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->