### PR TITLE
fix: update scroll-to-top button hover background color and improve image styling for dark mode

### DIFF
--- a/components/buttons/ScrollButton.tsx
+++ b/components/buttons/ScrollButton.tsx
@@ -31,11 +31,11 @@ function ScrollButton() {
     <div className='fixed bottom-14 right-4 z-40 h-16 w-12'>
       {backToTopButton && (
         <button
-          className='rounded-full bg-white shadow-md transition-all duration-300 ease-in-out hover:scale-110 hover:bg-[#8851FB]'
+          className='rounded-full bg-white shadow-md transition-all duration-300 ease-in-out hover:scale-110 hover:bg-primary-500 dark:bg-dark-card dark:hover:bg-primary-500'
           onClick={scrollUp}
           aria-label='Scroll to top'
         >
-          <img src={scrollImage} alt='scroll to top' />
+          <img src={scrollImage} alt='scroll to top' className='dark:invert' />
         </button>
       )}
     </div>


### PR DESCRIPTION
## Description

Ref: https://github.com/asyncapi/website/pull/5253#issuecomment-4539882638

- Added dark theme support for the scroll-to-top button.
- Replaced the hardcoded hover background color with an existing theme color for better consistency.
- Updated the scroll arrow icon styling so it remains visible in dark mode.

### Before applying fixes
The scroll-to-top button had visibility and hover styling issues in dark theme.

<img width="376" height="666" alt="Screenshot 2026-05-25 at 21 38 23" src="https://github.com/user-attachments/assets/9fff5f60-c4bf-49b8-9f40-dd246a2f8886" />

### After applying fixes

<img width="378" height="677" alt="Screenshot 2026-05-25 at 21 42 20" src="https://github.com/user-attachments/assets/1341d5fc-31a7-44dd-b625-bcbcb7bd484c" />

## Related issue(s)

- N/A