### PR TITLE
fix: yaml spectral example for issue #5117

### DIFF
--- a/markdown/docs/guides/validate.md
+++ b/markdown/docs/guides/validate.md
@@ -57,34 +57,23 @@ To get started:
 1. Install [Spectral](https://meta.stoplight.io/docs/spectral/b8391e051b7d8-installation). 
 2. Create a file named `.spectral.yaml` to begin writing your API description and document rules. 
     Example:
-    ```js
-    {
-      "rules": {
-        // add your own rules here
-      }
-    }
+    ```yaml
+    rules:
+      # add your own rules here
     ```
 
 3. Create and add your own custom ruleset:
- ```js
-  {
-      "rules": {
-          "valid-document-version": {
-              "message": "Application title must start with upper case",
-              "severity": "error",
-              "given": "$.info",
-              "then": [
-                  {
-                      "field": "title",
-                      "function": "pattern",
-                      "functionOptions": {
-                          "match": "^[A-Z]"
-                      }
-                  }
-              ]
-          }
-      }
-  }
+ ```yaml
+  rules:
+    valid-document-version:
+      message: "Application title must start with upper case"
+      severity: "error"
+      given: "$.info"
+      then:
+        - field: "title"
+          function: "pattern"
+          functionOptions:
+            match: "^[A-Z]"
   ```
 
 4. After setting up Spectral and creating custom rules following steps 1 - 3, validate your AsyncAPI document using this Spectral CLI command:

--- a/markdown/docs/guides/validate.md
+++ b/markdown/docs/guides/validate.md
@@ -63,18 +63,18 @@ To get started:
     ```
 
 3. Create and add your own custom ruleset:
- ```yaml
-  rules:
-    valid-document-version:
-      message: "Application title must start with upper case"
-      severity: "error"
-      given: "$.info"
-      then:
-        - field: "title"
-          function: "pattern"
-          functionOptions:
-            match: "^[A-Z]"
-  ```
+    ```yaml
+    rules:
+      valid-document-version:
+        message: "Application title must start with upper case"
+        severity: "error"
+        given: "$.info"
+        then:
+          - field: "title"
+            function: "pattern"
+            functionOptions:
+              match: "^[A-Z]"
+    ```
 
 4. After setting up Spectral and creating custom rules following steps 1 - 3, validate your AsyncAPI document using this Spectral CLI command:
 


### PR DESCRIPTION
## Fix YAML examples in Spectral validation guide

Changed JSON code blocks to valid YAML examples in the Spectral validation documentation.

**Changes:**
- Converted ```js JSON examples to ```yaml YAML
- Updated ruleset structure to proper YAML format

Ref: Issue #5117

Related: https://github.com/asyncapi/website/issues/5117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated validation guide examples to use YAML format instead of JavaScript object literals for clearer configuration guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->