### PR TITLE
fix: align mobile docs dropdown icon styles

### DIFF
--- a/components/navigation/MobileNavMenu.tsx
+++ b/components/navigation/MobileNavMenu.tsx
@@ -5,12 +5,12 @@ import i18nextConfig from '@/next-i18next.config.cjs';
 
 import { SearchButton } from '../AlgoliaSearch';
 import DarkModeToggle from '../DarkModeToggle';
+import { buckets } from '../data/buckets';
 import IconLanguage from '../icons/Language';
 import NavItemDropdown from '../icons/NavItemDropdown';
 import SearchIcon from '../icons/SearchIcon';
 import AsyncAPILogo from '../logos/AsyncAPILogo';
 import communityItems from './communityItems';
-import learningItems from './learningItems';
 import MenuBlocks from './MenuBlocks';
 import otherItems from './otherItems';
 import toolingItems from './toolingItems';
@@ -120,7 +120,7 @@ export default function MobileNavMenu({
             </h4>
             {open === 'learning' && (
               <div className='animate-in fade-in slide-in-from-top-2 duration-200'>
-                <MenuBlocks items={learningItems} />
+                <MenuBlocks items={buckets} />
               </div>
             )}
           </div>


### PR DESCRIPTION
refs: https://github.com/asyncapi/website/pull/5253#issuecomment-4534746423
**Description**

- Fixed inconsistent icon styling in the mobile Docs dropdown menu.
- Updated the mobile Docs dropdown to use the same `buckets` data as the desktop Docs dropdown.
- Kept the change minimal and scoped to `MobileNavMenu`.

**Steps to Reproduce**

1. Open the website on a mobile viewport.
2. Open the navbar menu.
3. Expand the Docs dropdown.
4. Notice that the Docs dropdown icons use a different purple style compared to the desktop Docs dropdown.

**Screenshots**

Before:
<img width="374" height="665" alt="Screenshot 2026-05-26 at 09 54 52" src="https://github.com/user-attachments/assets/61bbed42-e3dc-492f-a88d-d5d08512998c" />
<img width="377" height="672" alt="Screenshot 2026-05-26 at 10 06 38" src="https://github.com/user-attachments/assets/a04bdb9f-ff7c-4f51-b65d-a879d2325a92" />


After:
<img width="400" height="685" alt="Screenshot 2026-05-26 at 09 55 37" src="https://github.com/user-attachments/assets/8f1485b3-8f80-472d-9d59-a884d907142f" />
<img width="384" height="666" alt="Screenshot 2026-05-26 at 09 56 18" src="https://github.com/user-attachments/assets/429708bf-1b6e-4218-81be-000cdc5be417" />


**Related issue(s)**

Fixes https://github.com/asyncapi/website/pull/5253#issuecomment-4534746423