### PR TITLE
fix(roadmap): make roadmap description text fully readable in modal (#4958)

### DIFF
--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -70,7 +70,7 @@ export default function Modal({ title, children, onModalClose = () => {} }: IMod
             </svg>
           </button>
         </div>
-        <div className='max-h-[65vh] w-full overflow-auto lg:max-h-[70vh]'>{children}</div>
+        <div className='max-h-[65vh] w-full overflow-auto break-words lg:max-h-[70vh]'>{children}</div>
       </div>
     </div>
   );

--- a/components/roadmap/RoadmapPill.tsx
+++ b/components/roadmap/RoadmapPill.tsx
@@ -96,7 +96,7 @@ export default function Pill({
       </div>
       {isDescriptionVisible && (
         <Modal title={item.title} onModalClose={() => setIsDescriptionVisible(false)}>
-          <div className='prose'>{item.description}</div>
+          <div className='prose whitespace-normal break-words'>{item.description}</div>
         </Modal>
       )}
     </>


### PR DESCRIPTION
### Description
Fixes #4958 - Roadmap descriptions in the detail modal were being truncated/unreadable.

### Changes
1. Added `break-words` to Modal content container so long text properly wraps
2. Added `whitespace-normal break-words` to roadmap description text to prevent overflow and truncation

### How to test
1. Go to the Roadmap page
2. Click on any roadmap item to open the detail modal
3. Verify that the description text is fully visible and wraps properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text wrapping in modal content to ensure long unbroken text displays properly without breaking the layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->