### PR TITLE
fix: invert question mark avatar in dark mode for CommunityLayout

### DIFF
--- a/components/layout/CommunityLayout.tsx
+++ b/components/layout/CommunityLayout.tsx
@@ -262,7 +262,7 @@ function QuestionCard() {
         data-testid='Question-card-img'
         src='/img/avatars/questionmark.webp'
         alt='Question Mark'
-        className='mx-auto size-20 rounded-full xl:size-28'
+        className='mx-auto size-20 rounded-full xl:size-28 dark:invert'
       />
       <div className='my-4 text-gray-900 dark:text-gray-300'>
         Want to become a member? Follow this


### PR DESCRIPTION
refs: https://github.com/asyncapi/website/pull/5253#issuecomment-4540786056

**Description:**

- Added the `dark:invert` utility class to the Question Mark avatar image (`/img/avatars/questionmark.webp`) inside the `QuestionCard` component.
- Fixed a visual issue where the question mark avatar was poorly visible in dark mode because its default colors blended in with the dark card background.

**Steps to Reproduce**

1. Navigate to a community page that uses the `CommunityLayout` (/community/board`).
2. Toggle the website theme to dark mode.
3. Scroll down to the bottom of the members list to the "Want to become a member?" question card.
4. Notice that the question mark avatar is now properly inverted and readable against the dark background.

**Screenshots**

**Before:**
<img width="381" height="291" alt="Screenshot 2026-05-26 at 11 35 34" src="https://github.com/user-attachments/assets/f7180cd4-e700-4200-b366-d255406789f5" />

**After:**
<img width="372" height="285" alt="Screenshot 2026-05-26 at 11 36 12" src="https://github.com/user-attachments/assets/e63301ad-51dd-4584-b2a7-b06219dedbf4" />

**Related issue(s)**
Fixes: https://github.com/asyncapi/website/pull/5253#issuecomment-4540786056