### PR TITLE
fix: enhance table components for dark theme support

### DIFF
--- a/components/MDX/MDX.tsx
+++ b/components/MDX/MDX.tsx
@@ -325,7 +325,7 @@ const getMDXComponents = (reactId: string) => ({
   table: (props: React.HTMLProps<HTMLTableElement>) => (
     <div className={`${props.className || ''} flex flex-col`}>
       <div className='my-2 overflow-x-auto py-2 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8'>
-        <div className='inline-block w-full overflow-auto border-b border-gray-200 align-middle shadow sm:rounded-lg'>
+        <div className='inline-block w-full overflow-auto border-b border-gray-200 align-middle shadow dark:border-border sm:rounded-lg'>
           <table {...props} className={`${props.className || ''} w-full`} />
         </div>
       </div>
@@ -334,16 +334,16 @@ const getMDXComponents = (reactId: string) => ({
   th: (props: React.HTMLProps<HTMLTableCellElement>) => (
     <th
       {...props}
-      className={`${props.className || ''} border-b border-gray-200 bg-gray-100 px-6 py-3 text-left font-body text-xs font-medium uppercase leading-4 tracking-wider text-gray-900`}
+      className={`${props.className || ''} border-b border-gray-200 bg-gray-100 px-6 py-3 text-left font-body text-xs font-medium uppercase leading-4 tracking-wider text-gray-900 dark:border-border dark:bg-dark-background dark:text-dark-heading`}
     />
   ),
   tr: (props: React.HTMLProps<HTMLTableRowElement>) => (
-    <tr {...props} className={`${props.className || ''} bg-white`} />
+    <tr {...props} className={`${props.className || ''} bg-white dark:bg-dark-card`} />
   ),
   td: (props: React.HTMLProps<HTMLTableCellElement>) => (
     <td
       {...props}
-      className={`${props.className || ''} border-b border-gray-200 px-6 py-4 text-sm leading-5 tracking-tight text-gray-700`}
+      className={`${props.className || ''} border-b border-gray-200 px-6 py-4 text-sm leading-5 tracking-tight text-gray-700 dark:border-border dark:text-dark-text`}
     />
   ),
   pre: (props: React.HTMLProps<HTMLPreElement>) => CodeComponent((props.children as React.ReactElement)?.props),

--- a/components/MDX/MDXTable.tsx
+++ b/components/MDX/MDXTable.tsx
@@ -10,7 +10,7 @@ export function Table({ className = '' }: { className?: string }) {
   return (
     <div className={`${className} flex flex-col`}>
       <div className='my-2 overflow-x-auto py-2 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8'>
-        <div className='inline-block w-full overflow-auto border-b border-gray-200 align-middle shadow sm:rounded-lg'>
+        <div className='inline-block w-full overflow-auto border-b border-gray-200 align-middle shadow dark:border-border sm:rounded-lg'>
           <table className={`${className} w-full`} />
         </div>
       </div>
@@ -25,7 +25,7 @@ export function Table({ className = '' }: { className?: string }) {
  * @returns
  */
 export function TableRow({ className = '' }: { className?: string }) {
-  return <tr className={`${className} bg-white`} />;
+  return <tr className={`${className} bg-white dark:bg-dark-card`} />;
 }
 
 /**
@@ -36,7 +36,9 @@ export function TableRow({ className = '' }: { className?: string }) {
  */
 export function TableCell({ className = '' }: { className?: string }) {
   return (
-    <td className={`${className} border-b border-gray-200 px-6 py-4 text-sm leading-5 tracking-tight text-gray-700`} />
+    <td
+      className={`${className} border-b border-gray-200 px-6 py-4 text-sm leading-5 tracking-tight text-gray-700 dark:border-border dark:text-dark-text`}
+    />
   );
 }
 
@@ -49,7 +51,7 @@ export function TableCell({ className = '' }: { className?: string }) {
 export function TableHeader({ className = '' }: { className?: string }) {
   return (
     <th
-      className={`${className} border-b border-gray-200 bg-gray-100 px-6 py-3 text-left font-body text-xs font-medium uppercase leading-4 tracking-wider text-gray-900`}
+      className={`${className} border-b border-gray-200 bg-gray-100 px-6 py-3 text-left font-body text-xs font-medium uppercase leading-4 tracking-wider text-gray-900 dark:border-border dark:bg-dark-background dark:text-dark-heading`}
     />
   );
 }


### PR DESCRIPTION
**Description**

- Added dark theme support for MDX-rendered tables across docs pages.
- Updated markdown table headers, rows, cells, and borders to use existing dark theme classes.
- Applied the same dark theme styling to the shared custom MDX table components.

**Before**
<img width="1005" height="596" alt="Screenshot 2026-05-25 at 15 08 12" src="https://github.com/user-attachments/assets/fa3770cf-e28c-40bf-b4d6-190575beae07" />

<img width="1006" height="600" alt="Screenshot 2026-05-25 at 15 08 26" src="https://github.com/user-attachments/assets/433d2007-5fb2-459a-a672-bffa362cc257" />

**After**


**Related issue(s)**

Fixes #5253