### PR TITLE
chore: remove hardcoded stats 

### DIFF
--- a/pages/community/tsc.tsx
+++ b/pages/community/tsc.tsx
@@ -109,30 +109,6 @@ export default function TSC() {
         </div>
       </div>
 
-      {/* Stats Section */}
-      <div className='bg-white dark:bg-dark-background py-12'>
-        <div className='mx-auto max-w-7xl px-4 sm:px-6 lg:px-8'>
-          <div className='rounded-3xl py-20 px-8 bg-secondary-200 dark:bg-dark-card'>
-            <div className='grid grid-cols-1 md:grid-cols-2 gap-12 text-center text-gray-900 dark:text-white'>
-              <div className='flex flex-col items-center'>
-                <div className='bg-white/40 dark:bg-white/10 rounded-full p-4 mb-4'>
-                  <IconUsersGroup className='w-12 h-12 text-gray-900 dark:text-white' />
-                </div>
-                <div className='text-5xl font-bold mb-2'>10+</div>
-                <div className='text-xl font-medium opacity-90'>Active members</div>
-              </div>
-              <div className='flex flex-col items-center'>
-                <div className='bg-white/40 dark:bg-white/10 rounded-full p-4 mb-4'>
-                  <IconUsersGroup className='w-12 h-12 text-gray-900 dark:text-white' />
-                </div>
-                <div className='text-5xl font-bold mb-2'>100%</div>
-                <div className='text-xl font-medium opacity-90'>Open Source</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
       {/* Info Cards Section */}
       <div className='bg-white dark:bg-dark-background py-16 sm:py-20'>
         <div className='mx-auto max-w-7xl px-4 sm:px-6 lg:px-8'>

--- a/pages/community/tsc.tsx
+++ b/pages/community/tsc.tsx
@@ -110,7 +110,7 @@ export default function TSC() {
       </div>
 
       {/* Info Cards Section */}
-      <div className='bg-white dark:bg-dark-background py-16 sm:py-20'>
+      <div className='bg-white dark:bg-dark-background pt-8 pb-16 sm:pt-10 sm:pb-20'>
         <div className='mx-auto max-w-7xl px-4 sm:px-6 lg:px-8'>
           <div className='grid grid-cols-1 md:grid-cols-3 gap-8'>
             {/* What is TSC Card */}


### PR DESCRIPTION
After discussing with maintainer - The TSC component is being removed 
<img width="1376" height="702" alt="Screenshot 2026-05-28 at 12 06 50 AM" src="https://github.com/user-attachments/assets/b9cdf1a0-f7aa-4aff-ad12-4da02e864f11" />

Update : Vertical spacing was reduced from 80px → 40px 
<img width="1236" height="505" alt="Screenshot 2026-05-28 at 12 53 11 AM" src="https://github.com/user-attachments/assets/ad1b5266-98a5-467a-aa7e-c2eae9bbd8bb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Streamlined the Community TSC page layout by removing the statistics section, creating a more direct transition from the hero section to the info cards section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->