### PR TITLE
fix: improve Netlify badge fallback and use local asset

### DIFF
--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -111,10 +111,10 @@ export default function Footer() {
           </div>
           <div className='mt-8 block sm:mt-0'>
             <p className='block text-sm leading-6'>
-              <a href='https://netlify.com' target='_blank' rel='noopener noreferrer'>
+              <a href='https://netlify.com' target='_blank' rel='noopener noreferrer' className='inline-block'>
                 <img
-                  src='https://www.netlify.com/img/global/badges/netlify-color-bg.svg'
-                  className='inline'
+                  src='/img/supportus/netlify.png'
+                  className='inline h-11'
                   alt='Deploys by Netlify'
                 />
               </a>


### PR DESCRIPTION
Fixes #4921

**Problem:** When the Netlify badge image fails to load, the browser falls back to rendering the alt text with poor visual clarity - no spacing from the broken image icon, low contrast, and an unpolished look.

**Root Causes:**
1. The badge source was an external SVG URL (`netlify-color-bg.svg`) that could 404, triggering the fallback scenario
2. No explicit height or sizing constraints, so alt text had no vertical context

**Fix:**
- Replace the external SVG URL with the local PNG asset (`/img/supportus/netlify.png`), which is far more reliable and eliminates the 404 scenario
- Add `h-11` for consistent badge height, giving alt text proper vertical spacing if the image ever does fail to load
- Add `inline-block` to the anchor wrapper for proper container sizing

This also supersedes the fix in #5445 with a more comprehensive approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Netlify support badge styling in the Footer with refined image attributes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->