### PR TITLE
fix: add missing dark mode styling to SneakPeek documentation tab

### DIFF
--- a/components/SneakPeek.tsx
+++ b/components/SneakPeek.tsx
@@ -304,7 +304,7 @@ export default function SneakPeek() {
             {tabs.map((tab) => (
               <div key={tab.id} className={activeTab === tab.id ? 'block' : 'hidden'}>
                 <div
-                  className={`rounded-b-lg p-3 sm:p-4 lg:p-6 overflow-auto shadow-lg min-h-[300px] sm:min-h-[350px] lg:min-h-[400px] max-h-[500px] sm:max-h-[600px] ${tab.id === 'documentation' ? 'bg-gray-50 dark:bg-[#1B1B2F]' : 'bg-[#1B1130] dark:bg-[#0A0515]'}`}
+                  className={`rounded-b-lg p-3 sm:p-4 lg:p-6 overflow-auto shadow-lg min-h-[300px] sm:min-h-[350px] lg:min-h-[400px] max-h-[500px] sm:max-h-[600px] ${tab.id === 'documentation' ? 'bg-gray-50 dark:bg-[#0A0515]' : 'bg-[#1B1130] dark:bg-[#0A0515]'}`}
                 >
                   <div
                     className={

--- a/components/SneakPeek.tsx
+++ b/components/SneakPeek.tsx
@@ -166,7 +166,7 @@ export default function SneakPeek() {
           <span className='text-gray-500 dark:text-gray-400'>{'//'} Your business logic here</span>
         </div>
         <div>
-          {'\u00A0\u00A0\u00A0\u00A0'}
+          &nbsp;&nbsp;&nbsp;&nbsp;
           <span className={YELLOW_LIGHT}>console</span>
           {'.'}
           <span className={YELLOW}>log</span>
@@ -175,7 +175,7 @@ export default function SneakPeek() {
           {')'}
           {';'}
         </div>
-        <div>{'\u00A0\u00A0}'}</div>
+        <div>&nbsp;&nbsp;{'}'}</div>
         <div>{'}'}</div>
       </>
     );

--- a/components/SneakPeek.tsx
+++ b/components/SneakPeek.tsx
@@ -195,7 +195,9 @@ export default function SneakPeek() {
       </div>
 
       <div>
-        <div className='mb-2 mt-4 text-xs sm:text-sm text-gray-500 dark:text-gray-400'>Accepts the following message:</div>
+        <div className='mb-2 mt-4 text-xs sm:text-sm text-gray-500 dark:text-gray-400'>
+          Accepts the following message:
+        </div>
         <div className='rounded bg-gray-200 dark:bg-gray-800 p-3 sm:p-4 text-gray-600 dark:text-gray-300'>
           <button
             type='button'
@@ -231,7 +233,9 @@ export default function SneakPeek() {
                   </div>
                 </div>
 
-                <div className='mt-6 sm:mt-8 text-xs text-gray-500 dark:text-gray-400'>Additional properties are allowed.</div>
+                <div className='mt-6 sm:mt-8 text-xs text-gray-500 dark:text-gray-400'>
+                  Additional properties are allowed.
+                </div>
               </div>
 
               <div className='mt-4 rounded bg-[#252f3f] p-3 sm:p-4 font-mono text-xs sm:text-sm overflow-x-auto'>

--- a/components/SneakPeek.tsx
+++ b/components/SneakPeek.tsx
@@ -304,7 +304,7 @@ export default function SneakPeek() {
             {tabs.map((tab) => (
               <div key={tab.id} className={activeTab === tab.id ? 'block' : 'hidden'}>
                 <div
-                  className={`rounded-b-lg p-3 sm:p-4 lg:p-6 overflow-auto shadow-lg min-h-[300px] sm:min-h-[350px] lg:min-h-[400px] max-h-[500px] sm:max-h-[600px] ${tab.id === 'documentation' ? 'bg-gray-50 dark:bg-[#0A0515]' : 'bg-[#1B1130] dark:bg-[#0A0515]'}`}
+                  className={`rounded-b-lg p-3 sm:p-4 lg:p-6 overflow-auto shadow-lg min-h-[300px] sm:min-h-[350px] lg:min-h-[400px] max-h-[500px] sm:max-h-[600px] ${tab.id === 'documentation' ? 'bg-gray-50 dark:bg-[#1B1B2F]' : 'bg-[#1B1130] dark:bg-[#1B1B2F]'}`}
                 >
                   <div
                     className={

--- a/components/SneakPeek.tsx
+++ b/components/SneakPeek.tsx
@@ -142,7 +142,7 @@ export default function SneakPeek() {
           <span className='text-gray-500'>{'//'} Generated TypeScript code</span>
         </div>
         <div>
-          <span className={PURPLE}>export</span> <span className={PURPLE}>interface</span>&nbsp;
+          <span className={PURPLE}>export</span> <span className={PURPLE}>{'interface '}</span>
           <span className={YELLOW_LIGHT}>UserSignedUp</span> {'{'}
         </div>
         <div>
@@ -154,12 +154,12 @@ export default function SneakPeek() {
         <div>{'}'}</div>
         <div>&nbsp;</div>
         <div>
-          <span className={PURPLE}>export</span> <span className={PURPLE}>class</span>&nbsp;
+          <span className={PURPLE}>export</span> <span className={PURPLE}>{'class '}</span>
           <span className={YELLOW_LIGHT}>UserSignupService</span> {'{'}
         </div>
         <div>
           &nbsp;&nbsp;<span className={PURPLE}>async</span> <span className={YELLOW}>processSignup</span>(
-          <span className={ORANGE}>message</span>: <span className={YELLOW_LIGHT}>UserSignedUp</span>):&nbsp;
+          <span className={ORANGE}>message</span>: <span className={YELLOW_LIGHT}>{'UserSignedUp): '}</span>
           <span className={YELLOW_LIGHT}>Promise</span>
           {'<'}
           <span className={TEAL}>void</span>
@@ -247,12 +247,12 @@ export default function SneakPeek() {
                 <div>&nbsp;</div>
                 <div className='text-gray-300'>{'{'}</div>
                 <div>
-                  <span className='text-teal-400'>&nbsp;&nbsp;&quot;displayName&quot;</span>:&nbsp;
+                  <span className='text-teal-400'>{'\u00A0\u00A0"displayName": '}</span>
                   <span className='text-white'>&quot;Eve & Chan&quot;</span>
                   <span className='text-gray-300'>,</span>
                 </div>
                 <div>
-                  <span className='text-teal-400'>&nbsp;&nbsp;&quot;email&quot;</span>:&nbsp;
+                  <span className='text-teal-400'>{'\u00A0\u00A0"email": '}</span>
                   <span className='text-white'>&quot;info@asyncapi.io&quot;</span>
                 </div>
                 <div className='text-gray-300'>{'}'}</div>

--- a/components/SneakPeek.tsx
+++ b/components/SneakPeek.tsx
@@ -181,28 +181,28 @@ export default function SneakPeek() {
   };
 
   const renderDocumentationCode = () => (
-    <div className='font-sans text-gray-800'>
+    <div className='font-sans text-gray-800 dark:text-gray-200'>
       <div className='mb-6 mt-2 sm:mb-8 sm:mt-4'>
-        <h1 className='text-xl sm:text-2xl font-bold text-gray-500'>Account Service 1.0.0</h1>
-        <p className='text-sm sm:text-base text-gray-700 mt-2'>
+        <h1 className='text-xl sm:text-2xl font-bold text-gray-500 dark:text-gray-400'>Account Service 1.0.0</h1>
+        <p className='text-sm sm:text-base text-gray-700 dark:text-gray-300 mt-2'>
           This service is in charge of processing user signups 🚀
         </p>
       </div>
 
       <div className='mb-4 flex flex-wrap items-center gap-2'>
         <span className='rounded bg-green-500 px-2 py-1 sm:px-3 sm:py-2 font-bold text-white text-xs'>RECEIVES</span>
-        <span className='text-sm sm:text-base text-gray-700 break-all'>user/signedup</span>
+        <span className='text-sm sm:text-base text-gray-700 dark:text-gray-300 break-all'>user/signedup</span>
       </div>
 
       <div>
-        <div className='mb-2 mt-4 text-xs sm:text-sm text-gray-500'>Accepts the following message:</div>
-        <div className='rounded bg-gray-200 p-3 sm:p-4 text-gray-600'>
+        <div className='mb-2 mt-4 text-xs sm:text-sm text-gray-500 dark:text-gray-400'>Accepts the following message:</div>
+        <div className='rounded bg-gray-200 dark:bg-gray-800 p-3 sm:p-4 text-gray-600 dark:text-gray-300'>
           <button
             type='button'
             className='cursor-pointer bg-transparent border-none p-0 text-left w-full'
             onClick={() => setShowPayload(!showPayload)}
           >
-            <span className='font-medium text-sm sm:text-base'>Payload</span>{' '}
+            <span className='font-medium text-sm sm:text-base text-gray-900 dark:text-white'>Payload</span>{' '}
             <ArrowRight
               className={`inline-block size-4 transition-all duration-300 ease-in-out ${showPayload ? 'rotate-90' : ''}`}
             />{' '}
@@ -210,16 +210,16 @@ export default function SneakPeek() {
           </button>
           {showPayload && (
             <div>
-              <div className='mt-2 rounded bg-gray-100 p-3 sm:p-4'>
+              <div className='mt-2 rounded bg-gray-100 dark:bg-gray-700 p-3 sm:p-4'>
                 <div className='mb-4 grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4'>
-                  <div className='text-sm font-medium text-gray-700'>displayName</div>
+                  <div className='text-sm font-medium text-gray-700 dark:text-gray-300'>displayName</div>
                   <div>
                     <div className='font-bold text-green-500 text-sm'>String</div>
-                    <div className='text-xs text-gray-600 mt-1'>Name of the user</div>
+                    <div className='text-xs text-gray-600 dark:text-gray-400 mt-1'>Name of the user</div>
                   </div>
                 </div>
                 <div className='grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4'>
-                  <div className='text-sm font-medium text-gray-700'>email</div>
+                  <div className='text-sm font-medium text-gray-700 dark:text-gray-300'>email</div>
                   <div>
                     <div className='font-bold text-green-500 text-sm'>
                       String{' '}
@@ -227,11 +227,11 @@ export default function SneakPeek() {
                         email
                       </span>
                     </div>
-                    <div className='text-xs text-gray-600 mt-1'>Email of the user</div>
+                    <div className='text-xs text-gray-600 dark:text-gray-400 mt-1'>Email of the user</div>
                   </div>
                 </div>
 
-                <div className='mt-6 sm:mt-8 text-xs text-gray-500'>Additional properties are allowed.</div>
+                <div className='mt-6 sm:mt-8 text-xs text-gray-500 dark:text-gray-400'>Additional properties are allowed.</div>
               </div>
 
               <div className='mt-4 rounded bg-[#252f3f] p-3 sm:p-4 font-mono text-xs sm:text-sm overflow-x-auto'>
@@ -300,7 +300,7 @@ export default function SneakPeek() {
             {tabs.map((tab) => (
               <div key={tab.id} className={activeTab === tab.id ? 'block' : 'hidden'}>
                 <div
-                  className={`rounded-b-lg p-3 sm:p-4 lg:p-6 overflow-auto shadow-lg min-h-[300px] sm:min-h-[350px] lg:min-h-[400px] max-h-[500px] sm:max-h-[600px] ${tab.id === 'documentation' ? 'bg-gray-50 dark:bg-gray-100' : 'bg-[#1B1130] dark:bg-[#0A0515]'}`}
+                  className={`rounded-b-lg p-3 sm:p-4 lg:p-6 overflow-auto shadow-lg min-h-[300px] sm:min-h-[350px] lg:min-h-[400px] max-h-[500px] sm:max-h-[600px] ${tab.id === 'documentation' ? 'bg-gray-50 dark:bg-[#1B1B2F]' : 'bg-[#1B1130] dark:bg-[#0A0515]'}`}
                 >
                   <div
                     className={

--- a/components/SneakPeek.tsx
+++ b/components/SneakPeek.tsx
@@ -9,6 +9,15 @@ import Paragraph from './typography/Paragraph';
 
 type SneakPeekTab = 'document' | 'generation' | 'documentation';
 
+const TEAL = 'text-teal-600 dark:text-teal-400';
+const TEAL_LIGHT = 'text-teal-600 dark:text-teal-200';
+const WHITE = 'text-gray-900 dark:text-white';
+const YELLOW = 'text-yellow-600 dark:text-yellow-300';
+const YELLOW_LIGHT = 'text-yellow-600 dark:text-yellow-200';
+const PURPLE = 'text-purple-600 dark:text-purple-400';
+const GREEN = 'text-green-600 dark:text-green-400';
+const ORANGE = 'text-orange-600 dark:text-orange-300';
+
 /**
  * @description This component displays the Sneak Peek section with tabs showing AsyncAPI examples
  */
@@ -16,15 +25,6 @@ export default function SneakPeek() {
   const { t } = useTranslation('landing-page');
   const [activeTab, setActiveTab] = useState<SneakPeekTab>('document');
   const [showPayload, setShowPayload] = useState(true);
-
-  const TEAL = 'text-teal-600 dark:text-teal-400';
-  const TEAL_LIGHT = 'text-teal-600 dark:text-teal-200';
-  const WHITE = 'text-gray-900 dark:text-white';
-  const YELLOW = 'text-yellow-600 dark:text-yellow-300';
-  const YELLOW_LIGHT = 'text-yellow-600 dark:text-yellow-200';
-  const PURPLE = 'text-purple-600 dark:text-purple-400';
-  const GREEN = 'text-green-600 dark:text-green-400';
-  const ORANGE = 'text-orange-600 dark:text-orange-300';
 
   const renderAsyncAPICode = () => (
     <>
@@ -141,9 +141,9 @@ export default function SneakPeek() {
         <div>
           <span className='text-gray-500'>{'//'} Generated TypeScript code</span>
         </div>
+        {/* prettier-ignore */}
         <div>
-          <span className={PURPLE}>export</span> <span className={PURPLE}>{'interface '}</span>
-          <span className={YELLOW_LIGHT}>UserSignedUp</span> {'{'}
+          <span className={PURPLE}>export</span> <span className={PURPLE}>interface</span>{' '}<span className={YELLOW_LIGHT}>UserSignedUp</span> {'{'}
         </div>
         <div>
           &nbsp;&nbsp;<span className={WHITE}>displayName</span>: <span className={TEAL}>string</span>;
@@ -153,17 +153,13 @@ export default function SneakPeek() {
         </div>
         <div>{'}'}</div>
         <div>&nbsp;</div>
+        {/* prettier-ignore */}
         <div>
-          <span className={PURPLE}>export</span> <span className={PURPLE}>{'class '}</span>
-          <span className={YELLOW_LIGHT}>UserSignupService</span> {'{'}
+          <span className={PURPLE}>export</span> <span className={PURPLE}>class</span>{' '}<span className={YELLOW_LIGHT}>UserSignupService</span> {'{'}
         </div>
+        {/* prettier-ignore */}
         <div>
-          &nbsp;&nbsp;<span className={PURPLE}>async</span> <span className={YELLOW}>processSignup</span>(
-          <span className={ORANGE}>message</span>: <span className={YELLOW_LIGHT}>{'UserSignedUp): '}</span>
-          <span className={YELLOW_LIGHT}>Promise</span>
-          {'<'}
-          <span className={TEAL}>void</span>
-          {'>'} {'{'}
+          &nbsp;&nbsp;<span className={PURPLE}>async</span> <span className={YELLOW}>processSignup</span>(<span className={ORANGE}>message</span>: <span className={YELLOW_LIGHT}>UserSignedUp</span>): <span className={YELLOW_LIGHT}>Promise</span>{'<'}<span className={TEAL}>void</span>{'>'} {'{'}
         </div>
         <div>
           &nbsp;&nbsp;&nbsp;&nbsp;<span className='text-gray-500'>{'//'} Your business logic here</span>
@@ -207,6 +203,8 @@ export default function SneakPeek() {
             type='button'
             className='cursor-pointer bg-transparent border-none p-0 text-left w-full'
             onClick={() => setShowPayload((prev) => !prev)}
+            aria-expanded={showPayload}
+            aria-controls='sneakpeek-payload-content'
           >
             <span className='font-medium text-sm sm:text-base text-gray-900 dark:text-white'>Payload</span>{' '}
             <ArrowRight
@@ -215,7 +213,7 @@ export default function SneakPeek() {
             <span className='ml-4 sm:ml-24 font-bold text-green-500 text-sm sm:text-base'>Object</span>
           </button>
           {showPayload && (
-            <div>
+            <div id='sneakpeek-payload-content'>
               <div className='mt-2 rounded bg-gray-100 dark:bg-gray-700 p-3 sm:p-4'>
                 <div className='mb-4 grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4'>
                   <div className='text-sm font-medium text-gray-700 dark:text-gray-300'>displayName</div>
@@ -246,14 +244,13 @@ export default function SneakPeek() {
                 <div className='text-gray-500'>{'//'} Example</div>
                 <div>&nbsp;</div>
                 <div className='text-gray-300'>{'{'}</div>
+                {/* prettier-ignore */}
                 <div>
-                  <span className='text-teal-400'>{'\u00A0\u00A0"displayName": '}</span>
-                  <span className='text-white'>&quot;Eve & Chan&quot;</span>
-                  <span className='text-gray-300'>,</span>
+                  <span className='text-teal-400'>&nbsp;&nbsp;&quot;displayName&quot;</span>: <span className='text-white'>&quot;Eve &amp; Chan&quot;</span><span className='text-gray-300'>,</span>
                 </div>
+                {/* prettier-ignore */}
                 <div>
-                  <span className='text-teal-400'>{'\u00A0\u00A0"email": '}</span>
-                  <span className='text-white'>&quot;info@asyncapi.io&quot;</span>
+                  <span className='text-teal-400'>&nbsp;&nbsp;&quot;email&quot;</span>: <span className='text-white'>&quot;info@asyncapi.io&quot;</span>
                 </div>
                 <div className='text-gray-300'>{'}'}</div>
               </div>

--- a/components/SneakPeek.tsx
+++ b/components/SneakPeek.tsx
@@ -17,128 +17,118 @@ export default function SneakPeek() {
   const [activeTab, setActiveTab] = useState<SneakPeekTab>('document');
   const [showPayload, setShowPayload] = useState(true);
 
+  const TEAL = 'text-teal-600 dark:text-teal-400';
+  const TEAL_LIGHT = 'text-teal-600 dark:text-teal-200';
+  const WHITE = 'text-gray-900 dark:text-white';
+  const YELLOW = 'text-yellow-600 dark:text-yellow-300';
+  const YELLOW_LIGHT = 'text-yellow-600 dark:text-yellow-200';
+  const PURPLE = 'text-purple-600 dark:text-purple-400';
+  const GREEN = 'text-green-600 dark:text-green-400';
+  const ORANGE = 'text-orange-600 dark:text-orange-300';
+
   const renderAsyncAPICode = () => (
     <>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>asyncapi:</span>{' '}
-        <span className='text-gray-900 dark:text-white'>3.0.0</span>
+        <span className={TEAL}>asyncapi:</span> <span className={WHITE}>3.0.0</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>info:</span>
+        <span className={TEAL}>info:</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>&nbsp;&nbsp;title:</span>{' '}
-        <span className='text-gray-900 dark:text-white'>Account Service</span>
+        <span className={TEAL}>&nbsp;&nbsp;title:</span> <span className={WHITE}>Account Service</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>&nbsp;&nbsp;version:</span>{' '}
-        <span className='text-gray-900 dark:text-white'>1.0.0</span>
+        <span className={TEAL}>&nbsp;&nbsp;version:</span> <span className={WHITE}>1.0.0</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>&nbsp;&nbsp;description:</span>{' '}
-        <span className='text-gray-900 dark:text-white'>
-          This service is in charge of processing user signups :rocket:
-        </span>
+        <span className={TEAL}>&nbsp;&nbsp;description:</span>{' '}
+        <span className={WHITE}>This service is in charge of processing user signups :rocket:</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>channels:</span>
+        <span className={TEAL}>channels:</span>
       </div>
       <div>
-        <span className='text-yellow-600 dark:text-yellow-300'>&nbsp;&nbsp;userSignedup:</span>
+        <span className={YELLOW}>&nbsp;&nbsp;userSignedup:</span>
       </div>
       <div>
-        <span className='text-purple-600 dark:text-purple-400'>&nbsp;&nbsp;&nbsp;&nbsp;address:</span>
-        <span className='text-teal-600 dark:text-teal-200'>&apos;user/signedup&apos;</span>
+        <span className={PURPLE}>&nbsp;&nbsp;&nbsp;&nbsp;address:</span>
+        <span className={TEAL_LIGHT}>&apos;user/signedup&apos;</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>&nbsp;&nbsp;&nbsp;&nbsp;messages:</span>
+        <span className={TEAL}>&nbsp;&nbsp;&nbsp;&nbsp;messages:</span>
       </div>
       <div>
-        <span className='text-yellow-600 dark:text-yellow-300'>
-          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;userSignedupMessage:
-        </span>
+        <span className={YELLOW}>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;userSignedupMessage:</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-200'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;$ref:</span>
-        <span className='text-teal-600 dark:text-teal-200'>&apos;#/components/messages/UserSignedUp&apos;</span>
+        <span className={TEAL_LIGHT}>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;$ref:</span>
+        <span className={TEAL_LIGHT}>&apos;#/components/messages/UserSignedUp&apos;</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>operations:</span>
+        <span className={TEAL}>operations:</span>
       </div>
       <div>
-        <span className='text-yellow-600 dark:text-yellow-300'>&nbsp;&nbsp;processUserSignedupMessage:</span>
+        <span className={YELLOW}>&nbsp;&nbsp;processUserSignedupMessage:</span>
       </div>
       <div>
-        <span className='text-purple-600 dark:text-purple-400'>&nbsp;&nbsp;&nbsp;&nbsp;action:</span>
-        <span className='text-teal-600 dark:text-teal-200'>&apos;receive&apos;</span>
+        <span className={PURPLE}>&nbsp;&nbsp;&nbsp;&nbsp;action:</span>
+        <span className={TEAL_LIGHT}>&apos;receive&apos;</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>&nbsp;&nbsp;&nbsp;&nbsp;channel:</span>
+        <span className={TEAL}>&nbsp;&nbsp;&nbsp;&nbsp;channel:</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-200'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;$ref:</span>
-        <span className='text-teal-600 dark:text-teal-200'> &apos;#/channels/UserSignedup&apos;</span>
+        <span className={TEAL_LIGHT}>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;$ref:</span>
+        <span className={TEAL_LIGHT}> &apos;#/channels/UserSignedup&apos;</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>components:</span>
+        <span className={TEAL}>components:</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>&nbsp;&nbsp;messages:</span>
+        <span className={TEAL}>&nbsp;&nbsp;messages:</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-200'>&nbsp;&nbsp;&nbsp;&nbsp;UserSignedUp:</span>
+        <span className={TEAL_LIGHT}>&nbsp;&nbsp;&nbsp;&nbsp;UserSignedUp:</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;payload:</span>
+        <span className={TEAL}>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;payload:</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type:</span>
-        <span className='text-gray-900 dark:text-white'> object</span>
+        <span className={TEAL}>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type:</span>
+        <span className={WHITE}> object</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>
-          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;properties:
-        </span>
+        <span className={TEAL}>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;properties:</span>
       </div>
       <div>
-        <span className='text-green-600 dark:text-green-400'>
-          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;displayName:
-        </span>
+        <span className={GREEN}>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;displayName:</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>
-          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type:
-        </span>
-        <span className='text-gray-900 dark:text-white'> object</span>
+        <span className={TEAL}>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type:</span>
+        <span className={WHITE}> object</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>
+        <span className={TEAL}>
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description:
         </span>
-        <span className='text-gray-900 dark:text-white'> Name of the User</span>
+        <span className={WHITE}> Name of the User</span>
       </div>
       <div>
-        <span className='text-green-600 dark:text-green-400'>
-          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;email:
-        </span>
+        <span className={GREEN}>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;email:</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>
-          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type:
-        </span>
-        <span className='text-gray-900 dark:text-white'> string</span>
+        <span className={TEAL}>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type:</span>
+        <span className={WHITE}> string</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>
-          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;format:
-        </span>
-        <span className='text-gray-900 dark:text-white'> email</span>
+        <span className={TEAL}>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;format:</span>
+        <span className={WHITE}> email</span>
       </div>
       <div>
-        <span className='text-teal-600 dark:text-teal-400'>
+        <span className={TEAL}>
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description:
         </span>
-        <span className='text-gray-900 dark:text-white'> Email of the User</span>
+        <span className={WHITE}> Email of the User</span>
       </div>
     </>
   );
@@ -152,42 +142,43 @@ export default function SneakPeek() {
           <span className='text-gray-500'>{'//'} Generated TypeScript code</span>
         </div>
         <div>
-          <span className='text-purple-600 dark:text-purple-400'>export</span>{' '}
-          <span className='text-purple-600 dark:text-purple-400'>interface</span>{' '}
-          <span className='text-yellow-600 dark:text-yellow-200'>UserSignedUp</span> {'{'}
+          <span className={PURPLE}>export</span> <span className={PURPLE}>interface</span>{' '}
+          <span className={YELLOW_LIGHT}>UserSignedUp</span> {'{'}
         </div>
         <div>
-          &nbsp;&nbsp;<span className='text-gray-900 dark:text-white'>displayName</span>:{' '}
-          <span className='text-teal-600 dark:text-teal-400'>string</span>;
+          &nbsp;&nbsp;<span className={WHITE}>displayName</span>: <span className={TEAL}>string</span>;
         </div>
         <div>
-          &nbsp;&nbsp;<span className='text-gray-900 dark:text-white'>email</span>:{' '}
-          <span className='text-teal-600 dark:text-teal-400'>string</span>;
+          &nbsp;&nbsp;<span className={WHITE}>email</span>: <span className={TEAL}>string</span>;
         </div>
         <div>{'}'}</div>
         <div>&nbsp;</div>
         <div>
-          <span className='text-purple-600 dark:text-purple-400'>export</span>{' '}
-          <span className='text-purple-600 dark:text-purple-400'>class</span>{' '}
-          <span className='text-yellow-600 dark:text-yellow-200'>UserSignupService</span> {'{'}
+          <span className={PURPLE}>export</span> <span className={PURPLE}>class</span>{' '}
+          <span className={YELLOW_LIGHT}>UserSignupService</span> {'{'}
         </div>
         <div>
-          &nbsp;&nbsp;<span className='text-purple-600 dark:text-purple-400'>async</span>{' '}
-          <span className='text-yellow-600 dark:text-yellow-300'>processSignup</span>(
-          <span className='text-orange-600 dark:text-orange-300'>message</span>:{' '}
-          <span className='text-yellow-600 dark:text-yellow-200'>UserSignedUp</span>):{' '}
-          <span className='text-yellow-600 dark:text-yellow-200'>Promise</span>
+          &nbsp;&nbsp;<span className={PURPLE}>async</span> <span className={YELLOW}>processSignup</span>(
+          <span className={ORANGE}>message</span>: <span className={YELLOW_LIGHT}>UserSignedUp</span>):{' '}
+          <span className={YELLOW_LIGHT}>Promise</span>
           {'<'}
-          <span className='text-teal-600 dark:text-teal-400'>void</span>
+          <span className={TEAL}>void</span>
           {'>'} {'{'}
         </div>
         <div>
           &nbsp;&nbsp;&nbsp;&nbsp;<span className='text-gray-500'>{'//'} Your business logic here</span>
         </div>
         <div>
-          &nbsp;&nbsp;&nbsp;&nbsp;<span className='text-yellow-600 dark:text-yellow-200'>console</span>{'.'}<span className='text-yellow-600 dark:text-yellow-300'>log</span>{'('}<span className='text-teal-600 dark:text-teal-200'>{logStatement}</span>{')'}{';'}
+          {'\u00A0\u00A0\u00A0\u00A0'}
+          <span className={YELLOW_LIGHT}>console</span>
+          {'.'}
+          <span className={YELLOW}>log</span>
+          {'('}
+          <span className={TEAL_LIGHT}>{logStatement}</span>
+          {')'}
+          {';'}
         </div>
-        <div>&nbsp;&nbsp;{'}'}</div>
+        <div>{'\u00A0\u00A0}'}</div>
         <div>{'}'}</div>
       </>
     );
@@ -215,7 +206,7 @@ export default function SneakPeek() {
           <button
             type='button'
             className='cursor-pointer bg-transparent border-none p-0 text-left w-full'
-            onClick={() => setShowPayload(!showPayload)}
+            onClick={() => setShowPayload((prev) => !prev)}
           >
             <span className='font-medium text-sm sm:text-base text-gray-900 dark:text-white'>Payload</span>{' '}
             <ArrowRight

--- a/components/SneakPeek.tsx
+++ b/components/SneakPeek.tsx
@@ -20,112 +20,125 @@ export default function SneakPeek() {
   const renderAsyncAPICode = () => (
     <>
       <div>
-        <span className='text-teal-400'>asyncapi:</span> <span className='text-white'>3.0.0</span>
+        <span className='text-teal-600 dark:text-teal-400'>asyncapi:</span>{' '}
+        <span className='text-gray-900 dark:text-white'>3.0.0</span>
       </div>
       <div>
-        <span className='text-teal-400'>info:</span>
+        <span className='text-teal-600 dark:text-teal-400'>info:</span>
       </div>
       <div>
-        <span className='text-teal-400'>&nbsp;&nbsp;title:</span> <span className='text-white'>Account Service</span>
+        <span className='text-teal-600 dark:text-teal-400'>&nbsp;&nbsp;title:</span>{' '}
+        <span className='text-gray-900 dark:text-white'>Account Service</span>
       </div>
       <div>
-        <span className='text-teal-400'>&nbsp;&nbsp;version:</span> <span className='text-white'>1.0.0</span>
+        <span className='text-teal-600 dark:text-teal-400'>&nbsp;&nbsp;version:</span>{' '}
+        <span className='text-gray-900 dark:text-white'>1.0.0</span>
       </div>
       <div>
-        <span className='text-teal-400'>&nbsp;&nbsp;description:</span>{' '}
-        <span className='text-white'>This service is in charge of processing user signups :rocket:</span>
+        <span className='text-teal-600 dark:text-teal-400'>&nbsp;&nbsp;description:</span>{' '}
+        <span className='text-gray-900 dark:text-white'>
+          This service is in charge of processing user signups :rocket:
+        </span>
       </div>
       <div>
-        <span className='text-teal-400'>channels:</span>
+        <span className='text-teal-600 dark:text-teal-400'>channels:</span>
       </div>
       <div>
-        <span className='text-yellow-300'>&nbsp;&nbsp;userSignedup:</span>
+        <span className='text-yellow-600 dark:text-yellow-300'>&nbsp;&nbsp;userSignedup:</span>
       </div>
       <div>
-        <span className='text-purple-400'>&nbsp;&nbsp;&nbsp;&nbsp;address:</span>
-        <span className='text-teal-200'>&apos;user/signedup&apos;</span>
+        <span className='text-purple-600 dark:text-purple-400'>&nbsp;&nbsp;&nbsp;&nbsp;address:</span>
+        <span className='text-teal-600 dark:text-teal-200'>&apos;user/signedup&apos;</span>
       </div>
       <div>
-        <span className='text-teal-400'>&nbsp;&nbsp;&nbsp;&nbsp;messages:</span>
+        <span className='text-teal-600 dark:text-teal-400'>&nbsp;&nbsp;&nbsp;&nbsp;messages:</span>
       </div>
       <div>
-        <span className='text-yellow-300'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;userSignedupMessage:</span>
+        <span className='text-yellow-600 dark:text-yellow-300'>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;userSignedupMessage:
+        </span>
       </div>
       <div>
-        <span className='text-teal-200'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;$ref:</span>
-        <span className='text-teal-200'>&apos;#/components/messages/UserSignedUp&apos;</span>
+        <span className='text-teal-600 dark:text-teal-200'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;$ref:</span>
+        <span className='text-teal-600 dark:text-teal-200'>&apos;#/components/messages/UserSignedUp&apos;</span>
       </div>
       <div>
-        <span className='text-teal-400'>operations:</span>
+        <span className='text-teal-600 dark:text-teal-400'>operations:</span>
       </div>
       <div>
-        <span className='text-yellow-300'>&nbsp;&nbsp;processUserSignedupMessage:</span>
+        <span className='text-yellow-600 dark:text-yellow-300'>&nbsp;&nbsp;processUserSignedupMessage:</span>
       </div>
       <div>
-        <span className='text-purple-400'>&nbsp;&nbsp;&nbsp;&nbsp;action:</span>
-        <span className='text-teal-200'>&apos;receive&apos;</span>
+        <span className='text-purple-600 dark:text-purple-400'>&nbsp;&nbsp;&nbsp;&nbsp;action:</span>
+        <span className='text-teal-600 dark:text-teal-200'>&apos;receive&apos;</span>
       </div>
       <div>
-        <span className='text-teal-400'>&nbsp;&nbsp;&nbsp;&nbsp;channel:</span>
+        <span className='text-teal-600 dark:text-teal-400'>&nbsp;&nbsp;&nbsp;&nbsp;channel:</span>
       </div>
       <div>
-        <span className='text-teal-200'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;$ref:</span>
-        <span className='text-teal-200'> &apos;#/channels/UserSignedup&apos;</span>
+        <span className='text-teal-600 dark:text-teal-200'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;$ref:</span>
+        <span className='text-teal-600 dark:text-teal-200'> &apos;#/channels/UserSignedup&apos;</span>
       </div>
       <div>
-        <span className='text-teal-400'>components:</span>
+        <span className='text-teal-600 dark:text-teal-400'>components:</span>
       </div>
       <div>
-        <span className='text-teal-400'>&nbsp;&nbsp;messages:</span>
+        <span className='text-teal-600 dark:text-teal-400'>&nbsp;&nbsp;messages:</span>
       </div>
       <div>
-        <span className='text-teal-200'>&nbsp;&nbsp;&nbsp;&nbsp;UserSignedUp:</span>
+        <span className='text-teal-600 dark:text-teal-200'>&nbsp;&nbsp;&nbsp;&nbsp;UserSignedUp:</span>
       </div>
       <div>
-        <span className='text-teal-400'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;payload:</span>
+        <span className='text-teal-600 dark:text-teal-400'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;payload:</span>
       </div>
       <div>
-        <span className='text-teal-400'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type:</span>
-        <span className='text-white'> object</span>
+        <span className='text-teal-600 dark:text-teal-400'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type:</span>
+        <span className='text-gray-900 dark:text-white'> object</span>
       </div>
       <div>
-        <span className='text-teal-400'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;properties:</span>
+        <span className='text-teal-600 dark:text-teal-400'>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;properties:
+        </span>
       </div>
       <div>
-        <span className='text-green-400'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;displayName:</span>
+        <span className='text-green-600 dark:text-green-400'>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;displayName:
+        </span>
       </div>
       <div>
-        <span className='text-teal-400'>
+        <span className='text-teal-600 dark:text-teal-400'>
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type:
         </span>
-        <span className='text-white'> object</span>
+        <span className='text-gray-900 dark:text-white'> object</span>
       </div>
       <div>
-        <span className='text-teal-400'>
+        <span className='text-teal-600 dark:text-teal-400'>
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description:
         </span>
-        <span className='text-white'> Name of the User</span>
+        <span className='text-gray-900 dark:text-white'> Name of the User</span>
       </div>
       <div>
-        <span className='text-green-400'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;email:</span>
+        <span className='text-green-600 dark:text-green-400'>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;email:
+        </span>
       </div>
       <div>
-        <span className='text-teal-400'>
+        <span className='text-teal-600 dark:text-teal-400'>
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type:
         </span>
-        <span className='text-white'> string</span>
+        <span className='text-gray-900 dark:text-white'> string</span>
       </div>
       <div>
-        <span className='text-teal-400'>
+        <span className='text-teal-600 dark:text-teal-400'>
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;format:
         </span>
-        <span className='text-white'> email</span>
+        <span className='text-gray-900 dark:text-white'> email</span>
       </div>
       <div>
-        <span className='text-teal-400'>
+        <span className='text-teal-600 dark:text-teal-400'>
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description:
         </span>
-        <span className='text-white'> Email of the User</span>
+        <span className='text-gray-900 dark:text-white'> Email of the User</span>
       </div>
     </>
   );
@@ -139,38 +152,44 @@ export default function SneakPeek() {
           <span className='text-gray-500'>{'//'} Generated TypeScript code</span>
         </div>
         <div>
-          <span className='text-purple-400'>export</span> <span className='text-purple-400'>interface</span>{' '}
-          <span className='text-yellow-200'>UserSignedUp</span> {'{'}
+          <span className='text-purple-600 dark:text-purple-400'>export</span>{' '}
+          <span className='text-purple-600 dark:text-purple-400'>interface</span>{' '}
+          <span className='text-yellow-600 dark:text-yellow-200'>UserSignedUp</span> {'{'}
         </div>
         <div>
-          &nbsp;&nbsp;<span className='text-white'>displayName</span>: <span className='text-teal-400'>string</span>;
+          &nbsp;&nbsp;<span className='text-gray-900 dark:text-white'>displayName</span>:{' '}
+          <span className='text-teal-600 dark:text-teal-400'>string</span>;
         </div>
         <div>
-          &nbsp;&nbsp;<span className='text-white'>email</span>: <span className='text-teal-400'>string</span>;
+          &nbsp;&nbsp;<span className='text-gray-900 dark:text-white'>email</span>:{' '}
+          <span className='text-teal-600 dark:text-teal-400'>string</span>;
         </div>
         <div>{'}'}</div>
         <div>&nbsp;</div>
         <div>
-          <span className='text-purple-400'>export</span> <span className='text-purple-400'>class</span>{' '}
-          <span className='text-yellow-200'>UserSignupService</span> {'{'}
+          <span className='text-purple-600 dark:text-purple-400'>export</span>{' '}
+          <span className='text-purple-600 dark:text-purple-400'>class</span>{' '}
+          <span className='text-yellow-600 dark:text-yellow-200'>UserSignupService</span> {'{'}
         </div>
         <div>
-          &nbsp;&nbsp;<span className='text-purple-400'>async</span>{' '}
-          <span className='text-yellow-300'>processSignup</span>(<span className='text-orange-300'>message</span>:{' '}
-          <span className='text-yellow-200'>UserSignedUp</span>): <span className='text-yellow-200'>Promise</span>
+          &nbsp;&nbsp;<span className='text-purple-600 dark:text-purple-400'>async</span>{' '}
+          <span className='text-yellow-600 dark:text-yellow-300'>processSignup</span>(
+          <span className='text-orange-600 dark:text-orange-300'>message</span>:{' '}
+          <span className='text-yellow-600 dark:text-yellow-200'>UserSignedUp</span>):{' '}
+          <span className='text-yellow-600 dark:text-yellow-200'>Promise</span>
           {'<'}
-          <span className='text-teal-400'>void</span>
+          <span className='text-teal-600 dark:text-teal-400'>void</span>
           {'>'} {'{'}
         </div>
         <div>
           &nbsp;&nbsp;&nbsp;&nbsp;<span className='text-gray-500'>{'//'} Your business logic here</span>
         </div>
         <div>
-          &nbsp;&nbsp;&nbsp;&nbsp;<span className='text-yellow-200'>console</span>
+          &nbsp;&nbsp;&nbsp;&nbsp;<span className='text-yellow-600 dark:text-yellow-200'>console</span>
           {'.'}
-          <span className='text-yellow-300'>log</span>
+          <span className='text-yellow-600 dark:text-yellow-300'>log</span>
           {'('}
-          <span className='text-teal-200'>{logStatement}</span>
+          <span className='text-teal-600 dark:text-teal-200'>{logStatement}</span>
           {')'}
           {';'}
         </div>
@@ -283,15 +302,15 @@ export default function SneakPeek() {
         {/* Tabs Container */}
         <div className='mt-8 sm:mt-12'>
           {/* Tabs Bar */}
-          <div className='flex flex-col sm:flex-row justify-center bg-dark-background dark:bg-dark-card rounded-t-lg overflow-hidden'>
+          <div className='flex flex-col sm:flex-row justify-center bg-gray-100 dark:bg-dark-card rounded-t-lg overflow-hidden'>
             {tabs.map((tab, index) => (
               <button
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id)}
-                className={`flex-1 px-3 py-3 sm:px-4 sm:py-4 text-xs sm:text-sm font-medium transition-all duration-200 ${index === tabs.length - 1 ? '' : 'border-b sm:border-b-0 sm:border-r'} border-gray-300 dark:border-gray-300 ${
+                className={`flex-1 px-3 py-3 sm:px-4 sm:py-4 text-xs sm:text-sm font-medium transition-all duration-200 ${index === tabs.length - 1 ? '' : 'border-b sm:border-b-0 sm:border-r'} border-gray-300 dark:border-gray-700 ${
                   activeTab === tab.id
                     ? 'bg-white dark:bg-[#1B1B2F] text-gray-900 dark:text-white'
-                    : 'bg-[#2D1F3F] dark:bg-[#14111D] text-gray-300 dark:text-gray-400 hover:bg-[#3D2F4F] dark:hover:bg-[#1F1A2F]'
+                    : 'bg-gray-100 dark:bg-[#14111D] text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-[#1F1A2F]'
                 }`}
               >
                 {tab.label}
@@ -304,7 +323,7 @@ export default function SneakPeek() {
             {tabs.map((tab) => (
               <div key={tab.id} className={activeTab === tab.id ? 'block' : 'hidden'}>
                 <div
-                  className={`rounded-b-lg p-3 sm:p-4 lg:p-6 overflow-auto shadow-lg min-h-[300px] sm:min-h-[350px] lg:min-h-[400px] max-h-[500px] sm:max-h-[600px] ${tab.id === 'documentation' ? 'bg-gray-50 dark:bg-[#1B1B2F]' : 'bg-[#1B1130] dark:bg-[#1B1B2F]'}`}
+                  className={`rounded-b-lg p-3 sm:p-4 lg:p-6 overflow-auto shadow-lg min-h-[300px] sm:min-h-[350px] lg:min-h-[400px] max-h-[500px] sm:max-h-[600px] ${tab.id === 'documentation' ? 'bg-white dark:bg-[#1B1B2F] border border-gray-200 dark:border-none' : 'bg-white dark:bg-[#1B1B2F] border border-gray-200 dark:border-none'}`}
                 >
                   <div
                     className={

--- a/components/SneakPeek.tsx
+++ b/components/SneakPeek.tsx
@@ -139,7 +139,7 @@ export default function SneakPeek() {
     return (
       <>
         <div>
-          <span className='text-gray-500'>{'//'} Generated TypeScript code</span>
+          <span className='text-gray-500 dark:text-gray-400'>{'//'} Generated TypeScript code</span>
         </div>
         {/* prettier-ignore */}
         <div>
@@ -162,7 +162,8 @@ export default function SneakPeek() {
           &nbsp;&nbsp;<span className={PURPLE}>async</span> <span className={YELLOW}>processSignup</span>(<span className={ORANGE}>message</span>: <span className={YELLOW_LIGHT}>UserSignedUp</span>): <span className={YELLOW_LIGHT}>Promise</span>{'<'}<span className={TEAL}>void</span>{'>'} {'{'}
         </div>
         <div>
-          &nbsp;&nbsp;&nbsp;&nbsp;<span className='text-gray-500'>{'//'} Your business logic here</span>
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          <span className='text-gray-500 dark:text-gray-400'>{'//'} Your business logic here</span>
         </div>
         <div>
           {'\u00A0\u00A0\u00A0\u00A0'}
@@ -183,7 +184,7 @@ export default function SneakPeek() {
   const renderDocumentationCode = () => (
     <div className='font-sans text-gray-800 dark:text-gray-200'>
       <div className='mb-6 mt-2 sm:mb-8 sm:mt-4'>
-        <h1 className='text-xl sm:text-2xl font-bold text-gray-500 dark:text-gray-400'>Account Service 1.0.0</h1>
+        <h1 className='text-xl sm:text-2xl font-bold text-gray-700 dark:text-gray-400'>Account Service 1.0.0</h1>
         <p className='text-sm sm:text-base text-gray-700 dark:text-gray-300 mt-2'>
           This service is in charge of processing user signups 🚀
         </p>
@@ -227,7 +228,7 @@ export default function SneakPeek() {
                   <div>
                     <div className='font-bold text-green-500 text-sm'>
                       String{' '}
-                      <span className='ml-2 rounded bg-yellow-300 px-1.5 py-0.5 text-xs text-black font-normal'>
+                      <span className='ml-2 rounded bg-yellow-300 dark:bg-yellow-500 px-1.5 py-0.5 text-xs text-black font-normal'>
                         email
                       </span>
                     </div>

--- a/components/SneakPeek.tsx
+++ b/components/SneakPeek.tsx
@@ -142,7 +142,7 @@ export default function SneakPeek() {
           <span className='text-gray-500'>{'//'} Generated TypeScript code</span>
         </div>
         <div>
-          <span className={PURPLE}>export</span> <span className={PURPLE}>interface</span>{' '}
+          <span className={PURPLE}>export</span> <span className={PURPLE}>interface</span>&nbsp;
           <span className={YELLOW_LIGHT}>UserSignedUp</span> {'{'}
         </div>
         <div>
@@ -154,12 +154,12 @@ export default function SneakPeek() {
         <div>{'}'}</div>
         <div>&nbsp;</div>
         <div>
-          <span className={PURPLE}>export</span> <span className={PURPLE}>class</span>{' '}
+          <span className={PURPLE}>export</span> <span className={PURPLE}>class</span>&nbsp;
           <span className={YELLOW_LIGHT}>UserSignupService</span> {'{'}
         </div>
         <div>
           &nbsp;&nbsp;<span className={PURPLE}>async</span> <span className={YELLOW}>processSignup</span>(
-          <span className={ORANGE}>message</span>: <span className={YELLOW_LIGHT}>UserSignedUp</span>):{' '}
+          <span className={ORANGE}>message</span>: <span className={YELLOW_LIGHT}>UserSignedUp</span>):&nbsp;
           <span className={YELLOW_LIGHT}>Promise</span>
           {'<'}
           <span className={TEAL}>void</span>
@@ -247,12 +247,12 @@ export default function SneakPeek() {
                 <div>&nbsp;</div>
                 <div className='text-gray-300'>{'{'}</div>
                 <div>
-                  <span className='text-teal-400'>&nbsp;&nbsp;&quot;displayName&quot;</span>:{' '}
+                  <span className='text-teal-400'>&nbsp;&nbsp;&quot;displayName&quot;</span>:&nbsp;
                   <span className='text-white'>&quot;Eve & Chan&quot;</span>
                   <span className='text-gray-300'>,</span>
                 </div>
                 <div>
-                  <span className='text-teal-400'>&nbsp;&nbsp;&quot;email&quot;</span>:{' '}
+                  <span className='text-teal-400'>&nbsp;&nbsp;&quot;email&quot;</span>:&nbsp;
                   <span className='text-white'>&quot;info@asyncapi.io&quot;</span>
                 </div>
                 <div className='text-gray-300'>{'}'}</div>

--- a/components/SneakPeek.tsx
+++ b/components/SneakPeek.tsx
@@ -185,13 +185,7 @@ export default function SneakPeek() {
           &nbsp;&nbsp;&nbsp;&nbsp;<span className='text-gray-500'>{'//'} Your business logic here</span>
         </div>
         <div>
-          &nbsp;&nbsp;&nbsp;&nbsp;<span className='text-yellow-600 dark:text-yellow-200'>console</span>
-          {'.'}
-          <span className='text-yellow-600 dark:text-yellow-300'>log</span>
-          {'('}
-          <span className='text-teal-600 dark:text-teal-200'>{logStatement}</span>
-          {')'}
-          {';'}
+          &nbsp;&nbsp;&nbsp;&nbsp;<span className='text-yellow-600 dark:text-yellow-200'>console</span>{'.'}<span className='text-yellow-600 dark:text-yellow-300'>log</span>{'('}<span className='text-teal-600 dark:text-teal-200'>{logStatement}</span>{')'}{';'}
         </div>
         <div>&nbsp;&nbsp;{'}'}</div>
         <div>{'}'}</div>
@@ -322,9 +316,7 @@ export default function SneakPeek() {
           <div className='text-left'>
             {tabs.map((tab) => (
               <div key={tab.id} className={activeTab === tab.id ? 'block' : 'hidden'}>
-                <div
-                  className={`rounded-b-lg p-3 sm:p-4 lg:p-6 overflow-auto shadow-lg min-h-[300px] sm:min-h-[350px] lg:min-h-[400px] max-h-[500px] sm:max-h-[600px] ${tab.id === 'documentation' ? 'bg-white dark:bg-[#1B1B2F] border border-gray-200 dark:border-none' : 'bg-white dark:bg-[#1B1B2F] border border-gray-200 dark:border-none'}`}
-                >
+                <div className='rounded-b-lg p-3 sm:p-4 lg:p-6 overflow-auto shadow-lg min-h-[300px] sm:min-h-[350px] lg:min-h-[400px] max-h-[500px] sm:max-h-[600px] bg-white dark:bg-[#1B1B2F] border-x border-b border-gray-200 dark:border-none'>
                   <div
                     className={
                       tab.id === 'documentation' ? '' : 'text-[10px] sm:text-xs md:text-sm leading-relaxed font-mono'


### PR DESCRIPTION
ref - https://github.com/asyncapi/website/pull/5253#discussion_r2954594237

before 
Dark
<img width="1072" height="575" alt="Screenshot 2026-05-25 at 12 09 59 PM" src="https://github.com/user-attachments/assets/fb4fd95a-c8a2-4c94-b802-fb7ef18e2e69" />
<img width="1192" height="664" alt="Screenshot 2026-05-28 at 12 28 44 AM" src="https://github.com/user-attachments/assets/c6df189f-cff4-4646-8955-12e273bb216a" />
<img width="1148" height="463" alt="Screenshot 2026-05-28 at 12 29 18 AM" src="https://github.com/user-attachments/assets/b88a52e9-8bf8-4f1d-a753-0f22ae0be6b0" />

Light
<img width="1171" height="684" alt="Screenshot 2026-05-28 at 12 27 56 AM" src="https://github.com/user-attachments/assets/8ed49aef-9193-479d-9aa8-a71f50b09dea" />
<img width="1149" height="472" alt="Screenshot 2026-05-28 at 12 28 27 AM" src="https://github.com/user-attachments/assets/2b43dbcc-91e6-4965-8ba5-4b8248dc7e04" />



after
Dark 
<img width="1101" height="608" alt="Screenshot 2026-05-25 at 12 10 12 PM" src="https://github.com/user-attachments/assets/e6a2e387-a275-4610-82f5-66b3f7dd3efb" />

Light 
<img width="773" height="426" alt="Screenshot 2026-05-28 at 12 26 38 AM" src="https://github.com/user-attachments/assets/003c11c3-1774-4165-9bf2-d9c79054a2a5" />
<img width="770" height="330" alt="Screenshot 2026-05-28 at 12 26 51 AM" src="https://github.com/user-attachments/assets/41505d57-7fab-4aac-b1ad-3e7006683f84" />
<img width="770" height="439" alt="Screenshot 2026-05-28 at 12 27 06 AM" src="https://github.com/user-attachments/assets/24000228-f8ef-49d5-a959-3cfe54f9e697" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined Sneak Peek UI with consistent color theming using shared color variants for light/dark modes.
  * Restyled tabs, documentation wrapper, and code display panel for clearer backgrounds, borders, and active/inactive states.
  * Updated code snippet presentation to a reorganized TypeScript-style example with adjusted spacing and coloring.

* **Bug Fixes**
  * Fixed Payload expand/collapse interaction to reliably toggle state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->