### PR TITLE
fix: prevent info tooltip from reopening after outside click dismissal (#5098)

### DIFF
--- a/components/tools/CardData.tsx
+++ b/components/tools/CardData.tsx
@@ -67,9 +67,10 @@ export const CardData = ({
   // Decide whether the user click outside this component (card description) or not.
   useEffect(() => {
     const maybeHandler = (event: MouseEvent) => {
-      setOutsideClick(true);
       if (domNode.current && !domNode.current.contains(event.target as Node)) {
         setOutsideClick(false);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        setVisible((prev: any) => ({ ...prev, [type]: false }));
       }
     };
 
@@ -78,7 +79,7 @@ export const CardData = ({
     return () => {
       document.removeEventListener('mousedown', maybeHandler);
     };
-  }, []);
+  }, [type, setVisible]);
 
   return (
     <div className={twMerge('text-left text-sm text-gray-500', className)}>

--- a/components/tools/CardData.tsx
+++ b/components/tools/CardData.tsx
@@ -69,8 +69,7 @@ export const CardData = ({
     const maybeHandler = (event: MouseEvent) => {
       if (domNode.current && !domNode.current.contains(event.target as Node)) {
         setOutsideClick(false);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        setVisible((prev: any) => ({ ...prev, [type]: false }));
+        setVisible((prev: VisibleDataListType) => ({ ...prev, [type]: false }));
       }
     };
 

--- a/components/tools/CardData.tsx
+++ b/components/tools/CardData.tsx
@@ -113,6 +113,7 @@ export const CardData = ({
         )}
         <button
           onClick={() => {
+            setOutsideClick(true);
             setRead(false);
             setVisible({ ...initial, [type]: !visible[type] });
           }}


### PR DESCRIPTION
## Description

Fixes #5098

### Problem
When the user opens the info (ⓘ) tooltip on a tool card and then dismisses it by clicking outside, clicking anywhere on the page causes the tooltip to reappear without interaction.

### Root Cause
After outside click dismissal, `visible[type]` remains `true` while `outsideClick` is set to `false`. On the next mousedown, React clears `domNode.current` to `null` (the tooltip span was unmounted), so the guard condition `domNode.current.contains(event.target)` fails and `setOutsideClick(true)` fires without the corresponding `setOutsideClick(false)` — making `outsideClick` become `true`. Since `visible[type]` is still `true`, the tooltip reappears.

### Fix
1. Also reset `visible[type]` to `false` on outside click dismissal, keeping both state variables consistent.
2. Remove the unconditional `setOutsideClick(true)` that was flip-flopping the state.

### Changes
- `components/tools/CardData.tsx`: Updated outside-click handler to also reset visible state, added proper dependencies to the useEffect.

### Testing
Manual verification: open tooltip → click outside → click anywhere on page → tooltip stays closed. Click info button again → tooltip opens correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed card behavior so clicking outside a card's description reliably closes that card section.
  * Improved toggle and outside-click handling to ensure cards consistently reset state and close as expected when interacted with, preventing them from remaining open unexpectedly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->