### PR TITLE
fix: improve docs callout dark theme

### DIFF
--- a/components/layout/DocsLayout.tsx
+++ b/components/layout/DocsLayout.tsx
@@ -160,7 +160,7 @@ export default function DocsLayout({ post, navItems = {}, children }: IDocsLayou
                     // show only when it is related to specification (/docs/reference/specification)
                     // AND is not a pre-release. For example, if the post's title is "3.0.0 (Pre-release)",
                     // which will not have RN, so do not render this section.
-                    <div className='mt-5 w-full rounded-lg bg-secondary-100 px-2 py-3 text-center'>
+                    <div className='mt-5 w-full rounded-lg bg-secondary-100 px-2 py-3 text-center dark:bg-dark-card'>
                       <div>
                         <span className='font-sans text-sm dark:text-dark-heading text-gray-800 antialiased'>
                           {`What is new in v${post.title}? Have a look at the `}
@@ -181,7 +181,7 @@ export default function DocsLayout({ post, navItems = {}, children }: IDocsLayou
                         <span className='font-sans text-sm dark:text-dark-text text-gray-800 antialiased'>
                           Interested in release notes of other versions of the specification?&nbsp;
                         </span>
-                        <span className='font-sans text-sm text-gray-800 antialiased'>
+                        <span className='font-sans text-sm text-gray-800 antialiased dark:text-dark-text'>
                           Check&nbsp;
                           <Link
                             href='https://www.asyncapi.com/blog?tags=Release+Notes'

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -591,8 +591,8 @@ export default function RoadmapPage() {
                   text='Join Our Community'
                   href='https://github.com/asyncapi/community'
                   target='_blank'
-                  className='hover:bg-primary-600'
-                  icon={<IconPlus className='w-5 h-5' />}
+                  className='inline-flex items-center hover:bg-primary-600'
+                  icon={<IconPlus className='size-5 shrink-0' />}
                   iconPosition={ButtonIconPosition.RIGHT}
                 />
               </div>


### PR DESCRIPTION
ref :https://github.com/asyncapi/website/pull/5253#issuecomment-4532677110
ref :https://github.com/asyncapi/website/pull/5253#issuecomment-4532649920
**Description**

- Fixed dark theme styling for the release notes callout in the docs layout.
- Updated the release notes callout background and text to use existing dark theme classes.
- Fixed alignment of the plus icon in the roadmap page “Join Our Community” button.
- Kept the changes scoped to `components/layout/DocsLayout.tsx` and `pages/roadmap.tsx`.

- Before

<img width="983" height="164" alt="Screenshot 2026-05-25 at 14 12 24" src="https://github.com/user-attachments/assets/0a7737ed-9148-4df3-90d0-3fe5227ed812" />
<img width="630" height="259" alt="Screenshot 2026-05-25 at 14 13 29" src="https://github.com/user-attachments/assets/e043e542-2a87-4322-bfb9-cf32a55cf2c0" />


- After 

<img width="974" height="126" alt="Screenshot 2026-05-25 at 14 12 12" src="https://github.com/user-attachments/assets/16bb8125-a697-446c-b3e7-ef93299414de" />
<img width="606" height="312" alt="Screenshot 2026-05-25 at 14 13 15" src="https://github.com/user-attachments/assets/70150de2-aa22-4138-af0f-1a944d2285da" />



**Related issue(s)**

Fixes #5253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark mode appearance for the release notes section with updated background and text color styling.
  * Updated icon sizing and responsive behavior for the "Join Our Community" button.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5479?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->