### PR TITLE
refactor(navbar): use twMerge for z-index className management instead of template literal

### DIFF
--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -6,6 +6,8 @@ import React, { useEffect, useState } from 'react';
 
 import { defaultLanguage, i18nPaths, languages } from '@/utils/i18n';
 
+import { twMerge } from 'tailwind-merge';
+
 import { SearchButton } from '../AlgoliaSearch';
 import GithubButton from '../buttons/GithubButton';
 import { isMobileDevice } from '../helpers/is-mobile';
@@ -144,7 +146,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
   }, [asPath]);
 
   return (
-    <div className={`bg-white ${className} z-50`}>
+    <div className={twMerge('bg-white z-50', className)}>
       <div className='flex w-full items-center justify-between py-6 lg:justify-start lg:space-x-2'>
         {!hideLogo && (
           <div className='lg:w-auto lg:flex-1'>


### PR DESCRIPTION
## Description

Fixes #4779

Replaces template literal className concatenation with `twMerge` for proper Tailwind class conflict resolution, consistent with the established codebase pattern used in Button.tsx, TOC.tsx, and other components.

## Changes

- Import `twMerge` from `tailwind-merge`
- Replace `className={`bg-white ${className} z-50`}` with `className={twMerge('bg-white z-50', className)}` in NavBar.tsx line 147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved CSS class handling in the navigation component for better conflict resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->