### PR TITLE
fix(DocsMobileMenu): enhance dark theme support and improve styling c…

### DIFF
--- a/components/icons/DocsArrow.tsx
+++ b/components/icons/DocsArrow.tsx
@@ -20,7 +20,9 @@ interface DocsArrowProps {
 export default function DocsArrow({ isDropDown, activeDropDownItem, onClick, className }: DocsArrowProps) {
   return (
     <div
-      className={`my-auto w-6 cursor-pointer rounded-md p-2 ${isDropDown && 'hover:bg-gray-100'}`}
+      className={`my-auto w-6 cursor-pointer rounded-md p-2 ${
+        isDropDown && 'hover:bg-gray-100 dark:hover:bg-dark-card'
+      }`}
       onClick={isDropDown ? onClick : () => {}}
     >
       {isDropDown && (

--- a/components/navigation/DocsMobileMenu.tsx
+++ b/components/navigation/DocsMobileMenu.tsx
@@ -29,7 +29,7 @@ export default function DocsMobileMenu({ post, navigation, onClickClose = () => 
         <div className='fixed inset-0'>
           <div className='absolute inset-0 bg-gray-600 opacity-75' onClick={onClickClose}></div>
         </div>
-        <div className='relative flex w-full max-w-xs flex-1 flex-col bg-white'>
+        <div className='relative flex w-full max-w-xs flex-1 flex-col bg-white dark:bg-dark-background'>
           <div className='absolute right-0 top-0 -mr-14 p-1'>
             <button
               onClick={onClickClose}
@@ -47,7 +47,7 @@ export default function DocsMobileMenu({ post, navigation, onClickClose = () => 
             </div>
             <div className='mb-4 mt-10 w-full px-2'>
               <SearchButton
-                className='flex w-full items-center space-x-3 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-left text-sm text-gray-700 shadow-sm transition-all duration-500 ease-in-out hover:border-secondary-500 hover:bg-secondary-100 hover:text-secondary-500'
+                className='flex w-full items-center space-x-3 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-left text-sm text-gray-700 shadow-sm transition-all duration-500 ease-in-out hover:border-secondary-500 hover:bg-secondary-100 hover:text-secondary-500 dark:border-dark-text dark:bg-dark-card dark:text-dark-text dark:hover:border-secondary-500 dark:hover:bg-dark-background dark:hover:text-secondary-500'
                 indexName={DOCS_INDEX_NAME}
               >
                 <IconLoupe />


### PR DESCRIPTION
Ref: https://github.com/asyncapi/website/pull/5253#issuecomment-4532416854

**Description**

- Fixed dark theme styling for the mobile docs sidebar.
- Updated the mobile docs menu background and search button to use existing dark theme classes.
- Kept the change scoped to `DocsMobileMenu` without adding global CSS or new colors.

**Steps to Reproduce**

1. Open the website in a mobile viewport.
2. Enable dark mode from the navbar theme toggle.
3. Navigate to any docs page.
4. Tap the docs sidebar/menu button near the top of the docs page.
5. Notice that the mobile docs sidebar and search bar still appear in light theme colors.

**Before**

<img width="317" height="596" alt="Screenshot 2026-05-25 at 13 23 28" src="https://github.com/user-attachments/assets/fb80bfb0-3dd3-4972-907c-7fab709b7210" />

**After**

<img width="379" height="671" alt="Screenshot 2026-05-25 at 13 22 57" src="https://github.com/user-attachments/assets/297d71f3-d492-4a8c-ab77-d047bb1a9c50" />

**Related issue(s)**

Fixes #5253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Enhanced dark mode styling for navigation dropdown arrows with updated hover effects.
* Improved dark mode appearance for mobile menu, including background colors and search button styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->