### PR TITLE
test: add unit tests for scripts/compose.ts

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ const config = {
   coverageReporters: ['text', 'lcov', 'json-summary'],
   coverageDirectory: 'coverage',
   collectCoverageFrom: ['scripts/**/*.ts'],
-  coveragePathIgnorePatterns: ['scripts/tools/categorylist.ts', 'scripts/tools/tags-color.ts'],
+  coveragePathIgnorePatterns: ['scripts/compose.ts', 'scripts/tools/categorylist.ts', 'scripts/tools/tags-color.ts'],
   testMatch: ['**/tests/**/*.test.*', '!**/netlify/**/*.test.*'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json']
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ const config = {
   coverageReporters: ['text', 'lcov', 'json-summary'],
   coverageDirectory: 'coverage',
   collectCoverageFrom: ['scripts/**/*.ts'],
-  coveragePathIgnorePatterns: ['scripts/compose.ts', 'scripts/tools/categorylist.ts', 'scripts/tools/tags-color.ts'],
+  coveragePathIgnorePatterns: ['scripts/tools/categorylist.ts', 'scripts/tools/tags-color.ts'],
   testMatch: ['**/tests/**/*.test.*', '!**/netlify/**/*.test.*'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json']
 };

--- a/scripts/compose.ts
+++ b/scripts/compose.ts
@@ -162,14 +162,8 @@ if (require.main === module) {
     }
   ])
   .then((answers: ComposePromptType) => {
-    // Remove special characters and replace space with -
-    const fileName = answers.title
-      .toLowerCase()
-      .replace(/[^a-zA-Z0-9 ]/g, '')
-      .replace(/ /g, '-')
-      .replace(/-+/g, '-');
+    const filePath = generateFilePath(answers.title);
     const frontMatter = genFrontMatter(answers);
-    const filePath = `pages/blog/${fileName || 'untitled'}.md`;
 
     fs.writeFile(filePath, frontMatter, { flag: 'wx' }, (err) => {
       if (err) {

--- a/scripts/compose.ts
+++ b/scripts/compose.ts
@@ -31,7 +31,7 @@ type ComposePromptType = {
  * @param answers - User inputs for the blog post, including title, excerpt, comma-separated tags, type, and canonical URL.
  * @returns The generated Markdown front matter and blog post content template.
  */
-function genFrontMatter(answers: ComposePromptType): string {
+export function genFrontMatter(answers: ComposePromptType): string {
   const tagArray = answers.tags.split(',');
 
   tagArray.forEach((tag: string, index: number) => {
@@ -118,7 +118,21 @@ function genFrontMatter(answers: ComposePromptType): string {
   return frontMatter;
 }
 
-inquirer
+export function generateSlug(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-zA-Z0-9 ]/g, '')
+    .replace(/ /g, '-')
+    .replace(/-+/g, '-');
+}
+
+export function generateFilePath(title: string): string {
+  const slug = generateSlug(title);
+  return `pages/blog/${slug || 'untitled'}.md`;
+}
+
+if (require.main === module) {
+  inquirer
   .prompt([
     {
       name: 'title',
@@ -173,3 +187,4 @@ inquirer
       logger.error('Something went wrong, sorry!');
     }
   });
+}

--- a/tests/scripts/compose.test.ts
+++ b/tests/scripts/compose.test.ts
@@ -1,0 +1,125 @@
+const { genFrontMatter, generateSlug, generateFilePath } = require('../../scripts/compose');
+
+describe('generateSlug', () => {
+  test('converts title to kebab-case slug', () => {
+    expect(generateSlug('My First Blog Post')).toBe('my-first-blog-post');
+  });
+
+  test('removes special characters', () => {
+    expect(generateSlug('Hello, World! @2024')).toBe('hello-world-2024');
+  });
+
+  test('collapses multiple hyphens', () => {
+    expect(generateSlug('A   B')).toBe('a-b');
+  });
+
+  test('handles empty string', () => {
+    expect(generateSlug('')).toBe('');
+  });
+
+  test('handles title with only special characters', () => {
+    expect(generateSlug('!!!@@@')).toBe('');
+  });
+
+  test('converts to lowercase', () => {
+    expect(generateSlug('UPPERCASE TITLE')).toBe('uppercase-title');
+  });
+
+  test('preserves leading and trailing spaces as hyphens', () => {
+    expect(generateSlug('  Hello World  ')).toBe('-hello-world-');
+  });
+});
+
+describe('generateFilePath', () => {
+  test('generates correct file path from title', () => {
+    expect(generateFilePath('My Blog Post')).toBe('pages/blog/my-blog-post.md');
+  });
+
+  test('returns untitled for empty slug', () => {
+    expect(generateFilePath('')).toBe('pages/blog/untitled.md');
+  });
+
+  test('returns untitled for special-char-only title', () => {
+    expect(generateFilePath('@@@')).toBe('pages/blog/untitled.md');
+  });
+});
+
+describe('genFrontMatter', () => {
+  const baseAnswers = {
+    title: 'Test Post',
+    excerpt: 'A test excerpt',
+    tags: 'asyncapi,testing',
+    type: 'Engineering',
+    canonical: ''
+  };
+
+  test('includes title in front matter', () => {
+    const result = genFrontMatter(baseAnswers);
+    expect(result).toContain('title: Test Post');
+  });
+
+  test('uses Untitled when title is empty', () => {
+    const result = genFrontMatter({ ...baseAnswers, title: '' });
+    expect(result).toContain('title: Untitled');
+  });
+
+  test('includes type in front matter', () => {
+    const result = genFrontMatter(baseAnswers);
+    expect(result).toContain('type: Engineering');
+  });
+
+  test('includes tags in front matter', () => {
+    const result = genFrontMatter(baseAnswers);
+    expect(result).toContain("tags: ['asyncapi','testing']");
+  });
+
+  test('handles empty tags', () => {
+    const result = genFrontMatter({ ...baseAnswers, tags: '' });
+    expect(result).toContain('tags: []');
+  });
+
+  test('trims whitespace in tags', () => {
+    const result = genFrontMatter({ ...baseAnswers, tags: ' asyncapi , testing ' });
+    expect(result).toContain("tags: ['asyncapi','testing']");
+  });
+
+  test('includes excerpt when provided', () => {
+    const result = genFrontMatter(baseAnswers);
+    expect(result).toContain('excerpt: A test excerpt');
+  });
+
+  test('uses space when excerpt is empty', () => {
+    const result = genFrontMatter({ ...baseAnswers, excerpt: '' });
+    expect(result).toContain('excerpt:  ');
+  });
+
+  test('includes canonical URL when provided', () => {
+    const result = genFrontMatter({ ...baseAnswers, canonical: 'https://example.com' });
+    expect(result).toContain('canonical: https://example.com');
+  });
+
+  test('leaves canonical empty when not provided', () => {
+    const result = genFrontMatter(baseAnswers);
+    expect(result).toContain('canonical: ');
+  });
+
+  test('starts with YAML front matter delimiter', () => {
+    const result = genFrontMatter(baseAnswers);
+    expect(result.startsWith('---')).toBe(true);
+  });
+
+  test('contains blog content template', () => {
+    const result = genFrontMatter(baseAnswers);
+    expect(result).toContain('Write your blog post content here');
+  });
+
+  test('contains default author information', () => {
+    const result = genFrontMatter(baseAnswers);
+    expect(result).toContain('Lukasz Gornicki');
+  });
+
+  test('ends with closing delimiter', () => {
+    const result = genFrontMatter(baseAnswers);
+    expect(result.trimEnd().endsWith('---')).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #5096

**Changes:**

1. **Refactored scripts/compose.ts** - Exported genFrontMatter, generateSlug, and generateFilePath functions. Wrapped the CLI inquirer logic in a equire.main === module guard so the interactive prompt only runs when executed directly, not when imported by tests.

2. **Added 	ests/scripts/compose.test.ts** - 24 unit tests covering:
   - **Slug generation**: kebab-case conversion, special character removal, hyphen collapsing, empty string, lowercase conversion, leading/trailing space behavior
   - **File path generation**: correct path construction, untitled fallback for empty/special-char-only titles
   - **Front matter generation**: title, type, tags (including trimming and empty), excerpt, canonical URL, YAML delimiters, blog content template, default author info

3. **Updated jest.config.js** - Removed scripts/compose.ts from coveragePathIgnorePatterns so compose coverage is now tracked.

All 24 tests pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for content generation utilities, validating slug normalization, file path generation, and metadata formatting.

* **Refactor**
  * Exported utility functions for improved modularity and reusability of content generation helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->