### PR TITLE
fix: replace unstable external Netlify badge SVG with local asset

### DIFF
--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -112,11 +112,7 @@ export default function Footer() {
           <div className='mt-8 block sm:mt-0'>
             <p className='block text-sm leading-6'>
               <a href='https://netlify.com' target='_blank' rel='noopener noreferrer'>
-                <img
-                  src='/img/supportus/netlify.png'
-                  className='inline h-11'
-                  alt='Deploys by Netlify'
-                />
+                <img src='/img/supportus/netlify.png' className='inline h-11' alt='Deploys by Netlify' />
               </a>
             </p>
           </div>

--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -113,8 +113,8 @@ export default function Footer() {
             <p className='block text-sm leading-6'>
               <a href='https://netlify.com' target='_blank' rel='noopener noreferrer'>
                 <img
-                  src='https://www.netlify.com/img/global/badges/netlify-color-bg.svg'
-                  className='inline'
+                  src='/img/supportus/netlify.png'
+                  className='inline h-11'
                   alt='Deploys by Netlify'
                 />
               </a>


### PR DESCRIPTION
## Description

Fixes #5421

**Problem:** The Netlify footer badge depends on an external SVG URL that returns 404, causing the badge to disappear in local development and production.

**Root Cause:** The external URL `https://www.netlify.com/img/global/badges/netlify-color-bg.svg` no longer serves a valid SVG - it returns a 404 page.

**Fix:** Replace the broken external SVG with the local asset `/img/supportus/netlify.png` that already exists in the repository. This ensures the badge renders reliably regardless of external service availability.

## Changes

- `components/footer/Footer.tsx`: Replaced `src` from external URL to local `/img/supportus/netlify.png` with explicit `h-11` height for consistent sizing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Replaced the remote Netlify badge with a local image in the footer.
  * Adjusted badge sizing to improve visual consistency and alignment across screen sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->