### PR TITLE
fix: update broken link to GitHub Actions workflow in blog post

### DIFF
--- a/markdown/blog/shai-hulud-postmortem.md
+++ b/markdown/blog/shai-hulud-postmortem.md
@@ -97,7 +97,7 @@ Regardless of how much we prepare, security incidents can still occur. This inci
 
 - Have backup maintainers with publishing rights and revoking rights for tokens to reduce single points of failure.
 - Token rotation and limited scope tokens should be enforced. The NPM token we were using was three years old and has now been revoked.
-- Got to know about a [workflow with unsecured context](https://github.com/asyncapi/cli/blob/master/.github/workflows/auto-changeset.yml) in GitHub Actions. Although it is not the root cause here, we have fixed it to avoid any future risks in [PR #1909](https://github.com/asyncapi/cli/pull/1909)
+- Got to know about a [workflow with unsecured context](https://github.com/asyncapi/cli/blob/master/.github/workflows/release-with-changesets.yml) in GitHub Actions. Although it is not the root cause here, we have fixed it to avoid any future risks in [PR #1909](https://github.com/asyncapi/cli/pull/1909)
 
 
 **If you have any further questions or need assistance, please do not hesitate to reach out to us at [security@asyncapi.com](mailto:security@asyncapi.com)**


### PR DESCRIPTION
Fixes #4970

**Problem:** The link labeled "workflow with unsecured context" in the Shai Hulud postmortem blog post pointed to `auto-changeset.yml` which returns 404.

**Fix:** Updated the link to point to `release-with-changesets.yml`, which is the current name of the workflow file in the asyncapi/cli repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated blog post postmortem documentation with revised workflow reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->