### PR TITLE
Fix inconsistent tooltip behavior in tools section

### DIFF
--- a/components/tools/CardData.tsx
+++ b/components/tools/CardData.tsx
@@ -40,7 +40,6 @@ export const CardData = ({
   type,
   className = ''
 }: CardDataProps) => {
-  const [outsideClick, setOutsideClick] = useState<boolean>(true);
   const [description, setShowDescription] = useState<boolean>(false);
   const initial = {
     lang: false,
@@ -50,6 +49,7 @@ export const CardData = ({
     ownership: false
   };
   const domNode = useRef<HTMLSpanElement>(null);
+  const containerRef = useRef<HTMLSpanElement>(null);
 
   // Decide whether to show full description or not in the card based on the
   // number of lines occupied by the description.
@@ -64,12 +64,11 @@ export const CardData = ({
     }
   }, [visible]);
 
-  // Decide whether the user click outside this component (card description) or not.
+  // Close the tooltip when clicking outside the tooltip or info button.
   useEffect(() => {
     const maybeHandler = (event: MouseEvent) => {
-      setOutsideClick(true);
-      if (domNode.current && !domNode.current.contains(event.target as Node)) {
-        setOutsideClick(false);
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setVisible((prev) => ({ ...prev, [type]: false }));
       }
     };
 
@@ -78,13 +77,13 @@ export const CardData = ({
     return () => {
       document.removeEventListener('mousedown', maybeHandler);
     };
-  }, []);
+  }, [type, setVisible]);
 
   return (
     <div className={twMerge('text-left text-sm text-gray-500', className)}>
       {heading}
-      <span className='group relative'>
-        {outsideClick && visible[type] && (
+      <span className='group relative' ref={containerRef}>
+        {visible[type] && (
           <span
             ref={domNode}
             data-testid='Carddata-description'
@@ -102,7 +101,6 @@ export const CardData = ({
               <button
                 className='cursor-pointer text-cyan-600'
                 onClick={() => {
-                  setOutsideClick(true);
                   setRead(!read);
                 }}
               >


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
Fixes inconsistent tooltip behavior in the tools section where reopening/closing the info tooltip behaved unexpectedly after interaction.

**Changes**
Added containerRef to track both the tooltip and info button container
Updated outside click handling to close the tooltip only when clicking outside the component
Removed redundant tooltip state handling to avoid inconsistent behavior
Simplified tooltip visibility logic using visible[type]

**How to test**
Go to the tools section containing the info (ⓘ) button
Click the info button to open the tooltip
Click outside the tooltip and verify it closes
Click the info button again and verify the tooltip reopens correctly

**Related issue(s)**
Fixes #5098
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tooltip dismissal behavior when clicking outside the tooltip area for more reliable interaction handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->