### PR TITLE
fix(theme): apply dark mode support to global MDX tables

### DIFF
--- a/components/MDX/MDX.tsx
+++ b/components/MDX/MDX.tsx
@@ -324,8 +324,8 @@ const getMDXComponents = (reactId: string) => ({
   button: Button as React.ComponentType<React.ButtonHTMLAttributes<HTMLButtonElement>>,
   table: (props: React.HTMLProps<HTMLTableElement>) => (
     <div className={`${props.className || ''} flex flex-col`}>
-      <div className='my-2 overflow-x-auto py-2 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8'>
-        <div className='inline-block w-full overflow-auto border-b border-gray-200 dark:border-gray-800 align-middle shadow sm:rounded-lg'>
+      <div className='my-2 overflow-x-auto py-2'>
+        <div className='inline-block min-w-full border-b border-gray-200 dark:border-gray-800 align-middle shadow sm:rounded-lg'>
           <table {...props} className={`${props.className || ''} w-full`} />
         </div>
       </div>

--- a/components/MDX/MDX.tsx
+++ b/components/MDX/MDX.tsx
@@ -325,7 +325,7 @@ const getMDXComponents = (reactId: string) => ({
   table: (props: React.HTMLProps<HTMLTableElement>) => (
     <div className={`${props.className || ''} flex flex-col`}>
       <div className='my-2 overflow-x-auto py-2 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8'>
-        <div className='inline-block w-full overflow-auto border-b border-gray-200 align-middle shadow sm:rounded-lg'>
+        <div className='inline-block w-full overflow-auto border-b border-gray-200 dark:border-gray-800 align-middle shadow sm:rounded-lg'>
           <table {...props} className={`${props.className || ''} w-full`} />
         </div>
       </div>
@@ -334,23 +334,23 @@ const getMDXComponents = (reactId: string) => ({
   th: (props: React.HTMLProps<HTMLTableCellElement>) => (
     <th
       {...props}
-      className={`${props.className || ''} border-b border-gray-200 bg-gray-100 px-6 py-3 text-left font-body text-xs font-medium uppercase leading-4 tracking-wider text-gray-900`}
+      className={`${props.className || ''} border-b border-gray-200 dark:border-gray-800 bg-gray-100 dark:bg-dark-card px-6 py-3 text-left font-body text-xs font-medium uppercase leading-4 tracking-wider text-gray-900 dark:text-gray-200`}
     />
   ),
   tr: (props: React.HTMLProps<HTMLTableRowElement>) => (
-    <tr {...props} className={`${props.className || ''} bg-white`} />
+    <tr {...props} className={`${props.className || ''} bg-white dark:bg-transparent`} />
   ),
   td: (props: React.HTMLProps<HTMLTableCellElement>) => (
     <td
       {...props}
-      className={`${props.className || ''} border-b border-gray-200 px-6 py-4 text-sm leading-5 tracking-tight text-gray-700`}
+      className={`${props.className || ''} border-b border-gray-200 dark:border-gray-800 px-6 py-4 text-sm leading-5 tracking-tight text-gray-700 dark:text-gray-300`}
     />
   ),
   pre: (props: React.HTMLProps<HTMLPreElement>) => CodeComponent((props.children as React.ReactElement)?.props),
   code: (props: React.HTMLProps<HTMLElement>) => (
     <code
       {...props}
-      className={`${props.className || ''} rounded bg-gray-200 px-1 py-0.5 font-mono text-sm text-gray-800`}
+      className={`${props.className || ''} rounded bg-gray-200 dark:bg-gray-800 px-1 py-0.5 font-mono text-sm text-gray-800 dark:text-gray-300`}
     />
   ),
   hr: (props: React.HTMLProps<HTMLHRElement>) => <hr {...props} className={`${props.className || ''} my-8`} />,

--- a/components/MDX/MDXTable.tsx
+++ b/components/MDX/MDXTable.tsx
@@ -10,7 +10,7 @@ export function Table({ className = '' }: { className?: string }) {
   return (
     <div className={`${className} flex flex-col`}>
       <div className='my-2 overflow-x-auto py-2 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8'>
-        <div className='inline-block w-full overflow-auto border-b border-gray-200 align-middle shadow sm:rounded-lg'>
+        <div className='inline-block w-full overflow-auto border-b border-gray-200 dark:border-gray-800 align-middle shadow sm:rounded-lg'>
           <table className={`${className} w-full`} />
         </div>
       </div>
@@ -25,7 +25,7 @@ export function Table({ className = '' }: { className?: string }) {
  * @returns
  */
 export function TableRow({ className = '' }: { className?: string }) {
-  return <tr className={`${className} bg-white`} />;
+  return <tr className={`${className} bg-white dark:bg-transparent`} />;
 }
 
 /**
@@ -36,7 +36,9 @@ export function TableRow({ className = '' }: { className?: string }) {
  */
 export function TableCell({ className = '' }: { className?: string }) {
   return (
-    <td className={`${className} border-b border-gray-200 px-6 py-4 text-sm leading-5 tracking-tight text-gray-700`} />
+    <td
+      className={`${className} border-b border-gray-200 dark:border-gray-800 px-6 py-4 text-sm leading-5 tracking-tight text-gray-700 dark:text-gray-300`}
+    />
   );
 }
 
@@ -49,7 +51,7 @@ export function TableCell({ className = '' }: { className?: string }) {
 export function TableHeader({ className = '' }: { className?: string }) {
   return (
     <th
-      className={`${className} border-b border-gray-200 bg-gray-100 px-6 py-3 text-left font-body text-xs font-medium uppercase leading-4 tracking-wider text-gray-900`}
+      className={`${className} border-b border-gray-200 dark:border-gray-800 bg-gray-100 dark:bg-dark-card px-6 py-3 text-left font-body text-xs font-medium uppercase leading-4 tracking-wider text-gray-900 dark:text-gray-200`}
     />
   );
 }

--- a/components/MDX/MDXTable.tsx
+++ b/components/MDX/MDXTable.tsx
@@ -9,8 +9,8 @@ import React from 'react';
 export function Table({ className = '' }: { className?: string }) {
   return (
     <div className={`${className} flex flex-col`}>
-      <div className='my-2 overflow-x-auto py-2 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8'>
-        <div className='inline-block w-full overflow-auto border-b border-gray-200 dark:border-gray-800 align-middle shadow sm:rounded-lg'>
+      <div className='my-2 overflow-x-auto py-2'>
+        <div className='inline-block min-w-full border-b border-gray-200 dark:border-gray-800 align-middle shadow sm:rounded-lg'>
           <table className={`${className} w-full`} />
         </div>
       </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -29,6 +29,32 @@ html.dark body {
   fill: #131e35; /* dark-card color */
 }
 
+/* Dark mode scrollbar styling for overflow containers */
+.dark ::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.dark ::-webkit-scrollbar-track {
+  background: #1e293b;
+  border-radius: 4px;
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  background: #475569;
+  border-radius: 4px;
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: #64748b;
+}
+
+/* Firefox dark mode scrollbar */
+.dark * {
+  scrollbar-color: #475569 #1e293b;
+  scrollbar-width: thin;
+}
+
 /* Disable transitions on initial load to prevent flash */
 html:not(.transitions-enabled) *,
 html:not(.transitions-enabled) *::before,


### PR DESCRIPTION
Before - 
<img width="723" height="539" alt="Screenshot 2026-05-22 at 8 18 11 PM" src="https://github.com/user-attachments/assets/682d306b-1bc3-4230-af9c-c4038cbdc847" />

<img width="820" height="247" alt="Screenshot 2026-05-22 at 8 24 31 PM" src="https://github.com/user-attachments/assets/7d2e21f0-c71f-44e2-b8fd-38f65466ba43" />

After - 
<img width="1007" height="641" alt="Screenshot 2026-05-22 at 8 18 52 PM" src="https://github.com/user-attachments/assets/ec5bc927-3a43-4045-9a84-3e26251f1e78" />
<img width="1083" height="711" alt="Screenshot 2026-05-22 at 8 24 09 PM" src="https://github.com/user-attachments/assets/44d11435-a4db-4d8a-8553-f573872ddfe3" />

<img width="1044" height="306" alt="Screenshot 2026-05-22 at 8 24 21 PM" src="https://github.com/user-attachments/assets/2a3e890e-b2ae-4334-8333-11dde68fa6e4" />


## Proof of the new changes on few browsers - 
Chrome
<img width="1463" height="338" alt="Screenshot 2026-05-28 at 6 01 17 PM" src="https://github.com/user-attachments/assets/a1e44bab-d288-4908-bec0-5666023200f7" />
<img width="269" height="539" alt="Screenshot 2026-05-28 at 6 02 41 PM" src="https://github.com/user-attachments/assets/cf5245d4-bdec-4a56-a7d8-ea483f0a1932" />


Safari
<img width="1064" height="187" alt="Screenshot 2026-05-28 at 6 01 42 PM" src="https://github.com/user-attachments/assets/8bfa1fcd-4a62-4913-8da5-55e497defc87" />
<img width="285" height="481" alt="Screenshot 2026-05-28 at 6 03 00 PM" src="https://github.com/user-attachments/assets/86ed6da8-944f-4497-93cc-ee2602a7e723" />

Opera GX
<img width="901" height="189" alt="Screenshot 2026-05-28 at 6 05 44 PM" src="https://github.com/user-attachments/assets/ccead2f2-d67e-42a7-86ae-d1b01d90d4e0" />
<img width="199" height="498" alt="Screenshot 2026-05-28 at 6 06 11 PM" src="https://github.com/user-attachments/assets/7d399693-e74e-4efc-8607-3e2c43dc50c5" />

There is no scroll on tables that dont require it
<img width="737" height="646" alt="Screenshot 2026-05-28 at 6 02 14 PM" src="https://github.com/user-attachments/assets/246c6b1b-8426-4c0b-83a8-0c31eb312724" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved dark-mode styling for tables: clearer borders, more consistent row backgrounds, and higher-contrast headers for readability.
  * Enhanced dark-mode rendering for inline code: adjusted background and text contrast for better legibility.
  * Added dark-mode scrollbar styling for consistent colors, sizing, and hover behavior across browsers in scrollable areas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->