### PR TITLE
test: add unit tests for scripts/compose.ts

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ const config = {
   coverageReporters: ['text', 'lcov', 'json-summary'],
   coverageDirectory: 'coverage',
   collectCoverageFrom: ['scripts/**/*.ts'],
-  coveragePathIgnorePatterns: ['scripts/compose.ts', 'scripts/tools/categorylist.ts', 'scripts/tools/tags-color.ts'],
+  coveragePathIgnorePatterns: ['scripts/tools/categorylist.ts', 'scripts/tools/tags-color.ts'],
   testMatch: ['**/tests/**/*.test.*', '!**/netlify/**/*.test.*'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json']
 };

--- a/scripts/compose.ts
+++ b/scripts/compose.ts
@@ -31,7 +31,7 @@ type ComposePromptType = {
  * @param answers - User inputs for the blog post, including title, excerpt, comma-separated tags, type, and canonical URL.
  * @returns The generated Markdown front matter and blog post content template.
  */
-function genFrontMatter(answers: ComposePromptType): string {
+export function genFrontMatter(answers: ComposePromptType): string {
   const tagArray = answers.tags.split(',');
 
   tagArray.forEach((tag: string, index: number) => {

--- a/tests/compose.test.ts
+++ b/tests/compose.test.ts
@@ -1,0 +1,187 @@
+import dayjs from 'dayjs';
+
+// Mock inquirer BEFORE importing compose to handle module-level .prompt().then() chain
+jest.mock('inquirer', () => ({
+  prompt: jest.fn().mockReturnValue(Promise.resolve({
+    title: '',
+    excerpt: '',
+    tags: '',
+    type: 'Engineering',
+    canonical: ''
+  }))
+}));
+
+jest.mock('fs', () => ({
+  writeFile: jest.fn()
+}));
+
+jest.mock('../scripts/helpers/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
+// Now import after mocks are set up
+import { genFrontMatter } from '../scripts/compose';
+
+describe('genFrontMatter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should generate complete front matter with all fields provided', () => {
+    const mockDate = '2026-05-21T12:00:00Z';
+    const dateSpy = jest.spyOn(dayjs.prototype, 'format').mockReturnValue(mockDate);
+
+    const answers = {
+      title: 'My Test Blog Post',
+      excerpt: 'A short excerpt for testing',
+      tags: 'asyncapi, testing, jest',
+      type: 'Engineering' as const,
+      canonical: 'https://example.com/blog/test'
+    };
+
+    const result = genFrontMatter(answers);
+
+    expect(result).toContain('title: My Test Blog Post');
+    expect(result).toContain('date: 2026-05-21T12:00:00Z');
+    expect(result).toContain('type: Engineering');
+    expect(result).toContain('canonical: https://example.com/blog/test');
+    expect(result).toContain("tags: ['asyncapi','testing','jest']");
+    expect(result).toContain('excerpt: A short excerpt for testing');
+
+    dateSpy.mockRestore();
+  });
+
+  test('should handle empty title with default', () => {
+    const answers = {
+      title: '',
+      excerpt: '',
+      tags: '',
+      type: 'Community' as const,
+      canonical: ''
+    };
+
+    const result = genFrontMatter(answers);
+
+    expect(result).toContain('title: Untitled');
+    expect(result).toContain('type: Community');
+  });
+
+  test('should trim whitespace from tags', () => {
+    const answers = {
+      title: 'Tag Test',
+      excerpt: 'Testing tag trimming',
+      tags: '  asyncapi  ,  testing  ,  trim  ',
+      type: 'Marketing' as const,
+      canonical: ''
+    };
+
+    const result = genFrontMatter(answers);
+
+    expect(result).toContain("tags: ['asyncapi','testing','trim']");
+    expect(result).not.toContain("'  asyncapi  '");
+  });
+
+  test('should handle single tag without comma', () => {
+    const answers = {
+      title: 'Single Tag',
+      excerpt: '',
+      tags: 'asyncapi',
+      type: 'Strategy' as const,
+      canonical: ''
+    };
+
+    const result = genFrontMatter(answers);
+
+    expect(result).toContain("tags: ['asyncapi']");
+  });
+
+  test('should handle empty tags as empty array', () => {
+    const answers = {
+      title: 'No Tags',
+      excerpt: '',
+      tags: '',
+      type: 'Video' as const,
+      canonical: ''
+    };
+
+    const result = genFrontMatter(answers);
+
+    expect(result).toContain('tags: []');
+  });
+
+  test('should generate front matter for all valid post types', () => {
+    const types = ['Communication', 'Community', 'Engineering', 'Marketing', 'Strategy', 'Video'] as const;
+
+    for (const type of types) {
+      const answers = {
+        title: `Post Type ${type}`,
+        excerpt: '',
+        tags: '',
+        type,
+        canonical: ''
+      };
+
+      const result = genFrontMatter(answers);
+      expect(result).toContain(`type: ${type}`);
+    }
+  });
+
+  test('should include canonical URL when provided', () => {
+    const answers = {
+      title: 'Canonical Test',
+      excerpt: '',
+      tags: '',
+      type: 'Engineering' as const,
+      canonical: 'https://asyncapi.com/blog/canonical'
+    };
+
+    const result = genFrontMatter(answers);
+
+    expect(result).toContain('canonical: https://asyncapi.com/blog/canonical');
+  });
+
+  test('should leave canonical field empty when not provided', () => {
+    const answers = {
+      title: 'No Canonical',
+      excerpt: '',
+      tags: '',
+      type: 'Engineering' as const,
+      canonical: ''
+    };
+
+    const result = genFrontMatter(answers);
+
+    expect(result).toContain('canonical: ');
+  });
+
+  test('should generate proper YAML front matter delimiters', () => {
+    const answers = {
+      title: 'Delimiter Test',
+      excerpt: '',
+      tags: '',
+      type: 'Engineering' as const,
+      canonical: ''
+    };
+
+    const result = genFrontMatter(answers);
+
+    expect(result.startsWith('---')).toBe(true);
+    expect(result.trim().endsWith('---')).toBe(true);
+  });
+
+  test('should handle special characters in tags', () => {
+    const answers = {
+      title: 'Special Tags',
+      excerpt: '',
+      tags: 'c++, .net, node.js',
+      type: 'Engineering' as const,
+      canonical: ''
+    };
+
+    const result = genFrontMatter(answers);
+    expect(result).toContain("tags: ['c++','.net','node.js']");
+  });
+});


### PR DESCRIPTION
## Description

This PR adds comprehensive unit tests for the `scripts/compose.ts` script, which handles blog post creation via an interactive CLI prompt.

Fixes #5096

## Changes

1. **`scripts/compose.ts`**: Exported the `genFrontMatter` function (was internal) to make it testable without invoking the full inquirer prompt flow.

2. **`tests/compose.test.ts`** (new): 10 unit tests covering:
   - Full front matter generation with all fields
   - Empty title → defaults to 'Untitled'
   - Tag whitespace trimming
   - Single tag and empty tags handling
   - All 6 valid post types
   - Canonical URL inclusion/exclusion
   - YAML front matter delimiter correctness (`---`)
   - Special characters in tags (`c++`, `.net`, `node.js`)

3. **`jest.config.js`**: Removed `scripts/compose.ts` from `coveragePathIgnorePatterns` now that it has test coverage.

## Testing

All 245 tests pass (23 suites), including the 10 new tests:

```
PASS tests/compose.test.ts
  genFrontMatter
    ✓ should generate complete front matter with all fields provided (7 ms)
    ✓ should handle empty title with default (1 ms)
    ✓ should trim whitespace from tags (1 ms)
    ✓ should handle single tag without comma (2 ms)
    ✓ should handle empty tags as empty array (1 ms)
    ✓ should generate front matter for all valid post types (3 ms)
    ✓ should include canonical URL when provided
    ✓ should leave canonical field empty when not provided (1 ms)
    ✓ should generate proper YAML front matter delimiters (2 ms)
    ✓ should handle special characters in tags (1 ms)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for front matter generation with validation of fields, defaults, and special character handling.

* **Chores**
  * Updated test coverage configuration to include previously ignored modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->