### PR TITLE
fix: use canonical slack url and fix calendar account constraint

### DIFF
--- a/pages/[lang]/index.tsx
+++ b/pages/[lang]/index.tsx
@@ -70,7 +70,7 @@ export default function HomePage() {
           <Paragraph className='mx-auto mb-6 underline text-sky-400 max-w-prose'>{t('events.meetingTitle')}</Paragraph>
           <div className='flex flex-col items-center justify-center gap-2 md:flex-row'>
             <GoogleCalendarButton
-              href='https://calendar.google.com/calendar/u/3?cid=Y19xOXRzZWlnbG9tZHNqNm5qdWh2YnB0czExY0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t'
+              href='https://calendar.google.com/calendar/u/0?cid=Y19xOXRzZWlnbG9tZHNqNm5qdWh2YnB0czExY0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t'
               className='mt-2 md:ml-2 md:mt-0'
             />
             <ICSFileButton

--- a/pages/casestudies/index.tsx
+++ b/pages/casestudies/index.tsx
@@ -295,7 +295,7 @@ export default function CaseStudies() {
               />
               <Button
                 text='Join Our Community'
-                href='https://asyncapi.slack.com/join/shared_invite/zt-3clk6rmc0-Cujl2fChHYnHDUwFKRlQCw'
+                href='https://asyncapi.com/slack-invite'
                 className='w-full sm:w-auto bg-transparent border-2 border-white text-white hover:bg-white/10'
               />
             </div>

--- a/pages/community/events-and-updates.tsx
+++ b/pages/community/events-and-updates.tsx
@@ -161,7 +161,7 @@ export default function EventsAndUpdates() {
                 </Paragraph>
                 <ul className='mt-8 flex flex-wrap justify-center gap-3 lg:justify-start'>
                   <li>
-                    <GoogleCalendarButton href='https://calendar.google.com/calendar/u/3?cid=Y19xOXRzZWlnbG9tZHNqNm5qdWh2YnB0czExY0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t' />
+                    <GoogleCalendarButton href='https://calendar.google.com/calendar/u/0?cid=Y19xOXRzZWlnbG9tZHNqNm5qdWh2YnB0czExY0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t' />
                   </li>
                   <li>
                     <SubscribeButton href='/community/meetings' />

--- a/pages/community/events/index.tsx
+++ b/pages/community/events/index.tsx
@@ -33,7 +33,7 @@ export default function EventIndex() {
             Join an AsyncAPI event from anywhere in the world.
           </h1>
           <div className='mt-10' data-testid='Events-Button'>
-            <GoogleCalendarButton href='https://calendar.google.com/calendar/u/3?cid=Y19xOXRzZWlnbG9tZHNqNm5qdWh2YnB0czExY0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t' />
+            <GoogleCalendarButton href='https://calendar.google.com/calendar/u/0?cid=Y19xOXRzZWlnbG9tZHNqNm5qdWh2YnB0czExY0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t' />
             <ICSFileButton
               href='https://calendar.google.com/calendar/ical/c_q9tseiglomdsj6njuhvbpts11c%40group.calendar.google.com/public/basic.ics'
               className='mt-2 md:ml-2 md:mt-0'


### PR DESCRIPTION
ref - https://github.com/asyncapi/website/pull/5253#discussion_r2954594273
ref - https://github.com/asyncapi/website/pull/5253#discussion_r2954594269


slack invite 
<img width="1241" height="766" alt="Screenshot 2026-05-26 at 12 09 09 PM" src="https://github.com/user-attachments/assets/9d276a0c-a797-48e9-8545-cacc6499a847" />

calender - . The old link (.../embed?...) was a hardcoded embed link that would cause issues depending on the Google account the user logged from .

old - https://calendar.google.com/calendar/u/0/embed?src=c_q9tseiglomdsj6njuhvbpts11c@group.calendar.google.com&ctz=UTC

new - https://calendar.google.com/calendar/u/0/r?cid=Y19xOXRzZWlnbG9tZHNqNm5qdWh2YnB0czExY0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Google Calendar links across the site so calendar invites open with the correct account path (improves reliability when adding events).
  * Updated the community Slack invite CTA to use the simplified invite URL (easier access to join the community).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->