### PR TITLE
refactor(navbar): use twMerge for z-index className management instead of template literal

### DIFF
--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -3,6 +3,7 @@ import type { NextRouter } from 'next/router';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React, { useEffect, useState } from 'react';
+import { twMerge } from 'tailwind-merge';
 
 import { defaultLanguage, i18nPaths, languages } from '@/utils/i18n';
 
@@ -144,7 +145,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
   }, [asPath]);
 
   return (
-    <div className={`bg-white ${className} z-50`}>
+    <div className={twMerge('bg-white z-50', className)}>
       <div className='flex w-full items-center justify-between py-6 lg:justify-start lg:space-x-2'>
         {!hideLogo && (
           <div className='lg:w-auto lg:flex-1'>


### PR DESCRIPTION
## Description

Refactors  to use  for className concatenation instead of template literal, which is the established pattern used throughout the codebase.

### Changes
- Added  
- Changed `<div className={`bg-white ${className} z-50`}>` to `<div className={twMerge('bg-white z-50', className)}>`

### Related Issue
Closes #4779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to enhance maintainability.

**Note:** This release contains no new features or user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->