### PR TITLE
feat: enhance dark theme support in search and navigation components

### DIFF
--- a/components/AlgoliaSearch.tsx
+++ b/components/AlgoliaSearch.tsx
@@ -114,29 +114,31 @@ function AlgoliaModal({ onClose, initialQuery, indexName }: AlgoliaModalProps) {
   const router = useRouter();
 
   return createPortal(
-    <DocSearchModal
-      initialQuery={initialQuery}
-      initialScrollY={window.scrollY}
-      searchParameters={{
-        distinct: 1
-      }}
-      placeholder={indexName === DOCS_INDEX_NAME ? 'Search documentation' : 'Search resources'}
-      onClose={onClose}
-      indexName={indexName}
-      apiKey={API_KEY}
-      appId={APP_ID}
-      navigator={{
-        navigate({ itemUrl }) {
-          onClose();
-          router.push(itemUrl);
-        }
-      }}
-      hitComponent={Hit}
-      transformItems={transformItems}
-      getMissingResultsUrl={({ query }) => {
-        return `https://github.com/asyncapi/website/issues/new?title=Cannot%20search%20given%20query:%20${query}`;
-      }}
-    />,
+    <div className='dark:text-dark-text'>
+      <DocSearchModal
+        initialQuery={initialQuery}
+        initialScrollY={window.scrollY}
+        searchParameters={{
+          distinct: 1
+        }}
+        placeholder={indexName === DOCS_INDEX_NAME ? 'Search documentation' : 'Search resources'}
+        onClose={onClose}
+        indexName={indexName}
+        apiKey={API_KEY}
+        appId={APP_ID}
+        navigator={{
+          navigate({ itemUrl }) {
+            onClose();
+            router.push(itemUrl);
+          }
+        }}
+        hitComponent={Hit}
+        transformItems={transformItems}
+        getMissingResultsUrl={({ query }) => {
+          return `https://github.com/asyncapi/website/issues/new?title=Cannot%20search%20given%20query:%20${query}`;
+        }}
+      />
+    </div>,
     document.body
   );
 }

--- a/components/DarkModeToggle.tsx
+++ b/components/DarkModeToggle.tsx
@@ -30,6 +30,21 @@ const MoonIcon = ({ className = 'w-5 h-5' }) => (
 );
 
 /**
+ * Applies the selected theme to the website.
+ */
+function applyTheme(isDark: boolean) {
+  document.documentElement.classList.toggle('dark', isDark);
+
+  if (isDark) {
+    document.documentElement.dataset.theme = 'dark';
+
+    return;
+  }
+
+  delete document.documentElement.dataset.theme;
+}
+
+/**
  * A modern toggle button component that switches between light and dark mode.
  * Remembers the selected mode using localStorage with smooth animations.
  */
@@ -44,24 +59,14 @@ export default function DarkModeToggle() {
 
     const shouldUseDark = storedTheme === 'dark';
 
-    document.documentElement.classList.toggle('dark', shouldUseDark);
-    if (shouldUseDark) {
-      document.documentElement.dataset.theme = 'dark';
-    } else {
-      delete document.documentElement.dataset.theme;
-    }
+    applyTheme(shouldUseDark);
     setIsDark(shouldUseDark);
   }, []);
 
   const toggleDarkMode = () => {
     const newTheme = !isDark;
 
-    document.documentElement.classList.toggle('dark', newTheme);
-    if (newTheme) {
-      document.documentElement.dataset.theme = 'dark';
-    } else {
-      delete document.documentElement.dataset.theme;
-    }
+    applyTheme(newTheme);
     localStorage.setItem('theme', newTheme ? 'dark' : 'light');
     setIsDark(newTheme);
   };

--- a/components/DarkModeToggle.tsx
+++ b/components/DarkModeToggle.tsx
@@ -45,6 +45,11 @@ export default function DarkModeToggle() {
     const shouldUseDark = storedTheme === 'dark';
 
     document.documentElement.classList.toggle('dark', shouldUseDark);
+    if (shouldUseDark) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.removeAttribute('data-theme');
+    }
     setIsDark(shouldUseDark);
   }, []);
 
@@ -52,6 +57,11 @@ export default function DarkModeToggle() {
     const newTheme = !isDark;
 
     document.documentElement.classList.toggle('dark', newTheme);
+    if (newTheme) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.removeAttribute('data-theme');
+    }
     localStorage.setItem('theme', newTheme ? 'dark' : 'light');
     setIsDark(newTheme);
   };

--- a/components/DarkModeToggle.tsx
+++ b/components/DarkModeToggle.tsx
@@ -46,9 +46,9 @@ export default function DarkModeToggle() {
 
     document.documentElement.classList.toggle('dark', shouldUseDark);
     if (shouldUseDark) {
-      document.documentElement.setAttribute('data-theme', 'dark');
+      document.documentElement.dataset.theme = 'dark';
     } else {
-      document.documentElement.removeAttribute('data-theme');
+      delete document.documentElement.dataset.theme;
     }
     setIsDark(shouldUseDark);
   }, []);
@@ -58,9 +58,9 @@ export default function DarkModeToggle() {
 
     document.documentElement.classList.toggle('dark', newTheme);
     if (newTheme) {
-      document.documentElement.setAttribute('data-theme', 'dark');
+      document.documentElement.dataset.theme = 'dark';
     } else {
-      document.documentElement.removeAttribute('data-theme');
+      delete document.documentElement.dataset.theme;
     }
     localStorage.setItem('theme', newTheme ? 'dark' : 'light');
     setIsDark(newTheme);

--- a/components/navigation/DocsMobileMenu.tsx
+++ b/components/navigation/DocsMobileMenu.tsx
@@ -47,7 +47,7 @@ export default function DocsMobileMenu({ post, navigation, onClickClose = () => 
             </div>
             <div className='mb-4 mt-10 w-full px-2'>
               <SearchButton
-                className='flex w-full items-center space-x-3 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-left text-sm text-gray-700 shadow-sm transition-all duration-500 ease-in-out dark:border-dark-text dark:bg-dark-card dark:text-dark-text dark:hover:border-secondary-500 dark:hover:text-secondary-500 hover:border-secondary-500 hover:bg-secondary-100 hover:text-secondary-500'
+                className='flex w-full items-center space-x-3 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-left text-sm text-gray-700 shadow-sm transition-all duration-500 ease-in-out dark:border-dark-text dark:bg-dark-card dark:text-dark-text dark:hover:border-secondary-500 dark:hover:bg-dark-background dark:hover:text-secondary-500 hover:border-secondary-500 hover:bg-secondary-100 hover:text-secondary-500'
                 indexName={DOCS_INDEX_NAME}
               >
                 <IconLoupe />

--- a/components/navigation/DocsMobileMenu.tsx
+++ b/components/navigation/DocsMobileMenu.tsx
@@ -47,7 +47,7 @@ export default function DocsMobileMenu({ post, navigation, onClickClose = () => 
             </div>
             <div className='mb-4 mt-10 w-full px-2'>
               <SearchButton
-                className='flex w-full items-center space-x-3 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-left text-sm text-gray-700 shadow-sm transition-all duration-500 ease-in-out hover:border-secondary-500 hover:bg-secondary-100 hover:text-secondary-500'
+                className='flex w-full items-center space-x-3 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-left text-sm text-gray-700 shadow-sm transition-all duration-500 ease-in-out dark:border-dark-text dark:bg-dark-card dark:text-dark-text dark:hover:border-secondary-500 dark:hover:text-secondary-500 hover:border-secondary-500 hover:bg-secondary-100 hover:text-secondary-500'
                 indexName={DOCS_INDEX_NAME}
               >
                 <IconLoupe />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -30,7 +30,6 @@ class MyDocument extends Document {
                     var shouldUseDark = theme === 'dark';
                     if (shouldUseDark) {
                       document.documentElement.classList.add('dark');
-                      document.documentElement.dataset.theme = 'dark';
                     }
                     document.documentElement.classList.add('transitions-enabled');
                   } catch (e) {}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -30,7 +30,7 @@ class MyDocument extends Document {
                     var shouldUseDark = theme === 'dark';
                     if (shouldUseDark) {
                       document.documentElement.classList.add('dark');
-                      document.documentElement.setAttribute('data-theme', 'dark');
+                      document.documentElement.dataset.theme = 'dark';
                     }
                     document.documentElement.classList.add('transitions-enabled');
                   } catch (e) {}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -30,6 +30,7 @@ class MyDocument extends Document {
                     var shouldUseDark = theme === 'dark';
                     if (shouldUseDark) {
                       document.documentElement.classList.add('dark');
+                      document.documentElement.setAttribute('data-theme', 'dark');
                     }
                     document.documentElement.classList.add('transitions-enabled');
                   } catch (e) {}


### PR DESCRIPTION
## Description

- Updated the mobile docs search button to support dark theme using existing theme classes.
- Added `data-theme="dark"` alongside the existing `dark` class so Algolia DocSearch uses its dark theme.
- Wrapped the DocSearch modal with existing dark text styling to keep no-results text readable in dark mode.

### New behaviour

<video src="https://github.com/user-attachments/assets/53b86845-e2c5-4e38-99e4-519347e812ea" controls width="100%"></video>

## Related issue(s)

Fixes #5470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode styling consistency across search modal, mobile navigation, and theme components.

* **Bug Fixes**
  * Improved dark mode theme synchronization to ensure proper styling persistence and visual consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->