### PR TITLE
fix(StickyNavbar): update className for improved styling consistency

### DIFF
--- a/components/navigation/StickyNavbar.tsx
+++ b/components/navigation/StickyNavbar.tsx
@@ -33,8 +33,7 @@ export default function StickyNavbar({ children, className = '' }: StickyNavbarP
 
   return (
     <div
-      className={`sticky ${isScrolled ? 'dark:bg-transparent' : 'dark:bg-dark-background'} top-0 z-50 lg:pt-2 ${className}`}
-      style={{ transform: 'translateZ(0)', willChange: 'transform' }}
+      className={`sticky ${isScrolled ? 'dark:bg-transparent' : 'dark:bg-dark-background'} top-0 z-50 lg:pt-2 lg:[transform:translateZ(0)] lg:will-change-transform ${className}`}
       data-testid='Sticky-div'
     >
       {children}


### PR DESCRIPTION
## Description

- Fixed the mobile hamburger menu not opening correctly on small screens.
- The issue was caused by `transform: translateZ(0)` being applied to the sticky navbar on all screen sizes. Since the mobile menu uses fixed positioning and is rendered inside the navbar, the transformed parent interfered with the mobile overlay behavior.
- Updated the `transform` and `will-change` styles to apply only on large screens using Tailwind responsive classes, preserving the existing desktop behavior while preventing the mobile menu issue on smaller devices.

## Related issue(s)

### Before
<video src="https://github.com/user-attachments/assets/bb12f0ed-2afe-4536-bde8-721467c553d4" controls width="100%"></video>

### After
<video src="https://github.com/user-attachments/assets/c031bd05-0f81-4e54-b17e-9b36d7d70e34" controls width="100%"></video>

Fixes #5469 