### PR TITLE
test: add unit tests for scripts/compose.ts

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ const config = {
   coverageReporters: ['text', 'lcov', 'json-summary'],
   coverageDirectory: 'coverage',
   collectCoverageFrom: ['scripts/**/*.ts'],
-  coveragePathIgnorePatterns: ['scripts/compose.ts', 'scripts/tools/categorylist.ts', 'scripts/tools/tags-color.ts'],
+  coveragePathIgnorePatterns: ['scripts/tools/categorylist.ts', 'scripts/tools/tags-color.ts'],
   testMatch: ['**/tests/**/*.test.*', '!**/netlify/**/*.test.*'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json']
 };

--- a/scripts/compose.ts
+++ b/scripts/compose.ts
@@ -21,6 +21,18 @@ type ComposePromptType = {
 };
 
 /**
+ * Converts a blog post title into a URL-safe kebab-case filename (without extension).
+ * Special characters are stripped, spaces become hyphens, and consecutive hyphens are collapsed.
+ */
+export function generateFileName(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-zA-Z0-9 ]/g, '')
+    .replace(/ /g, '-')
+    .replace(/-+/g, '-');
+}
+
+/**
  * Generates a complete Markdown front matter block for a blog post.
  *
  * Constructs a YAML front matter section using the blog post details provided by the user,
@@ -31,7 +43,7 @@ type ComposePromptType = {
  * @param answers - User inputs for the blog post, including title, excerpt, comma-separated tags, type, and canonical URL.
  * @returns The generated Markdown front matter and blog post content template.
  */
-function genFrontMatter(answers: ComposePromptType): string {
+export function genFrontMatter(answers: ComposePromptType): string {
   const tagArray = answers.tags.split(',');
 
   tagArray.forEach((tag: string, index: number) => {
@@ -118,8 +130,8 @@ function genFrontMatter(answers: ComposePromptType): string {
   return frontMatter;
 }
 
-inquirer
-  .prompt([
+export async function run(): Promise<void> {
+  const answers = (await inquirer.prompt([
     {
       name: 'title',
       message: 'Enter post title:',
@@ -146,30 +158,29 @@ inquirer
       message: 'Enter the canonical URL if any:',
       type: 'input'
     }
-  ])
-  .then((answers: ComposePromptType) => {
-    // Remove special characters and replace space with -
-    const fileName = answers.title
-      .toLowerCase()
-      .replace(/[^a-zA-Z0-9 ]/g, '')
-      .replace(/ /g, '-')
-      .replace(/-+/g, '-');
-    const frontMatter = genFrontMatter(answers);
-    const filePath = `pages/blog/${fileName || 'untitled'}.md`;
+  ])) as ComposePromptType;
 
+  const fileName = generateFileName(answers.title);
+  const frontMatter = genFrontMatter(answers);
+  const filePath = `pages/blog/${fileName || 'untitled'}.md`;
+
+  await new Promise<void>((resolve, reject) => {
     fs.writeFile(filePath, frontMatter, { flag: 'wx' }, (err) => {
       if (err) {
-        throw err;
+        reject(err);
       } else {
         logger.info(`Blog post generated successfully at ${filePath}`);
+        resolve();
       }
     });
-  })
-  .catch((error) => {
-    logger.error(error);
-    if (error.isTtyError) {
-      logger.error("Prompt couldn't be rendered in the current environment");
-    } else {
-      logger.error('Something went wrong, sorry!');
-    }
   });
+}
+
+run().catch((error) => {
+  logger.error(error);
+  if (error.isTtyError) {
+    logger.error("Prompt couldn't be rendered in the current environment");
+  } else {
+    logger.error('Something went wrong, sorry!');
+  }
+});

--- a/scripts/compose.ts
+++ b/scripts/compose.ts
@@ -6,6 +6,7 @@ import dedent from 'dedent';
 import fs from 'fs';
 import inquirer from 'inquirer';
 import dayjs from 'dayjs';
+import { fileURLToPath } from 'url';
 
 import { logger } from './helpers/logger';
 
@@ -26,10 +27,12 @@ type ComposePromptType = {
  */
 export function generateFileName(title: string): string {
   return title
+    .trim()
     .toLowerCase()
-    .replace(/[^a-zA-Z0-9 ]/g, '')
+    .replace(/[^a-z0-9 ]/g, '')
     .replace(/ /g, '-')
-    .replace(/-+/g, '-');
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
 /**
@@ -130,6 +133,27 @@ export function genFrontMatter(answers: ComposePromptType): string {
   return frontMatter;
 }
 
+/**
+ * Handles errors thrown by the run() entry point, logging a TTY-specific
+ * message when the prompt cannot be rendered, or a generic fallback otherwise.
+ * Accepts unknown because Promise.catch() callbacks receive unknown at runtime.
+ *
+ * @param error - The value caught from the top-level run() rejection.
+ */
+export function handleError(error: unknown): void {
+  logger.error(error);
+  if (error instanceof Error && (error as Error & { isTtyError?: boolean }).isTtyError) {
+    logger.error("Prompt couldn't be rendered in the current environment");
+  } else {
+    logger.error('Something went wrong, sorry!');
+  }
+}
+
+/**
+ * Entry point for the blog post composition CLI.
+ * Prompts the user for post metadata, generates the front matter and slug,
+ * and writes a new Markdown file to pages/blog/<slug>.md.
+ */
 export async function run(): Promise<void> {
   const answers = (await inquirer.prompt([
     {
@@ -176,11 +200,6 @@ export async function run(): Promise<void> {
   });
 }
 
-run().catch((error) => {
-  logger.error(error);
-  if (error.isTtyError) {
-    logger.error("Prompt couldn't be rendered in the current environment");
-  } else {
-    logger.error('Something went wrong, sorry!');
-  }
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  run().catch(handleError);
+}

--- a/scripts/compose.ts
+++ b/scripts/compose.ts
@@ -23,7 +23,8 @@ type ComposePromptType = {
 
 /**
  * Converts a blog post title into a URL-safe kebab-case filename (without extension).
- * Special characters are stripped, spaces become hyphens, and consecutive hyphens are collapsed.
+ * Special characters are stripped, spaces become hyphens, and empty segments (from
+ * consecutive hyphens or leading/trailing special characters) are removed.
  */
 export function generateFileName(title: string): string {
   return title
@@ -31,8 +32,9 @@ export function generateFileName(title: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9 ]/g, '')
     .replace(/ /g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .split('-')
+    .filter(Boolean)
+    .join('-');
 }
 
 /**

--- a/tests/scripts/compose.test.ts
+++ b/tests/scripts/compose.test.ts
@@ -1,0 +1,138 @@
+jest.mock('fs', () => ({
+  writeFile: jest.fn((_path: any, _data: any, _opts: any, cb: any) => cb(null))
+}));
+jest.mock('inquirer', () => ({
+  prompt: jest.fn().mockResolvedValue({
+    title: 'Default Test Post',
+    excerpt: 'Default excerpt',
+    tags: '',
+    type: 'Engineering',
+    canonical: ''
+  })
+}));
+jest.mock('dayjs', () => () => ({ format: () => '2026-01-15T12:00:00+0000' }));
+jest.mock('../../scripts/helpers/logger', () => ({
+  logger: { info: jest.fn(), error: jest.fn() }
+}));
+
+import fs from 'fs';
+import inquirer from 'inquirer';
+import { genFrontMatter, generateFileName, run } from '../../scripts/compose';
+
+const baseAnswers = {
+  title: 'Hello World',
+  excerpt: 'A test post excerpt',
+  tags: 'asyncapi, testing',
+  type: 'Engineering',
+  canonical: 'https://example.com'
+};
+
+describe('generateFileName', () => {
+  it('converts spaces to hyphens', () => {
+    expect(generateFileName('Hello World Post')).toBe('hello-world-post');
+  });
+
+  it('lowercases the title', () => {
+    expect(generateFileName('AsyncAPI Tutorial')).toBe('asyncapi-tutorial');
+  });
+
+  it('removes special characters', () => {
+    expect(generateFileName('Hello! World? 2026')).toBe('hello-world-2026');
+  });
+
+  it('collapses consecutive hyphens', () => {
+    expect(generateFileName('Hello  World')).toBe('hello-world');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(generateFileName('')).toBe('');
+  });
+});
+
+describe('genFrontMatter', () => {
+  it('generates complete front matter from provided answers', () => {
+    const result = genFrontMatter(baseAnswers);
+
+    expect(result).toContain('title: Hello World');
+    expect(result).toContain('date: 2026-01-15T12:00:00+0000');
+    expect(result).toContain('type: Engineering');
+    expect(result).toContain("'asyncapi','testing'");
+    expect(result).toContain('canonical: https://example.com');
+    expect(result).toContain('excerpt: A test post excerpt');
+    expect(result).toMatch(/^---/);
+    expect(result).toMatch(/---\s*$/);
+  });
+
+  it('defaults title to "Untitled" when empty', () => {
+    const result = genFrontMatter({ ...baseAnswers, title: '' });
+
+    expect(result).toContain('title: Untitled');
+  });
+
+  it('defaults excerpt to a space when empty', () => {
+    const result = genFrontMatter({ ...baseAnswers, excerpt: '' });
+
+    expect(result).toContain('excerpt:  ');
+  });
+
+  it('leaves canonical blank when not provided', () => {
+    const result = genFrontMatter({ ...baseAnswers, canonical: '' });
+
+    expect(result).toContain('canonical: \n');
+  });
+
+  it('produces an empty tags array when tags input is empty', () => {
+    const result = genFrontMatter({ ...baseAnswers, tags: '' });
+
+    expect(result).toContain('tags: []');
+  });
+
+  it('trims whitespace from each tag', () => {
+    const result = genFrontMatter({ ...baseAnswers, tags: ' react , typescript , nextjs ' });
+
+    expect(result).toContain("'react','typescript','nextjs'");
+  });
+});
+
+describe('run', () => {
+  const mockWriteFile = jest.mocked(fs.writeFile as jest.MockedFunction<typeof fs.writeFile>);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWriteFile.mockImplementation((_path: any, _data: any, _opts: any, cb: any) => cb(null));
+  });
+
+  it('writes the blog post to pages/blog/<slug>.md', async () => {
+    jest.mocked(inquirer.prompt).mockResolvedValueOnce({ ...baseAnswers, title: 'My New Blog Post' });
+
+    await run();
+
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      'pages/blog/my-new-blog-post.md',
+      expect.stringContaining('title: My New Blog Post'),
+      expect.anything(),
+      expect.any(Function)
+    );
+  });
+
+  it('uses "untitled" as the filename when title is empty', async () => {
+    jest.mocked(inquirer.prompt).mockResolvedValueOnce({ ...baseAnswers, title: '' });
+
+    await run();
+
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      'pages/blog/untitled.md',
+      expect.anything(),
+      expect.anything(),
+      expect.any(Function)
+    );
+  });
+
+  it('rejects when the file write fails', async () => {
+    const writeError = new Error('EEXIST: file already exists');
+    jest.mocked(inquirer.prompt).mockResolvedValueOnce(baseAnswers);
+    mockWriteFile.mockImplementation((_path: any, _data: any, _opts: any, cb: any) => cb(writeError));
+
+    await expect(run()).rejects.toThrow('EEXIST: file already exists');
+  });
+});

--- a/tests/scripts/compose.test.ts
+++ b/tests/scripts/compose.test.ts
@@ -1,3 +1,9 @@
+import fs from 'fs';
+import inquirer from 'inquirer';
+
+import { genFrontMatter, generateFileName, handleError, run } from '../../scripts/compose';
+import { logger } from '../../scripts/helpers/logger';
+
 jest.mock('fs', () => ({
   writeFile: jest.fn((_path: any, _data: any, _opts: any, cb: any) => cb(null))
 }));
@@ -14,10 +20,6 @@ jest.mock('dayjs', () => () => ({ format: () => '2026-01-15T12:00:00+0000' }));
 jest.mock('../../scripts/helpers/logger', () => ({
   logger: { info: jest.fn(), error: jest.fn() }
 }));
-
-import fs from 'fs';
-import inquirer from 'inquirer';
-import { genFrontMatter, generateFileName, run } from '../../scripts/compose';
 
 const baseAnswers = {
   title: 'Hello World',
@@ -110,7 +112,7 @@ describe('run', () => {
     expect(mockWriteFile).toHaveBeenCalledWith(
       'pages/blog/my-new-blog-post.md',
       expect.stringContaining('title: My New Blog Post'),
-      expect.anything(),
+      expect.objectContaining({ flag: 'wx' }),
       expect.any(Function)
     );
   });
@@ -134,5 +136,39 @@ describe('run', () => {
     mockWriteFile.mockImplementation((_path: any, _data: any, _opts: any, cb: any) => cb(writeError));
 
     await expect(run()).rejects.toThrow('EEXIST: file already exists');
+  });
+});
+
+describe('generateFileName edge cases', () => {
+  it('trims leading and trailing whitespace before slugifying', () => {
+    expect(generateFileName('  Hello World  ')).toBe('hello-world');
+  });
+
+  it('strips leading and trailing hyphens produced by special characters', () => {
+    expect(generateFileName('!Hello World!')).toBe('hello-world');
+  });
+});
+
+describe('handleError', () => {
+  beforeEach(() => {
+    jest.mocked(logger.error).mockClear();
+  });
+
+  it('logs the TTY-specific message when isTtyError is true', () => {
+    const error = Object.assign(new Error('tty failure'), { isTtyError: true });
+
+    handleError(error);
+
+    expect(logger.error).toHaveBeenCalledWith(error);
+    expect(logger.error).toHaveBeenCalledWith("Prompt couldn't be rendered in the current environment");
+  });
+
+  it('logs the generic fallback message when isTtyError is false', () => {
+    const error = new Error('unexpected failure');
+
+    handleError(error);
+
+    expect(logger.error).toHaveBeenCalledWith(error);
+    expect(logger.error).toHaveBeenCalledWith('Something went wrong, sorry!');
   });
 });


### PR DESCRIPTION
## Summary

Closes #5096

This PR adds 14 Jest unit tests covering the `scripts/compose.ts` blog post generation script, which previously had zero automated test coverage and was excluded from coverage collection.

### Changes

**`scripts/compose.ts`** — minimal refactor to make the script testable:
- Extract slug generation into an exported `generateFileName(title)` helper
- Export `genFrontMatter(answers)` (previously unexported)
- Wrap the CLI flow in an exported `run()` async function; the top-level entry point now calls `run()` so CLI behaviour is unchanged
- Convert the `fs.writeFile` callback to a Promise inside `run()` so tests can `await run()`

**`tests/scripts/compose.test.ts`** — new test file with 14 tests across 3 suites:
| Suite | Tests |
|-------|-------|
| `generateFileName` | spaces→hyphens, lowercases, strips special chars, collapses hyphens, empty input |
| `genFrontMatter` | full output, empty title fallback, empty excerpt fallback, empty canonical, empty tags, tag whitespace trimming |
| `run` | correct file path written, untitled fallback, rejects on write error |

**`jest.config.js`** — removes `scripts/compose.ts` from `coveragePathIgnorePatterns` so coverage is now collected for this file.

### Test run

```
Tests: 14 passed, 14 total (compose suite)
Test Suites: 24 passed, 24 total (full suite — no regressions)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for the blog-post creation flow: filename slug rules, front-matter defaults/formatting, file-write behavior, and error-handling (including TTY-specific cases).

* **New Features / Chores**
  * Improved filename slug generation and front-matter handling for new blog posts.
  * Refactored the blog-post creation CLI into clearer, testable units and improved error reporting/handling.
  * Adjusted test coverage ignore patterns in the test configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->