### PR TITLE
fix: resolve React Hooks ESLint warnings in Filters.tsx and AnnouncementHero.tsx

### DIFF
--- a/components/campaigns/AnnouncementHero.tsx
+++ b/components/campaigns/AnnouncementHero.tsx
@@ -21,7 +21,7 @@ interface IAnnouncementHeroProps {
 export default function AnnouncementHero({ className = '', small = false }: IAnnouncementHeroProps) {
   const [activeIndex, setActiveIndex] = useState(0);
 
-  const visibleBanners = useMemo(() => banners.filter((banner) => shouldShowBanner(banner.cfpDeadline)), [banners]);
+  const visibleBanners = useMemo(() => banners.filter((banner) => shouldShowBanner(banner.cfpDeadline)), []);
   const numberOfVisibleBanners = visibleBanners.length;
 
   const goToPrevious = () => {

--- a/components/dashboard/table/Filters.tsx
+++ b/components/dashboard/table/Filters.tsx
@@ -39,7 +39,7 @@ function useOutsideAlerter(ref: RefObject<any>, setOpen: (open: boolean) => void
       // Unbind the event listener on clean up
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [ref]);
+  }, [ref, setOpen]);
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes two React Hooks ESLint warnings in the codebase:

### Changes

1. **components/dashboard/table/Filters.tsx**: Added `setOpen` to the `useOutsideAlerter` useEffect dependency array to prevent stale closures.

2. **components/campaigns/AnnouncementHero.tsx**: Removed unnecessary `banners` dependency from the `useMemo` hook since `banners` is a module-level constant that never changes.

### Related Issue
Closes #5125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated component dependency arrays to improve computation and effect execution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->