### PR TITLE
chore: restore original text and links for TSC info cards

### DIFF
--- a/pages/community/tsc.tsx
+++ b/pages/community/tsc.tsx
@@ -142,11 +142,11 @@ export default function TSC() {
               <div className='flex items-center justify-center w-14 h-14 rounded-full bg-purple-100 dark:bg-purple-900/30 mb-6'>
                 <IconUsersGroup className='w-8 h-8 text-purple-600 dark:text-purple-400' />
               </div>
-              <h3 className='text-xl font-bold text-gray-900 dark:text-white mb-4'>What is TSC?</h3>
+              <h3 className='text-xl font-bold text-gray-900 dark:text-white mb-4'>What is a TSC?</h3>
               <p className='text-gray-600 dark:text-gray-400 leading-relaxed'>
                 The Technical Steering Committee (TSC) is responsible for the oversight of the AsyncAPI Initiative.
-                Maintainers take committee seats decisions on the direction of the project, including releases,
-                contribution policies, and other strategic matters.
+                Maintainers (aka committers) make decisions at the given repository/project level. The TSC helps to make
+                decisions on a higher level, or when maintainers cannot find a consensus.
               </p>
             </div>
 
@@ -155,11 +155,22 @@ export default function TSC() {
               <div className='flex items-center justify-center w-14 h-14 rounded-full bg-purple-100 dark:bg-purple-900/30 mb-6'>
                 <IconArrowRight className='w-8 h-8 text-purple-600 dark:text-purple-400' />
               </div>
-              <h3 className='text-xl font-bold text-gray-900 dark:text-white mb-4'>How to become a member?</h3>
+              <h3 className='text-xl font-bold text-gray-900 dark:text-white mb-4'>How can I become a TSC member?</h3>
               <p className='text-gray-600 dark:text-gray-400 leading-relaxed'>
-                Anybody can become a maintainer of the TSC. All you have to do is become a maintainer of one of the
-                AsyncAPI projects. To become a maintainer, you need to be nominated by a TSC member and then other
-                maintainers will make a vote.
+                Anybody can become a member of the TSC. All you have to do is become a maintainer of one of the AsyncAPI
+                projects! To become a maintainer, you just need to regularly contribute to one of the projects and then
+                other maintainers will invite you to join. You can also build a great AsyncAPI-based project that we
+                don&apos;t have yet in our GitHub organization and donate it (we&apos;ll ask you to stay as a
+                maintainer). Follow this{' '}
+                <a
+                  href='https://github.com/asyncapi/community/blob/master/docs/020-governance-and-policies/TSC_MEMBERSHIP.md'
+                  className='text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  Link
+                </a>{' '}
+                to know more!
               </p>
             </div>
 

--- a/pages/community/tsc.tsx
+++ b/pages/community/tsc.tsx
@@ -170,8 +170,26 @@ export default function TSC() {
               </div>
               <h3 className='text-xl font-bold text-gray-900 dark:text-white mb-4'>Our governance model</h3>
               <p className='text-gray-600 dark:text-gray-400 leading-relaxed'>
-                AsyncAPI Initiative runs under an Open Governance Model with its technical project and community assets
-                under a neutral home, with an independent board of directors representing a cross-section.
+                AsyncAPI Initiative runs under an{' '}
+                <a
+                  href='https://github.com/asyncapi/community/blob/master/docs/020-governance-and-policies/CHARTER.md'
+                  className='text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  Open Governance Model
+                </a>{' '}
+                that gives power to the people actively involved and working on the project. No matter if you are an
+                individual contributor or backed by a company, you have equal rights. Read{' '}
+                <a
+                  href='https://www.asyncapi.com/blog/governance-motivation'
+                  className='text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  this
+                </a>{' '}
+                article to learn more.
               </p>
             </div>
           </div>


### PR DESCRIPTION
ref : https://github.com/asyncapi/website/issues/5103#issuecomment-4527866535

Website-UI 
<img width="1342" height="448" alt="Screenshot 2026-05-24 at 2 58 50 PM" src="https://github.com/user-attachments/assets/2d0a1c47-3d85-4e5d-9e2e-18220c402077" />

Original 
<img width="1231" height="394" alt="Screenshot 2026-05-24 at 2 59 01 PM" src="https://github.com/user-attachments/assets/4850dc11-98d5-4bcd-b812-7cb82c055a50" />

New with light and Dark mode
<img width="1301" height="568" alt="Screenshot 2026-05-24 at 3 00 19 PM" src="https://github.com/user-attachments/assets/cc5e0ca8-b9b5-4116-85f5-452d2b015221" />

<img width="1217" height="575" alt="Screenshot 2026-05-24 at 3 00 28 PM" src="https://github.com/user-attachments/assets/d889aa77-d0cb-443e-aaa1-31aa19584176" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TSC informational cards with revised headings and descriptions.
  * Added links to TSC membership documentation and governance model resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->