### PR TITLE
fix: add dark mode text to FAQ list and About title.

### DIFF
--- a/components/faq/FAQList.tsx
+++ b/components/faq/FAQList.tsx
@@ -64,11 +64,11 @@ export const faqList: FAQ[] = [
     title: 'Where can I find more information?',
     content: (
       <div>
-        <ul className='font-normal list-disc pl-8 font-semibold text-gray-900 antialiased'>
+        <ul className='font-normal list-disc pl-8 font-semibold text-gray-900 antialiased dark:text-white'>
           <li className='py-1'>
             <Link
               href='/docs'
-              className='border-b border-secondary-400 transition duration-300 ease-in-out hover:border-secondary-500'
+              className='border-b border-secondary-400 transition duration-300 ease-in-out hover:border-secondary-500 dark:text-white'
             >
               Official AsyncAPI Documentation
             </Link>{' '}
@@ -76,7 +76,7 @@ export const faqList: FAQ[] = [
           <li className='py-1'>
             <a
               href='https://www.youtube.com/watch?v=UID1nnuFDtM&list=PLbi1gRlP7piitNgvqhIAvGNZM_kvP0r8R'
-              className='border-b border-secondary-400 transition duration-300 ease-in-out hover:border-secondary-500'
+              className='border-b border-secondary-400 transition duration-300 ease-in-out hover:border-secondary-500 dark:text-white'
             >
               Presentation by Fran Méndez
             </a>{' '}

--- a/components/layout/GenericPostLayout.tsx
+++ b/components/layout/GenericPostLayout.tsx
@@ -37,7 +37,7 @@ export default function GenericPostLayout({ post, children }: IGenericPostLayout
         <main className='mt-8 px-4 sm:px-6' data-testid='GenericPostLayout-main-div'>
           <header className='pr-4 sm:pr-6 md:pr-8'>
             <h1
-              className='font-normal font-sans text-4xl text-gray-800 antialiased'
+              className='font-normal font-sans text-4xl text-gray-800 antialiased dark:invert'
               data-testid='GenericPostLayout-Heading'
             >
               {post.title}


### PR DESCRIPTION
refs: https://github.com/asyncapi/website/pull/5253#issuecomment-4556441703

**Description:**

- Added the `dark:invert` utility class to the main heading inside the `GenericPostLayout` component to ensure generic page titles adapt correctly to dark mode.
- Added the `dark:text-white` utility class to the `FAQList` component.

**Steps to Reproduce (FAQ List):**

1. Scroll down to the bottom of the `/about` page.
2. Ensure the website theme is toggled to dark mode.
3. Expand the "Where can I find more information?" question.
4. Notice that the bulleted text and the embedded links (e.g., "Official AsyncAPI Documentation") are now correctly styled in white and easily readable.

| Before | After |
|--------|--------|
| <img width="400" alt="Before FAQ" src="https://github.com/user-attachments/assets/65aa1208-5361-4089-8067-6821ae93d5c8" /> | <img width="400" alt="After FAQ" src="https://github.com/user-attachments/assets/2ba9b3d4-8b25-4f6e-80a5-cc5489de80f4" /> |
| <img width="400" alt="Before FAQ Dark" src="https://github.com/user-attachments/assets/5834ee87-973d-41ea-8aa9-de2fd6bd51dd" /> | <img width="400" alt="After FAQ Dark" src="https://github.com/user-attachments/assets/d040dcdf-fc36-4aaf-b6ae-213d44df6825" /> |

**Steps to Reproduce ('About' Screen title):**

1. Navigate to `/about` page that uses the `GenericPostLayout`.
2. Toggle the website theme to dark mode.
3. Notice that the main page title ("About") now properly inverts its color to remain readable against the dark background.

**Screenshots**

| Before | After |
|--------|--------|
| <img width="400" alt="Before Light" src="https://github.com/user-attachments/assets/68ea6e69-66c7-4c46-b43b-315c10081477" /> | <img width="400" alt="After Light" src="https://github.com/user-attachments/assets/d5b3c682-f9a2-4cdd-9b57-0543d668ad8d" /> |
| <img width="400" alt="Before Dark" src="https://github.com/user-attachments/assets/a08248d1-7751-4a92-86b6-830e2c8bf903" /> | <img width="400" alt="After Dark" src="https://github.com/user-attachments/assets/5d270ffe-3cd9-437a-8e3a-fbf6d018a7da" /> |

Related issue(s)
Fixes: https://github.com/asyncapi/website/pull/5253#issuecomment-4556441703


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode styling for FAQ answers section with consistent text color treatment across all link elements, list items, and content areas for improved visual contrast and readability
  * Refined dark mode styling for post layout section headings with enhanced visual appearance and presentation to ensure improved readability and consistent look in dark theme mode

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->