### PR TITLE
fix: prevent info tooltip from reopening on outside click

### DIFF
--- a/components/tools/CardData.tsx
+++ b/components/tools/CardData.tsx
@@ -67,9 +67,14 @@ export const CardData = ({
   // Decide whether the user click outside this component (card description) or not.
   useEffect(() => {
     const maybeHandler = (event: MouseEvent) => {
-      setOutsideClick(true);
       if (domNode.current && !domNode.current.contains(event.target as Node)) {
+        // Clicked outside: hide tooltip and reset visibility so it won't
+        // reappear on the next arbitrary click (fixes #5098)
         setOutsideClick(false);
+        setVisible((prev) => ({ ...prev, [type]: false }));
+        setRead(false);
+      } else {
+        setOutsideClick(true);
       }
     };
 
@@ -78,7 +83,7 @@ export const CardData = ({
     return () => {
       document.removeEventListener('mousedown', maybeHandler);
     };
-  }, []);
+  }, [type, setVisible, setRead]);
 
   return (
     <div className={twMerge('text-left text-sm text-gray-500', className)}>


### PR DESCRIPTION
## Description

Fixes #5098

**Problem:** When clicking the info (?) button in ToolCard components to open a tooltip, then closing it by clicking outside, clicking anywhere on the page would cause the tooltip to reopen automatically without interacting with the info button.

**Root Cause:** In `CardData.tsx`, the `mousedown` event handler always set `outsideClick` to `true` first, then conditionally set it to `false` if the click was outside the tooltip. However, `visible[type]` remained `true` after an outside click. On the next arbitrary click, `outsideClick` was immediately set back to `true`, and since `visible[type]` was still `true`, the tooltip reappeared.

**Fix:** When a click outside the tooltip is detected, reset both `outsideClick` to `false` **and** `visible[type]` to `false`. The tooltip will now only reappear when the user explicitly clicks the info button again.

## Changes

- `components/tools/CardData.tsx`: Restructured the `maybeHandler` to set `visible[type] = false` and `setRead(false)` when clicking outside, preventing the tooltip from reappearing on subsequent clicks.

## Testing

- Click info button ? tooltip opens ?
- Click outside ? tooltip closes ?
- Click anywhere on page ? tooltip stays closed ?
- Click info button again ? tooltip opens ?
- Click "Show More"/"Show Less" inside tooltip ? works correctly ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tooltip behavior to reliably hide when clicking outside the associated element while remaining visible for clicks inside it.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->