### PR TITLE
fix: update broken link to auto-changeset.yml -> release-with-changesets.yml in Shai Hulud postmortem

### DIFF
--- a/markdown/blog/shai-hulud-postmortem.md
+++ b/markdown/blog/shai-hulud-postmortem.md
@@ -97,7 +97,7 @@ Regardless of how much we prepare, security incidents can still occur. This inci
 
 - Have backup maintainers with publishing rights and revoking rights for tokens to reduce single points of failure.
 - Token rotation and limited scope tokens should be enforced. The NPM token we were using was three years old and has now been revoked.
-- Got to know about a [workflow with unsecured context](https://github.com/asyncapi/cli/blob/master/.github/workflows/auto-changeset.yml) in GitHub Actions. Although it is not the root cause here, we have fixed it to avoid any future risks in [PR #1909](https://github.com/asyncapi/cli/pull/1909)
+- Got to know about a [workflow with unsecured context](https://github.com/asyncapi/cli/blob/master/.github/workflows/release-with-changesets.yml) in GitHub Actions. Although it is not the root cause here, we have fixed it to avoid any future risks in [PR #1909](https://github.com/asyncapi/cli/pull/1909)
 
 
 **If you have any further questions or need assistance, please do not hesitate to reach out to us at [security@asyncapi.com](mailto:security@asyncapi.com)**


### PR DESCRIPTION
## Description

Fixes #4970

The blog post 'Shai Hulud postmortem' contains a link to `.github/workflows/auto-changeset.yml`, but that file no longer exists (was renamed/removed in PR #1909). The correct workflow file is now `release-with-changesets.yml`.

## Changes

- Updated the link in `markdown/blog/shai-hulud-postmortem.md` line 100 from `auto-changeset.yml` to `release-with-changesets.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a workflow reference in the lessons learned section of the postmortem documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->