### PR TITLE
refactor: use twMerge for z-index className in NavBar

### DIFF
--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { twMerge } from 'tailwind-merge';
 import type { NextRouter } from 'next/router';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
@@ -144,7 +145,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
   }, [asPath]);
 
   return (
-    <div className={`bg-white ${className} z-50`}>
+    <div className={twMerge('bg-white z-50', className)}>
       <div className='flex w-full items-center justify-between py-6 lg:justify-start lg:space-x-2'>
         {!hideLogo && (
           <div className='lg:w-auto lg:flex-1'>


### PR DESCRIPTION
Fixes #4779

**Problem:** `NavBar.tsx` line 147 uses template literal for className concatenation (`className={`bg-white  z-50`}`), which is inconsistent with the codebase convention of using `twMerge`.

**Fix:** Import `twMerge` from `tailwind-merge` and replace the template literal with `twMerge('bg-white z-50', className)`.

This follows the same pattern used in `Button.tsx`, `TOC.tsx`, `Paragraph.tsx`, and other components. The `twMerge` approach properly resolves Tailwind class conflicts and allows the `className` prop to override base styles correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved styling class handling in the navigation component for better CSS property conflict resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->