### PR TITLE
fix: enhance dark theme support for CLI page components

### DIFF
--- a/pages/[lang]/tools/cli.tsx
+++ b/pages/[lang]/tools/cli.tsx
@@ -51,7 +51,7 @@ const features: Feature[] = [
       return (
         <>
           {t('cli.features.open-studio.description_pretext')}{' '}
-          <code className=' rounded bg-gray-200 px-1 py-0.5 font-mono text-sm text-gray-900'>
+          <code className='rounded bg-gray-200 px-1 py-0.5 font-mono text-sm text-gray-900 dark:bg-dark-card dark:text-dark-heading'>
             asyncapi start studio
           </code>{' '}
           {t('cli.features.open-studio.description_posttext')}
@@ -201,7 +201,7 @@ export default function CliPage() {
               </div>
             </div>
           </div>
-          <div className='mt-20 bg-white lg:py-12'>
+          <div className='mt-20 bg-white dark:bg-dark-background lg:py-12'>
             <div className='mx-auto max-w-7xl px-4 sm:px-6 lg:px-8'>
               <div className='mb-16 text-center'>
                 <Heading level={HeadingLevel.h2} typeStyle={HeadingTypeStyle.mdSemibold}>
@@ -217,7 +217,7 @@ export default function CliPage() {
                   {features.map(({ description: Description, ...feature }) => (
                     <div key={feature.name} className='relative mb-10'>
                       <dt>
-                        <div className='absolute flex size-12 items-center justify-center rounded-md border border-gray-900 bg-secondary-100 text-gray-900'>
+                        <div className='absolute flex size-12 items-center justify-center rounded-md border border-gray-900 bg-secondary-100 text-gray-900 dark:border-dark-text dark:bg-dark-card dark:text-dark-heading'>
                           <feature.icon className='size-6' aria-hidden='true' />
                         </div>
                         <Heading level={HeadingLevel.h4} typeStyle={HeadingTypeStyle.smSemibold} className='ml-16'>

--- a/pages/tools/cli.tsx
+++ b/pages/tools/cli.tsx
@@ -30,7 +30,9 @@ const features = [
     description: () => (
       <>
         Got an AsyncAPI file locally? Run{' '}
-        <code className=' rounded bg-gray-200 px-1 py-0.5 font-mono text-sm text-gray-900'>asyncapi start studio</code>{' '}
+        <code className='rounded bg-gray-200 px-1 py-0.5 font-mono text-sm text-gray-900 dark:bg-dark-card dark:text-dark-heading'>
+          asyncapi start studio
+        </code>{' '}
         to open our studio in seconds.
       </>
     ),
@@ -173,7 +175,7 @@ export default function CliPage() {
               </div>
             </div>
           </div>
-          <div className='mt-20 bg-white lg:py-12'>
+          <div className='mt-20 bg-white dark:bg-dark-background lg:py-12'>
             <div className='mx-auto max-w-7xl px-4 sm:px-6 lg:px-8'>
               <div className='mb-16 text-center'>
                 <Heading level={HeadingLevel.h2} typeStyle={HeadingTypeStyle.mdSemibold}>
@@ -189,7 +191,7 @@ export default function CliPage() {
                   {features.map(({ description: Description, ...feature }) => (
                     <div key={feature.name} className='relative mb-10'>
                       <dt>
-                        <div className='absolute flex size-12 items-center justify-center rounded-md border border-gray-900 bg-secondary-100 text-gray-900'>
+                        <div className='absolute flex size-12 items-center justify-center rounded-md border border-gray-900 bg-secondary-100 text-gray-900 dark:border-dark-text dark:bg-dark-card dark:text-dark-heading'>
                           <feature.icon className='size-6' aria-hidden='true' />
                         </div>
                         <Heading level={HeadingLevel.h4} typeStyle={HeadingTypeStyle.smSemibold} className='ml-16'>


### PR DESCRIPTION
Fixes : https://github.com/asyncapi/website/pull/5253#issuecomment-4533246868
**Description**

- Added dark theme support for the CLI tools page.
- Updated the features section, feature icon cards, and inline command snippet to use existing dark theme classes.
- Applied the same styling to both localized and non-localized CLI routes.

- Before 
<img width="1233" height="641" alt="Screenshot 2026-05-25 at 15 17 19" src="https://github.com/user-attachments/assets/4eb11705-f03e-4172-8012-52d630f34d62" />

- After 
<img width="1362" height="698" alt="Screenshot 2026-05-25 at 15 17 09" src="https://github.com/user-attachments/assets/66656cf8-1975-4535-90f1-b009737e0686" />


**Related issue(s)**

Fixes #5253


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark mode appearance across CLI tools documentation with enhanced styling for code elements and feature icons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5482?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->