### PR TITLE
fix: make tools workflow output fully deterministic

### DIFF
--- a/scripts/tools/combine-tools.ts
+++ b/scripts/tools/combine-tools.ts
@@ -291,6 +291,7 @@ const combineTools = async (
           }
 
           const titleCmp = tool.title.localeCompare(anotherTool.title);
+
           if (titleCmp !== 0) return titleCmp;
 
           // Secondary sort by repoUrl to ensure deterministic ordering when titles match

--- a/scripts/tools/combine-tools.ts
+++ b/scripts/tools/combine-tools.ts
@@ -290,18 +290,29 @@ const combineTools = async (
             return 0;
           }
 
-          return tool.title.localeCompare(anotherTool.title);
+          const titleCmp = tool.title.localeCompare(anotherTool.title);
+          if (titleCmp !== 0) return titleCmp;
+
+          // Secondary sort by repoUrl to ensure deterministic ordering when titles match
+          const repoA = tool.links?.repoUrl || '';
+          const repoB = anotherTool.links?.repoUrl || '';
+          return repoA.localeCompare(repoB);
         }) as FinalAsyncAPITool[];
       }
     }
 
     fs.writeFileSync(toolsPath, JSON.stringify(finalTools, null, 2));
+
+    // Sort tags alphabetically to ensure deterministic output
+    const sortedLanguages = [...languageList].sort((a, b) => a.name.localeCompare(b.name));
+    const sortedTechnologies = [...technologyList].sort((a, b) => a.name.localeCompare(b.name));
+
     fs.writeFileSync(
       tagsPath,
       JSON.stringify(
         {
-          languages: languageList,
-          technologies: technologyList
+          languages: sortedLanguages,
+          technologies: sortedTechnologies
         },
         null,
         2
@@ -320,6 +331,15 @@ const combineTools = async (
     }
 
     if (ignoredOutputPath && ignoredTools.length > 0) {
+      // Sort ignored tools deterministically for consistent output
+      const sortedIgnoredTools = [...ignoredTools].sort((a, b) => {
+        const titleCmp = (a.title || '').localeCompare(b.title || '');
+        if (titleCmp !== 0) return titleCmp;
+        const catCmp = (a.category || '').localeCompare(b.category || '');
+        if (catCmp !== 0) return catCmp;
+        return (a.repoUrl || '').localeCompare(b.repoUrl || '');
+      });
+
       fs.writeFileSync(
         ignoredOutputPath,
         JSON.stringify(
@@ -327,7 +347,7 @@ const combineTools = async (
             description: 'Auto-generated audit log of tools ignored during the last combine run.',
             generatedAt: new Date().toISOString(),
             totalIgnored: ignoredTools.length,
-            ignoredTools
+            ignoredTools: sortedIgnoredTools
           },
           null,
           2

--- a/scripts/tools/combine-tools.ts
+++ b/scripts/tools/combine-tools.ts
@@ -296,6 +296,7 @@ const combineTools = async (
           // Secondary sort by repoUrl to ensure deterministic ordering when titles match
           const repoA = tool.links?.repoUrl || '';
           const repoB = anotherTool.links?.repoUrl || '';
+
           return repoA.localeCompare(repoB);
         }) as FinalAsyncAPITool[];
       }
@@ -334,9 +335,13 @@ const combineTools = async (
       // Sort ignored tools deterministically for consistent output
       const sortedIgnoredTools = [...ignoredTools].sort((a, b) => {
         const titleCmp = (a.title || '').localeCompare(b.title || '');
+
         if (titleCmp !== 0) return titleCmp;
+
         const catCmp = (a.category || '').localeCompare(b.category || '');
+
         if (catCmp !== 0) return catCmp;
+
         return (a.repoUrl || '').localeCompare(b.repoUrl || '');
       });
 

--- a/tests/fixtures/combineToolsData.ts
+++ b/tests/fixtures/combineToolsData.ts
@@ -15,14 +15,14 @@ const expectedDataT1 = {
   ],
   technologies: [
     {
-      name: 'Node.js',
-      color: 'bg-[#61d0f2]',
-      borderColor: 'border-[#40ccf7]'
-    },
-    {
       name: 'Flask',
       color: 'bg-[#000000]',
       borderColor: 'border-[#FFFFFF]'
+    },
+    {
+      name: 'Node.js',
+      color: 'bg-[#61d0f2]',
+      borderColor: 'border-[#40ccf7]'
     }
   ]
 };


### PR DESCRIPTION
## Description

This PR addresses issue #5341: the weekly `regenerate-tools.yml` workflow produces PRs with non-deterministic diffs (reordering of tools even when nothing changed), making reviews harder for maintainers.

### Changes

Three fixes in `scripts/tools/combine-tools.ts` to ensure fully deterministic output:

1. **Secondary sort key in `tools.json`** — When two tools share the same title, they are now sorted by `repoUrl` as a tiebreaker. Previously, their relative order depended on the non-deterministic order items arrived from `Promise.all`.

2. **Alphabetical tag ordering in `all-tags.json`** — `languageList` and `technologyList` are now sorted by `name` before writing. Previously, their order depended on which tools were processed first, which varied across runs.

3. **Deterministic `tools-ignored.json` audit log** — The ignored tools array is now sorted by title → category → repoUrl for consistent diff output.

### Testing

All 56 tool tests pass (3 test suites).

Closes #5341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tools and tag lists now use deterministic ordering so outputs are consistent and repeatable.
  * When tool titles match, a secondary deterministic tie-breaker ensures stable placement.
  * Language and technology tag lists are written alphabetically.
  * Ignored-tools audit output is now sorted deterministically for predictable review.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->