### PR TITLE
fix: improve dark mode styles for AsyncAPI v3 comparison components

### DIFF
--- a/components/Asyncapi3Comparison/Asyncapi3ChannelComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ChannelComparison.tsx
@@ -33,25 +33,25 @@ export default function Asyncapi3ChannelComparison({ className = '' }: AsyncAPI3
 
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <div className='ml-1 flex-1 border border-black p-2'>
+      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
         <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 2.x</h3>
         <div>
           <div
-            className={`${hoverState.Paths ? 'bg-yellow-100' : ' '} m-2 border border-yellow-300 p-2`}
+            className={`${hoverState.Paths ? 'bg-yellow-100 dark:bg-yellow-900/40' : ' '} m-2 border border-yellow-300 p-2 dark:border-yellow-700`}
             onMouseEnter={() => handleMouseEnter('Paths')}
             onMouseLeave={() => handleMouseLeave('Paths')}
           >
             Channels
             <div className='flex flex-1 flex-wrap'>
               <div
-                className={`${hoverState.PathItem ? 'bg-yellow-300' : 'bg-white'} m-2 border border-yellow-600 p-2`}
+                className={`${hoverState.PathItem ? 'bg-yellow-300 dark:bg-yellow-800/60' : 'bg-white dark:bg-gray-900'} m-2 border border-yellow-600 p-2 dark:border-yellow-700`}
                 onMouseOver={() => handleMouseEnter('PathItem')}
                 onMouseLeave={() => handleMouseLeave('PathItem')}
               >
                 Channel Item
                 <div className='flex flex-1 flex-wrap'>
                   <div
-                    className={`${hoverState.Operation ? 'bg-orange-100' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
+                    className={`${hoverState.Operation ? 'bg-orange-100 dark:bg-orange-900/40' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
                     onMouseOver={() => handleMouseEnter('Operation')}
                     onMouseLeave={() => handleMouseLeave('Operation')}
                   >
@@ -59,15 +59,19 @@ export default function Asyncapi3ChannelComparison({ className = '' }: AsyncAPI3
                     <div className='flex flex-1 flex-col flex-wrap'>
                       <div className='flex flex-1 flex-wrap'>
                         <div
-                          className={`${hoverState.Message ? 'bg-red-400' : 'bg-white'} m-2 flex-1 border border-red-600 p-2`}
+                          className={`${hoverState.Message ? 'bg-red-400 dark:bg-red-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-red-600 p-2 dark:border-red-700`}
                           onMouseEnter={() => handleMouseEnter('Message')}
                           onMouseLeave={() => handleMouseLeave('Message')}
                         >
                           Messages
-                          <div className='m-2 mr-1 box-border flex-1 border border-black p-2'>
+                          <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
                             Message
-                            <div className='m-2 mr-1 box-border flex-1 border border-black p-2'>Headers</div>
-                            <div className='m-2 mr-1 box-border flex-1 border border-black p-2'>Payload</div>
+                            <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
+                              Headers
+                            </div>
+                            <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
+                              Payload
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -79,52 +83,60 @@ export default function Asyncapi3ChannelComparison({ className = '' }: AsyncAPI3
           </div>
         </div>
       </div>
-      <div className='ml-1 flex-1 border border-black p-2'>
+      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
         <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 3.0</h3>
         <div>
           <div
-            className={`${hoverState.Paths ? 'bg-yellow-100' : ' '} m-2 border border-yellow-300 p-2`}
+            className={`${hoverState.Paths ? 'bg-yellow-100 dark:bg-yellow-900/40' : ' '} m-2 border border-yellow-300 p-2 dark:border-yellow-700`}
             onMouseEnter={() => handleMouseEnter('Paths')}
             onMouseLeave={() => handleMouseLeave('Paths')}
           >
             Channels
             <div
-              className={`${hoverState.PathItem ? 'bg-yellow-300' : 'bg-white'} m-2 border border-yellow-600 p-2`}
+              className={`${hoverState.PathItem ? 'bg-yellow-300 dark:bg-yellow-800/60' : 'bg-white dark:bg-gray-900'} m-2 border border-yellow-600 p-2 dark:border-yellow-700`}
               onMouseOver={() => handleMouseEnter('PathItem')}
               onMouseLeave={() => handleMouseLeave('PathItem')}
             >
               Channel
               <div className='flex flex-1 flex-col flex-wrap'>
                 <div
-                  className={`${hoverState.Message ? 'bg-red-400' : 'bg-white'} m-2 flex-1 border border-red-600 p-2`}
+                  className={`${hoverState.Message ? 'bg-red-400 dark:bg-red-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-red-600 p-2 dark:border-red-700`}
                   onMouseEnter={() => handleMouseEnter('Message')}
                   onMouseLeave={() => handleMouseLeave('Message')}
                 >
                   Messages
-                  <div className='m-2 mr-1 box-border flex-1 border border-black p-2'>
+                  <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
                     Message
-                    <div className='m-2 mr-1 box-border flex-1 border border-black p-2'>Headers</div>
-                    <div className='m-2 mr-1 box-border flex-1 border border-black p-2'>Payload</div>
+                    <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
+                      Headers
+                    </div>
+                    <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
+                      Payload
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className={`${hoverState.Operation ? 'bg-yellow-100' : ' '} m-2 border border-yellow-300 p-2`}
+            className={`${hoverState.Operation ? 'bg-yellow-100 dark:bg-yellow-900/40' : ' '} m-2 border border-yellow-300 p-2 dark:border-yellow-700`}
             onMouseEnter={() => handleMouseEnter('Operation')}
             onMouseLeave={() => handleMouseLeave('Operation')}
           >
             Operations
             <div className='flex flex-1 flex-wrap'>
-              <div className='m-2 flex-1 border border-orange-300 p-2'>
+              <div className='m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700'>
                 Operation
                 <div className='flex flex-1 flex-col flex-wrap'>
-                  <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200'>
+                  <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200 dark:border-blue-400 dark:bg-gray-900 dark:hover:bg-blue-900/50'>
                     action (send or receive)
                   </div>
-                  <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200'>channel</div>
-                  <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200'>messages</div>
+                  <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200 dark:border-blue-400 dark:bg-gray-900 dark:hover:bg-blue-900/50'>
+                    channel
+                  </div>
+                  <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200 dark:border-blue-400 dark:bg-gray-900 dark:hover:bg-blue-900/50'>
+                    messages
+                  </div>
                 </div>
               </div>
             </div>

--- a/components/Asyncapi3Comparison/Asyncapi3ChannelComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ChannelComparison.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Column, HoverBox } from './ComparisonCommon';
 
 export interface HoverState {
   Paths: boolean;
@@ -10,6 +11,18 @@ export interface HoverState {
 export interface AsyncAPI3ChannelComparisonProps {
   className?: string;
 }
+
+const MessageDetails = () => (
+  <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
+    Message
+    <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
+      Headers
+    </div>
+    <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
+      Payload
+    </div>
+  </div>
+);
 
 /**
  * @description Component to compare AsyncAPI 2.x and AsyncAPI 3.0 channels.
@@ -23,126 +36,123 @@ export default function Asyncapi3ChannelComparison({ className = '' }: AsyncAPI3
     Message: false
   });
 
-  const handleMouseEnter = (key: keyof HoverState) => {
-    setHoverState((prevState) => ({ ...prevState, [key]: true }));
-  };
-
-  const handleMouseLeave = (key: keyof HoverState) => {
-    setHoverState((prevState) => ({ ...prevState, [key]: false }));
-  };
-
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 2.x</h3>
-        <div>
-          <div
-            className={`${hoverState.Paths ? 'bg-yellow-100 dark:bg-yellow-900/40' : ' '} m-2 border border-yellow-300 p-2 dark:border-yellow-700`}
-            onMouseEnter={() => handleMouseEnter('Paths')}
-            onMouseLeave={() => handleMouseLeave('Paths')}
-          >
-            Channels
-            <div className='flex flex-1 flex-wrap'>
-              <div
-                className={`${hoverState.PathItem ? 'bg-yellow-300 dark:bg-yellow-800/60' : 'bg-white dark:bg-gray-900'} m-2 border border-yellow-600 p-2 dark:border-yellow-700`}
-                onMouseOver={() => handleMouseEnter('PathItem')}
-                onMouseLeave={() => handleMouseLeave('PathItem')}
-              >
-                Channel Item
-                <div className='flex flex-1 flex-wrap'>
-                  <div
-                    className={`${hoverState.Operation ? 'bg-orange-100 dark:bg-orange-900/40' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
-                    onMouseOver={() => handleMouseEnter('Operation')}
-                    onMouseLeave={() => handleMouseLeave('Operation')}
-                  >
-                    Operation (Publish and Subscribe)
-                    <div className='flex flex-1 flex-col flex-wrap'>
-                      <div className='flex flex-1 flex-wrap'>
-                        <div
-                          className={`${hoverState.Message ? 'bg-red-400 dark:bg-red-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-red-600 p-2 dark:border-red-700`}
-                          onMouseEnter={() => handleMouseEnter('Message')}
-                          onMouseLeave={() => handleMouseLeave('Message')}
-                        >
-                          Messages
-                          <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
-                            Message
-                            <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
-                              Headers
-                            </div>
-                            <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
-                              Payload
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 3.0</h3>
-        <div>
-          <div
-            className={`${hoverState.Paths ? 'bg-yellow-100 dark:bg-yellow-900/40' : ' '} m-2 border border-yellow-300 p-2 dark:border-yellow-700`}
-            onMouseEnter={() => handleMouseEnter('Paths')}
-            onMouseLeave={() => handleMouseLeave('Paths')}
-          >
-            Channels
-            <div
-              className={`${hoverState.PathItem ? 'bg-yellow-300 dark:bg-yellow-800/60' : 'bg-white dark:bg-gray-900'} m-2 border border-yellow-600 p-2 dark:border-yellow-700`}
-              onMouseOver={() => handleMouseEnter('PathItem')}
-              onMouseLeave={() => handleMouseLeave('PathItem')}
+      <Column title="AsyncAPI 2.x">
+        <HoverBox<HoverState>
+          label="Channels"
+          fieldKey="Paths"
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass="bg-yellow-100 dark:bg-yellow-900/40"
+          defaultClass=" "
+          borderClass="border-yellow-300 dark:border-yellow-700"
+        >
+          <div className='flex flex-1 flex-wrap'>
+            <HoverBox<HoverState>
+              label="Channel Item"
+              fieldKey="PathItem"
+              hoverState={hoverState}
+              setHoverState={setHoverState}
+              activeClass="bg-yellow-300 dark:bg-yellow-800/60"
+              borderClass="border-yellow-600 dark:border-yellow-700"
+              useMouseOver
             >
-              Channel
-              <div className='flex flex-1 flex-col flex-wrap'>
-                <div
-                  className={`${hoverState.Message ? 'bg-red-400 dark:bg-red-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-red-600 p-2 dark:border-red-700`}
-                  onMouseEnter={() => handleMouseEnter('Message')}
-                  onMouseLeave={() => handleMouseLeave('Message')}
+              <div className='flex flex-1 flex-wrap'>
+                <HoverBox<HoverState>
+                  label="Operation (Publish and Subscribe)"
+                  fieldKey="Operation"
+                  hoverState={hoverState}
+                  setHoverState={setHoverState}
+                  activeClass="bg-orange-100 dark:bg-orange-900/40"
+                  borderClass="border-orange-300 dark:border-orange-700"
+                  className="flex-1"
+                  useMouseOver
                 >
-                  Messages
-                  <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
-                    Message
-                    <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
-                      Headers
-                    </div>
-                    <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
-                      Payload
+                  <div className='flex flex-1 flex-col flex-wrap'>
+                    <div className='flex flex-1 flex-wrap'>
+                      <HoverBox<HoverState>
+                        label="Messages"
+                        fieldKey="Message"
+                        hoverState={hoverState}
+                        setHoverState={setHoverState}
+                        activeClass="bg-red-400 dark:bg-red-900/60"
+                        borderClass="border-red-600 dark:border-red-700"
+                        className="flex-1"
+                      >
+                        <MessageDetails />
+                      </HoverBox>
                     </div>
                   </div>
-                </div>
+                </HoverBox>
               </div>
-            </div>
+            </HoverBox>
           </div>
-          <div
-            className={`${hoverState.Operation ? 'bg-yellow-100 dark:bg-yellow-900/40' : ' '} m-2 border border-yellow-300 p-2 dark:border-yellow-700`}
-            onMouseEnter={() => handleMouseEnter('Operation')}
-            onMouseLeave={() => handleMouseLeave('Operation')}
+        </HoverBox>
+      </Column>
+
+      <Column title="AsyncAPI 3.0">
+        <HoverBox<HoverState>
+          label="Channels"
+          fieldKey="Paths"
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass="bg-yellow-100 dark:bg-yellow-900/40"
+          defaultClass=" "
+          borderClass="border-yellow-300 dark:border-yellow-700"
+        >
+          <HoverBox<HoverState>
+            label="Channel"
+            fieldKey="PathItem"
+            hoverState={hoverState}
+            setHoverState={setHoverState}
+            activeClass="bg-yellow-300 dark:bg-yellow-800/60"
+            borderClass="border-yellow-600 dark:border-yellow-700"
+            useMouseOver
           >
-            Operations
-            <div className='flex flex-1 flex-wrap'>
-              <div className='m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700'>
-                Operation
-                <div className='flex flex-1 flex-col flex-wrap'>
-                  <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200 dark:border-blue-400 dark:bg-gray-900 dark:hover:bg-blue-900/50'>
-                    action (send or receive)
-                  </div>
-                  <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200 dark:border-blue-400 dark:bg-gray-900 dark:hover:bg-blue-900/50'>
-                    channel
-                  </div>
-                  <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200 dark:border-blue-400 dark:bg-gray-900 dark:hover:bg-blue-900/50'>
-                    messages
-                  </div>
+            <div className='flex flex-1 flex-col flex-wrap'>
+              <HoverBox<HoverState>
+                label="Messages"
+                fieldKey="Message"
+                hoverState={hoverState}
+                setHoverState={setHoverState}
+                activeClass="bg-red-400 dark:bg-red-900/60"
+                borderClass="border-red-600 dark:border-red-700"
+                className="flex-1"
+              >
+                <MessageDetails />
+              </HoverBox>
+            </div>
+          </HoverBox>
+        </HoverBox>
+
+        <HoverBox<HoverState>
+          label="Operations"
+          fieldKey="Operation"
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass="bg-yellow-100 dark:bg-yellow-900/40"
+          defaultClass=" "
+          borderClass="border-yellow-300 dark:border-yellow-700"
+        >
+          <div className='flex flex-1 flex-wrap'>
+            <div className='m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700'>
+              Operation
+              <div className='flex flex-1 flex-col flex-wrap'>
+                <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200 dark:border-blue-400 dark:bg-gray-900 dark:hover:bg-blue-900/50'>
+                  action (send or receive)
+                </div>
+                <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200 dark:border-blue-400 dark:bg-gray-900 dark:hover:bg-blue-900/50'>
+                  channel
+                </div>
+                <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200 dark:border-blue-400 dark:bg-gray-900 dark:hover:bg-blue-900/50'>
+                  messages
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      </div>
+        </HoverBox>
+      </Column>
     </div>
   );
 }

--- a/components/Asyncapi3Comparison/Asyncapi3ChannelComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ChannelComparison.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+
 import { Column, HoverBox } from './ComparisonCommon';
 
 export interface HoverState {
@@ -15,12 +16,8 @@ export interface AsyncAPI3ChannelComparisonProps {
 const MessageDetails = () => (
   <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
     Message
-    <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
-      Headers
-    </div>
-    <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
-      Payload
-    </div>
+    <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>Headers</div>
+    <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>Payload</div>
   </div>
 );
 
@@ -38,47 +35,47 @@ export default function Asyncapi3ChannelComparison({ className = '' }: AsyncAPI3
 
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <Column title="AsyncAPI 2.x">
+      <Column title='AsyncAPI 2.x'>
         <HoverBox<HoverState>
-          label="Channels"
-          fieldKey="Paths"
+          label='Channels'
+          fieldKey='Paths'
           hoverState={hoverState}
           setHoverState={setHoverState}
-          activeClass="bg-yellow-100 dark:bg-yellow-900/40"
-          defaultClass=" "
-          borderClass="border-yellow-300 dark:border-yellow-700"
+          activeClass='bg-yellow-100 dark:bg-yellow-900/40'
+          defaultClass=' '
+          borderClass='border-yellow-300 dark:border-yellow-700'
         >
           <div className='flex flex-1 flex-wrap'>
             <HoverBox<HoverState>
-              label="Channel Item"
-              fieldKey="PathItem"
+              label='Channel Item'
+              fieldKey='PathItem'
               hoverState={hoverState}
               setHoverState={setHoverState}
-              activeClass="bg-yellow-300 dark:bg-yellow-800/60"
-              borderClass="border-yellow-600 dark:border-yellow-700"
+              activeClass='bg-yellow-300 dark:bg-yellow-800/60'
+              borderClass='border-yellow-600 dark:border-yellow-700'
               useMouseOver
             >
               <div className='flex flex-1 flex-wrap'>
                 <HoverBox<HoverState>
-                  label="Operation (Publish and Subscribe)"
-                  fieldKey="Operation"
+                  label='Operation (Publish and Subscribe)'
+                  fieldKey='Operation'
                   hoverState={hoverState}
                   setHoverState={setHoverState}
-                  activeClass="bg-orange-100 dark:bg-orange-900/40"
-                  borderClass="border-orange-300 dark:border-orange-700"
-                  className="flex-1"
+                  activeClass='bg-orange-100 dark:bg-orange-900/40'
+                  borderClass='border-orange-300 dark:border-orange-700'
+                  className='flex-1'
                   useMouseOver
                 >
                   <div className='flex flex-1 flex-col flex-wrap'>
                     <div className='flex flex-1 flex-wrap'>
                       <HoverBox<HoverState>
-                        label="Messages"
-                        fieldKey="Message"
+                        label='Messages'
+                        fieldKey='Message'
                         hoverState={hoverState}
                         setHoverState={setHoverState}
-                        activeClass="bg-red-400 dark:bg-red-900/60"
-                        borderClass="border-red-600 dark:border-red-700"
-                        className="flex-1"
+                        activeClass='bg-red-400 dark:bg-red-900/60'
+                        borderClass='border-red-600 dark:border-red-700'
+                        className='flex-1'
                       >
                         <MessageDetails />
                       </HoverBox>
@@ -91,34 +88,34 @@ export default function Asyncapi3ChannelComparison({ className = '' }: AsyncAPI3
         </HoverBox>
       </Column>
 
-      <Column title="AsyncAPI 3.0">
+      <Column title='AsyncAPI 3.0'>
         <HoverBox<HoverState>
-          label="Channels"
-          fieldKey="Paths"
+          label='Channels'
+          fieldKey='Paths'
           hoverState={hoverState}
           setHoverState={setHoverState}
-          activeClass="bg-yellow-100 dark:bg-yellow-900/40"
-          defaultClass=" "
-          borderClass="border-yellow-300 dark:border-yellow-700"
+          activeClass='bg-yellow-100 dark:bg-yellow-900/40'
+          defaultClass=' '
+          borderClass='border-yellow-300 dark:border-yellow-700'
         >
           <HoverBox<HoverState>
-            label="Channel"
-            fieldKey="PathItem"
+            label='Channel'
+            fieldKey='PathItem'
             hoverState={hoverState}
             setHoverState={setHoverState}
-            activeClass="bg-yellow-300 dark:bg-yellow-800/60"
-            borderClass="border-yellow-600 dark:border-yellow-700"
+            activeClass='bg-yellow-300 dark:bg-yellow-800/60'
+            borderClass='border-yellow-600 dark:border-yellow-700'
             useMouseOver
           >
             <div className='flex flex-1 flex-col flex-wrap'>
               <HoverBox<HoverState>
-                label="Messages"
-                fieldKey="Message"
+                label='Messages'
+                fieldKey='Message'
                 hoverState={hoverState}
                 setHoverState={setHoverState}
-                activeClass="bg-red-400 dark:bg-red-900/60"
-                borderClass="border-red-600 dark:border-red-700"
-                className="flex-1"
+                activeClass='bg-red-400 dark:bg-red-900/60'
+                borderClass='border-red-600 dark:border-red-700'
+                className='flex-1'
               >
                 <MessageDetails />
               </HoverBox>
@@ -127,13 +124,13 @@ export default function Asyncapi3ChannelComparison({ className = '' }: AsyncAPI3
         </HoverBox>
 
         <HoverBox<HoverState>
-          label="Operations"
-          fieldKey="Operation"
+          label='Operations'
+          fieldKey='Operation'
           hoverState={hoverState}
           setHoverState={setHoverState}
-          activeClass="bg-yellow-100 dark:bg-yellow-900/40"
-          defaultClass=" "
-          borderClass="border-yellow-300 dark:border-yellow-700"
+          activeClass='bg-yellow-100 dark:bg-yellow-900/40'
+          defaultClass=' '
+          borderClass='border-yellow-300 dark:border-yellow-700'
         >
           <div className='flex flex-1 flex-wrap'>
             <div className='m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700'>

--- a/components/Asyncapi3Comparison/Asyncapi3IdAndAddressComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3IdAndAddressComparison.tsx
@@ -29,17 +29,17 @@ export default function Asyncapi3IdAndAddressComparison({ className = '' }: Asyn
 
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <div className='ml-1 flex-1 border border-black p-2'>
+      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
         <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 2.x</h3>
         <div>
           <div
-            className={`${hoverState.Paths ? 'bg-yellow-100' : ' '} m-2 border border-yellow-300 p-2`}
+            className={`${hoverState.Paths ? 'bg-yellow-100 dark:bg-yellow-900/40' : ' '} m-2 border border-yellow-300 p-2 dark:border-yellow-700`}
             onMouseEnter={() => handleMouseEnter('Paths')}
             onMouseLeave={() => handleMouseLeave('Paths')}
           >
             Channels
             <div
-              className={`${hoverState.PathItem ? 'bg-yellow-300' : 'bg-white'} m-2 border border-yellow-600 p-2`}
+              className={`${hoverState.PathItem ? 'bg-yellow-300 dark:bg-yellow-800/60' : 'bg-white dark:bg-gray-900'} m-2 border border-yellow-600 p-2 dark:border-yellow-700`}
               onMouseOver={() => handleMouseEnter('PathItem')}
               onMouseLeave={() => handleMouseLeave('PathItem')}
             >
@@ -48,23 +48,25 @@ export default function Asyncapi3IdAndAddressComparison({ className = '' }: Asyn
           </div>
         </div>
       </div>
-      <div className='ml-1 flex-1 border border-black p-2'>
+      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
         <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 3.0</h3>
         <div>
           <div
-            className={`${hoverState.Paths ? 'bg-yellow-100' : ' '} m-2 border border-yellow-300 p-2`}
+            className={`${hoverState.Paths ? 'bg-yellow-100 dark:bg-yellow-900/40' : ' '} m-2 border border-yellow-300 p-2 dark:border-yellow-700`}
             onMouseEnter={() => handleMouseEnter('Paths')}
             onMouseLeave={() => handleMouseLeave('Paths')}
           >
             Channels
             <div
-              className={`${hoverState.PathItem ? 'bg-yellow-300' : 'bg-white'} m-2 border border-yellow-600 p-2`}
+              className={`${hoverState.PathItem ? 'bg-yellow-300 dark:bg-yellow-800/60' : 'bg-white dark:bg-gray-900'} m-2 border border-yellow-600 p-2 dark:border-yellow-700`}
               onMouseOver={() => handleMouseEnter('PathItem')}
               onMouseLeave={() => handleMouseLeave('PathItem')}
             >
               Channel
               <div className='flex flex-1 flex-col flex-wrap'>
-                <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200'>address</div>
+                <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200 dark:border-blue-400 dark:bg-gray-900 dark:hover:bg-blue-900/50'>
+                  address
+                </div>
               </div>
             </div>
           </div>

--- a/components/Asyncapi3Comparison/Asyncapi3IdAndAddressComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3IdAndAddressComparison.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+
 import { Column, HoverBox } from './ComparisonCommon';
 
 export interface HoverState {
@@ -22,45 +23,45 @@ export default function Asyncapi3IdAndAddressComparison({ className = '' }: Asyn
 
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <Column title="AsyncAPI 2.x">
+      <Column title='AsyncAPI 2.x'>
         <HoverBox<HoverState>
-          label="Channels"
-          fieldKey="Paths"
+          label='Channels'
+          fieldKey='Paths'
           hoverState={hoverState}
           setHoverState={setHoverState}
-          activeClass="bg-yellow-100 dark:bg-yellow-900/40"
-          defaultClass=" "
-          borderClass="border-yellow-300 dark:border-yellow-700"
+          activeClass='bg-yellow-100 dark:bg-yellow-900/40'
+          defaultClass=' '
+          borderClass='border-yellow-300 dark:border-yellow-700'
         >
           <HoverBox<HoverState>
-            label="Channel Item"
-            fieldKey="PathItem"
+            label='Channel Item'
+            fieldKey='PathItem'
             hoverState={hoverState}
             setHoverState={setHoverState}
-            activeClass="bg-yellow-300 dark:bg-yellow-800/60"
-            borderClass="border-yellow-600 dark:border-yellow-700"
+            activeClass='bg-yellow-300 dark:bg-yellow-800/60'
+            borderClass='border-yellow-600 dark:border-yellow-700'
             useMouseOver
           />
         </HoverBox>
       </Column>
 
-      <Column title="AsyncAPI 3.0">
+      <Column title='AsyncAPI 3.0'>
         <HoverBox<HoverState>
-          label="Channels"
-          fieldKey="Paths"
+          label='Channels'
+          fieldKey='Paths'
           hoverState={hoverState}
           setHoverState={setHoverState}
-          activeClass="bg-yellow-100 dark:bg-yellow-900/40"
-          defaultClass=" "
-          borderClass="border-yellow-300 dark:border-yellow-700"
+          activeClass='bg-yellow-100 dark:bg-yellow-900/40'
+          defaultClass=' '
+          borderClass='border-yellow-300 dark:border-yellow-700'
         >
           <HoverBox<HoverState>
-            label="Channel"
-            fieldKey="PathItem"
+            label='Channel'
+            fieldKey='PathItem'
             hoverState={hoverState}
             setHoverState={setHoverState}
-            activeClass="bg-yellow-300 dark:bg-yellow-800/60"
-            borderClass="border-yellow-600 dark:border-yellow-700"
+            activeClass='bg-yellow-300 dark:bg-yellow-800/60'
+            borderClass='border-yellow-600 dark:border-yellow-700'
             useMouseOver
           >
             <div className='flex flex-1 flex-col flex-wrap'>

--- a/components/Asyncapi3Comparison/Asyncapi3IdAndAddressComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3IdAndAddressComparison.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Column, HoverBox } from './ComparisonCommon';
 
 export interface HoverState {
   Paths: boolean;
@@ -19,59 +20,57 @@ export default function Asyncapi3IdAndAddressComparison({ className = '' }: Asyn
     PathItem: false
   });
 
-  const handleMouseEnter = (key: keyof HoverState) => {
-    setHoverState((prevState) => ({ ...prevState, [key]: true }));
-  };
-
-  const handleMouseLeave = (key: keyof HoverState) => {
-    setHoverState((prevState) => ({ ...prevState, [key]: false }));
-  };
-
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 2.x</h3>
-        <div>
-          <div
-            className={`${hoverState.Paths ? 'bg-yellow-100 dark:bg-yellow-900/40' : ' '} m-2 border border-yellow-300 p-2 dark:border-yellow-700`}
-            onMouseEnter={() => handleMouseEnter('Paths')}
-            onMouseLeave={() => handleMouseLeave('Paths')}
+      <Column title="AsyncAPI 2.x">
+        <HoverBox<HoverState>
+          label="Channels"
+          fieldKey="Paths"
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass="bg-yellow-100 dark:bg-yellow-900/40"
+          defaultClass=" "
+          borderClass="border-yellow-300 dark:border-yellow-700"
+        >
+          <HoverBox<HoverState>
+            label="Channel Item"
+            fieldKey="PathItem"
+            hoverState={hoverState}
+            setHoverState={setHoverState}
+            activeClass="bg-yellow-300 dark:bg-yellow-800/60"
+            borderClass="border-yellow-600 dark:border-yellow-700"
+            useMouseOver
+          />
+        </HoverBox>
+      </Column>
+
+      <Column title="AsyncAPI 3.0">
+        <HoverBox<HoverState>
+          label="Channels"
+          fieldKey="Paths"
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass="bg-yellow-100 dark:bg-yellow-900/40"
+          defaultClass=" "
+          borderClass="border-yellow-300 dark:border-yellow-700"
+        >
+          <HoverBox<HoverState>
+            label="Channel"
+            fieldKey="PathItem"
+            hoverState={hoverState}
+            setHoverState={setHoverState}
+            activeClass="bg-yellow-300 dark:bg-yellow-800/60"
+            borderClass="border-yellow-600 dark:border-yellow-700"
+            useMouseOver
           >
-            Channels
-            <div
-              className={`${hoverState.PathItem ? 'bg-yellow-300 dark:bg-yellow-800/60' : 'bg-white dark:bg-gray-900'} m-2 border border-yellow-600 p-2 dark:border-yellow-700`}
-              onMouseOver={() => handleMouseEnter('PathItem')}
-              onMouseLeave={() => handleMouseLeave('PathItem')}
-            >
-              Channel Item
-            </div>
-          </div>
-        </div>
-      </div>
-      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 3.0</h3>
-        <div>
-          <div
-            className={`${hoverState.Paths ? 'bg-yellow-100 dark:bg-yellow-900/40' : ' '} m-2 border border-yellow-300 p-2 dark:border-yellow-700`}
-            onMouseEnter={() => handleMouseEnter('Paths')}
-            onMouseLeave={() => handleMouseLeave('Paths')}
-          >
-            Channels
-            <div
-              className={`${hoverState.PathItem ? 'bg-yellow-300 dark:bg-yellow-800/60' : 'bg-white dark:bg-gray-900'} m-2 border border-yellow-600 p-2 dark:border-yellow-700`}
-              onMouseOver={() => handleMouseEnter('PathItem')}
-              onMouseLeave={() => handleMouseLeave('PathItem')}
-            >
-              Channel
-              <div className='flex flex-1 flex-col flex-wrap'>
-                <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200 dark:border-blue-400 dark:bg-gray-900 dark:hover:bg-blue-900/50'>
-                  address
-                </div>
+            <div className='flex flex-1 flex-col flex-wrap'>
+              <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200 dark:border-blue-400 dark:bg-gray-900 dark:hover:bg-blue-900/50'>
+                address
               </div>
             </div>
-          </div>
-        </div>
-      </div>
+          </HoverBox>
+        </HoverBox>
+      </Column>
     </div>
   );
 }

--- a/components/Asyncapi3Comparison/Asyncapi3MetaComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3MetaComparison.tsx
@@ -73,8 +73,9 @@ export default function Asyncapi3MetaComparison({ className = '' }: Asyncapi3Met
               >
                 <p>Tags</p>
               </div>
-              <div
-                className={`${hoverState.External ? 'bg-green-500 dark:bg-green-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600`}
+              <button
+                type='button'
+                className={`${hoverState.External ? 'bg-green-500 dark:bg-green-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600 focus:outline-none`}
                 onMouseOver={() =>
                   setHoverState((prevState) => ({
                     ...prevState,
@@ -101,7 +102,7 @@ export default function Asyncapi3MetaComparison({ className = '' }: Asyncapi3Met
                 }
               >
                 <p>External Docs</p>
-              </div>
+              </button>
             </div>
           </div>
         </div>

--- a/components/Asyncapi3Comparison/Asyncapi3MetaComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3MetaComparison.tsx
@@ -75,7 +75,6 @@ export default function Asyncapi3MetaComparison({ className = '' }: Asyncapi3Met
               </div>
               <div
                 className={`${hoverState.External ? 'bg-green-500 dark:bg-green-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600`}
-                tabIndex={0}
                 onMouseOver={() =>
                   setHoverState((prevState) => ({
                     ...prevState,

--- a/components/Asyncapi3Comparison/Asyncapi3MetaComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3MetaComparison.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 
+import { Column, HoverBox } from './ComparisonCommon';
+
 export interface Asyncapi3MetaComparisonProps {
   className?: string;
 }
@@ -23,90 +25,72 @@ export default function Asyncapi3MetaComparison({ className = '' }: Asyncapi3Met
 
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 2.x</h3>
-        <div>
-          <div
-            className={`${hoverState.Info ? 'bg-blue-100 dark:bg-blue-900/40 ' : ' '}m-2 border border-blue-300 p-2 dark:border-blue-700`}
-            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Info: true }))}
-            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Info: false }))}
-          >
-            Info
-          </div>
+      <Column title='AsyncAPI 2.x'>
+        <HoverBox<HoverState>
+          label='Info'
+          fieldKey='Info'
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass='bg-blue-100 dark:bg-blue-900/40'
+          borderClass='border-blue-300 dark:border-blue-700'
+        />
+        <div className='flex flex-1 flex-wrap'>
+          <HoverBox<HoverState>
+            label='Tags'
+            fieldKey='Tags'
+            hoverState={hoverState}
+            setHoverState={setHoverState}
+            activeClass='bg-pink-300 dark:bg-pink-900/60'
+            borderClass='border-black dark:border-gray-600'
+            className='flex-1'
+            focusable
+          />
+          <HoverBox<HoverState>
+            label='External Docs'
+            fieldKey='External'
+            hoverState={hoverState}
+            setHoverState={setHoverState}
+            activeClass='bg-green-500 dark:bg-green-900/60'
+            borderClass='border-black dark:border-gray-600'
+            className='flex-1'
+            focusable
+          />
+        </div>
+      </Column>
+
+      <Column title='AsyncAPI 3.0'>
+        <HoverBox<HoverState>
+          label='Info'
+          fieldKey='Info'
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass='bg-blue-100 dark:bg-blue-900/40'
+          borderClass='border-blue-300 dark:border-blue-700'
+        >
           <div className='flex flex-1 flex-wrap'>
-            <div
-              className={`${hoverState.Tags ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600`}
-              onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Tags: true }))}
-              onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Tags: false }))}
-            >
-              <p>Tags</p>
-            </div>
-            <div
-              className={`${hoverState.External ? 'bg-green-500 dark:bg-green-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600`}
-              onMouseOver={() => setHoverState((prevState) => ({ ...prevState, External: true }))}
-              onMouseLeave={() =>
-                setHoverState((prevState) => ({
-                  ...prevState,
-                  External: false
-                }))
-              }
-            >
-              <p>External Docs</p>
-            </div>
+            <HoverBox<HoverState>
+              label='Tags'
+              fieldKey='Tags'
+              hoverState={hoverState}
+              setHoverState={setHoverState}
+              activeClass='bg-pink-300 dark:bg-pink-900/60'
+              borderClass='border-black dark:border-gray-600'
+              className='flex-1'
+              focusable
+            />
+            <HoverBox<HoverState>
+              label='External Docs'
+              fieldKey='External'
+              hoverState={hoverState}
+              setHoverState={setHoverState}
+              activeClass='bg-green-500 dark:bg-green-900/60'
+              borderClass='border-black dark:border-gray-600'
+              className='flex-1'
+              focusable
+            />
           </div>
-        </div>
-      </div>
-      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 3.0</h3>
-        <div>
-          <div
-            className={`${hoverState.Info ? 'bg-blue-100 dark:bg-blue-900/40 ' : ' '}m-2 border border-blue-300 p-2 dark:border-blue-700`}
-            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Info: true }))}
-            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Info: false }))}
-          >
-            Info
-            <div className='flex flex-1 flex-wrap'>
-              <div
-                className={`${hoverState.Tags ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600`}
-                onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Tags: true }))}
-                onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Tags: false }))}
-              >
-                <p>Tags</p>
-              </div>
-              <button
-                type='button'
-                className={`${hoverState.External ? 'bg-green-500 dark:bg-green-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600 focus:outline-none`}
-                onMouseOver={() =>
-                  setHoverState((prevState) => ({
-                    ...prevState,
-                    External: true
-                  }))
-                }
-                onMouseLeave={() =>
-                  setHoverState((prevState) => ({
-                    ...prevState,
-                    External: false
-                  }))
-                }
-                onFocus={() =>
-                  setHoverState((prevState) => ({
-                    ...prevState,
-                    External: true
-                  }))
-                }
-                onBlur={() =>
-                  setHoverState((prevState) => ({
-                    ...prevState,
-                    External: false
-                  }))
-                }
-              >
-                <p>External Docs</p>
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
+        </HoverBox>
+      </Column>
     </div>
   );
 }

--- a/components/Asyncapi3Comparison/Asyncapi3MetaComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3MetaComparison.tsx
@@ -23,11 +23,11 @@ export default function Asyncapi3MetaComparison({ className = '' }: Asyncapi3Met
 
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <div className='ml-1 flex-1 border border-black p-2'>
+      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
         <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 2.x</h3>
         <div>
           <div
-            className={`${hoverState.Info ? 'bg-blue-100 ' : ' '}m-2 border border-blue-300 p-2`}
+            className={`${hoverState.Info ? 'bg-blue-100 dark:bg-blue-900/40 ' : ' '}m-2 border border-blue-300 p-2 dark:border-blue-700`}
             onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Info: true }))}
             onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Info: false }))}
           >
@@ -35,43 +35,58 @@ export default function Asyncapi3MetaComparison({ className = '' }: Asyncapi3Met
           </div>
           <div className='flex flex-1 flex-wrap'>
             <div
-              className={`${hoverState.Tags ? 'bg-pink-300' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2`}
+              className={`${hoverState.Tags ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600`}
               onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Tags: true }))}
               onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Tags: false }))}
             >
               <p>Tags</p>
             </div>
             <div
-              className={`${hoverState.External ? 'bg-green-500' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2`}
+              className={`${hoverState.External ? 'bg-green-500 dark:bg-green-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600`}
               onMouseOver={() => setHoverState((prevState) => ({ ...prevState, External: true }))}
-              onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, External: false }))}
+              onMouseLeave={() =>
+                setHoverState((prevState) => ({
+                  ...prevState,
+                  External: false
+                }))
+              }
             >
               <p>External Docs</p>
             </div>
           </div>
         </div>
       </div>
-      <div className='ml-1 flex-1 border border-black p-2'>
+      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
         <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 3.0</h3>
         <div>
           <div
-            className={`${hoverState.Info ? 'bg-blue-100 ' : ' '}m-2 border border-blue-300 p-2`}
+            className={`${hoverState.Info ? 'bg-blue-100 dark:bg-blue-900/40 ' : ' '}m-2 border border-blue-300 p-2 dark:border-blue-700`}
             onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Info: true }))}
             onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Info: false }))}
           >
             Info
             <div className='flex flex-1 flex-wrap'>
               <div
-                className={`${hoverState.Tags ? 'bg-pink-300' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2`}
+                className={`${hoverState.Tags ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600`}
                 onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Tags: true }))}
                 onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Tags: false }))}
               >
                 <p>Tags</p>
               </div>
               <div
-                className={`${hoverState.External ? 'bg-green-500' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2`}
-                onMouseOver={() => setHoverState((prevState) => ({ ...prevState, External: true }))}
-                onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, External: false }))}
+                className={`${hoverState.External ? 'bg-green-500 dark:bg-green-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600`}
+                onMouseOver={() =>
+                  setHoverState((prevState) => ({
+                    ...prevState,
+                    External: true
+                  }))
+                }
+                onMouseLeave={() =>
+                  setHoverState((prevState) => ({
+                    ...prevState,
+                    External: false
+                  }))
+                }
               >
                 <p>External Docs</p>
               </div>

--- a/components/Asyncapi3Comparison/Asyncapi3MetaComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3MetaComparison.tsx
@@ -75,6 +75,7 @@ export default function Asyncapi3MetaComparison({ className = '' }: Asyncapi3Met
               </div>
               <div
                 className={`${hoverState.External ? 'bg-green-500 dark:bg-green-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600`}
+                tabIndex={0}
                 onMouseOver={() =>
                   setHoverState((prevState) => ({
                     ...prevState,
@@ -82,6 +83,18 @@ export default function Asyncapi3MetaComparison({ className = '' }: Asyncapi3Met
                   }))
                 }
                 onMouseLeave={() =>
+                  setHoverState((prevState) => ({
+                    ...prevState,
+                    External: false
+                  }))
+                }
+                onFocus={() =>
+                  setHoverState((prevState) => ({
+                    ...prevState,
+                    External: true
+                  }))
+                }
+                onBlur={() =>
                   setHoverState((prevState) => ({
                     ...prevState,
                     External: false

--- a/components/Asyncapi3Comparison/Asyncapi3OperationComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3OperationComparison.tsx
@@ -11,32 +11,36 @@ export interface Asyncapi3OperationComparisonProps {
 export default function Asyncapi3OperationComparison({ className = '' }: Asyncapi3OperationComparisonProps) {
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <div className='ml-1 flex-1 border border-black p-2'>
+      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
         <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 2.x</h3>
         <div>
-          <div className='m-2 border border-yellow-300 p-2'>
+          <div className='m-2 border border-yellow-300 p-2 dark:border-yellow-700'>
             Channels
             <div className='flex flex-1 flex-wrap'>
-              <div className='m-2 border border-yellow-600 p-2'>
+              <div className='m-2 border border-yellow-600 p-2 dark:border-yellow-700'>
                 Channel Item
                 <div className='flex flex-1 flex-wrap'>
-                  <div className='m-2 flex-1 border border-orange-300 p-2'>Operation (Publish and Subscribe)</div>
+                  <div className='m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700'>
+                    Operation (Publish and Subscribe)
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-      <div className='ml-1 flex-1 border border-black p-2'>
+      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
         <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 3.0</h3>
         <div>
-          <div className='m-2 border border-yellow-300 p-2'>
+          <div className='m-2 border border-yellow-300 p-2 dark:border-yellow-700'>
             Operations
             <div className='flex flex-1 flex-wrap'>
-              <div className='m-2 flex-1 border border-orange-300 p-2'>
+              <div className='m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700'>
                 Operation
                 <div className='flex flex-1 flex-col flex-wrap'>
-                  <div className='m-2 border border-blue-500 bg-white p-2'>action (send or receive)</div>
+                  <div className='m-2 border border-blue-500 bg-white p-2 dark:border-blue-400 dark:bg-gray-900'>
+                    action (send or receive)
+                  </div>
                 </div>
               </div>
             </div>

--- a/components/Asyncapi3Comparison/Asyncapi3ParameterComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ParameterComparison.tsx
@@ -38,6 +38,7 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
         borderClass='border-orange-300 dark:border-orange-700'
         className='flex-1'
         useMouseOver
+        focusable
       />
       <HoverBox<HoverState>
         label='description'
@@ -48,6 +49,7 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
         borderClass='border-orange-300 dark:border-orange-700'
         className='flex-1'
         useMouseOver
+        focusable
       />
     </>
   );
@@ -78,6 +80,7 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
                           borderClass='border-orange-300 dark:border-orange-700'
                           className='flex-1'
                           useMouseOver
+                          focusable
                         />
                         <HoverBox<HoverState>
                           label='examples'
@@ -88,6 +91,7 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
                           borderClass='border-orange-300 dark:border-orange-700'
                           className='flex-1'
                           useMouseOver
+                          focusable
                         />
                         <HoverBox<HoverState>
                           label='default'
@@ -98,6 +102,7 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
                           borderClass='border-orange-300 dark:border-orange-700'
                           className='flex-1'
                           useMouseOver
+                          focusable
                         />
                         <HoverBox<HoverState>
                           label='description'
@@ -108,6 +113,7 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
                           borderClass='border-orange-300 dark:border-orange-700'
                           className='flex-1'
                           useMouseOver
+                          focusable
                         />
                         <div className='m-2 flex-1 bg-white p-2 dark:bg-gray-950'>pattern</div>
                         <div className='m-2 flex-1 bg-white p-2 dark:bg-gray-950'>multipleOf</div>
@@ -142,6 +148,7 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
                       borderClass='border-orange-300 dark:border-orange-700'
                       className='flex-1'
                       useMouseOver
+                      focusable
                     />
                     <HoverBox<HoverState>
                       label='examples'
@@ -152,6 +159,7 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
                       borderClass='border-orange-300 dark:border-orange-700'
                       className='flex-1'
                       useMouseOver
+                      focusable
                     />
                     <HoverBox<HoverState>
                       label='default'
@@ -162,6 +170,7 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
                       borderClass='border-orange-300 dark:border-orange-700'
                       className='flex-1'
                       useMouseOver
+                      focusable
                     />
                   </div>
                 </div>

--- a/components/Asyncapi3Comparison/Asyncapi3ParameterComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ParameterComparison.tsx
@@ -1,7 +1,16 @@
 import React, { useState } from 'react';
+import { Column, HoverBox } from './ComparisonCommon';
 
 export interface Asyncapi3ParameterComparisonProps {
   className?: string;
+}
+
+export interface HoverState {
+  location: boolean;
+  description: boolean;
+  enum: boolean;
+  examples: boolean;
+  default: boolean;
 }
 
 /**
@@ -9,7 +18,7 @@ export interface Asyncapi3ParameterComparisonProps {
  * @param {string} [props.className=''] - Additional CSS classes for styling.
  */
 export default function Asyncapi3ParameterComparison({ className = '' }: Asyncapi3ParameterComparisonProps) {
-  const [hoverState, setHoverState] = useState({
+  const [hoverState, setHoverState] = useState<HoverState>({
     location: false,
     description: false,
     enum: false,
@@ -17,130 +26,91 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
     default: false
   });
 
+  const renderFields = () => (
+    <>
+      <HoverBox<HoverState>
+        label="location"
+        fieldKey="location"
+        hoverState={hoverState}
+        setHoverState={setHoverState}
+        activeClass="bg-orange-300 dark:bg-orange-900/60"
+        borderClass="border-orange-300 dark:border-orange-700"
+        className="flex-1"
+        useMouseOver
+      />
+      <HoverBox<HoverState>
+        label="description"
+        fieldKey="description"
+        hoverState={hoverState}
+        setHoverState={setHoverState}
+        activeClass="bg-orange-300 dark:bg-orange-900/60"
+        borderClass="border-orange-300 dark:border-orange-700"
+        className="flex-1"
+        useMouseOver
+      />
+    </>
+  );
+
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 2.x</h3>
-        <div>
-          <div className={'m-2 border border-yellow-300 p-2 dark:border-yellow-700'}>
-            components | channels
-            <div className='flex flex-1 flex-wrap'>
-              <div className={'m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'}>
-                parameters
-                <div className='flex flex-1 flex-wrap'>
-                  <div className={'m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'}>
-                    parameter
-                    <div className='flex flex-1 flex-wrap'>
-                      <div
-                        className={`${hoverState.location ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
-                        onMouseOver={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            location: true
-                          }))
-                        }
-                        onMouseLeave={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            location: false
-                          }))
-                        }
-                      >
-                        location
-                      </div>
-                      <div
-                        className={`${hoverState.description ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
-                        onMouseOver={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            description: true
-                          }))
-                        }
-                        onMouseLeave={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            description: false
-                          }))
-                        }
-                      >
-                        description
-                      </div>
-                      <div className='m-2 flex-1 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'>
-                        schema
-                        <div className='flex flex-1 flex-wrap'>
-                          <div className={'m-2 flex-1 bg-white p-2 dark:bg-gray-950'}>type</div>
-                          <div
-                            className={`${hoverState.enum ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
-                            onMouseOver={() =>
-                              setHoverState((prevState) => ({
-                                ...prevState,
-                                enum: true
-                              }))
-                            }
-                            onMouseLeave={() =>
-                              setHoverState((prevState) => ({
-                                ...prevState,
-                                enum: false
-                              }))
-                            }
-                          >
-                            enum
-                          </div>
-                          <div
-                            className={`${hoverState.examples ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
-                            onMouseOver={() =>
-                              setHoverState((prevState) => ({
-                                ...prevState,
-                                examples: true
-                              }))
-                            }
-                            onMouseLeave={() =>
-                              setHoverState((prevState) => ({
-                                ...prevState,
-                                examples: false
-                              }))
-                            }
-                          >
-                            examples
-                          </div>
-                          <div
-                            className={`${hoverState.default ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
-                            onMouseOver={() =>
-                              setHoverState((prevState) => ({
-                                ...prevState,
-                                default: true
-                              }))
-                            }
-                            onMouseLeave={() =>
-                              setHoverState((prevState) => ({
-                                ...prevState,
-                                default: false
-                              }))
-                            }
-                          >
-                            default
-                          </div>
-                          <div
-                            className={`${hoverState.description ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
-                            onMouseOver={() =>
-                              setHoverState((prevState) => ({
-                                ...prevState,
-                                description: true
-                              }))
-                            }
-                            onMouseLeave={() =>
-                              setHoverState((prevState) => ({
-                                ...prevState,
-                                description: false
-                              }))
-                            }
-                          >
-                            description
-                          </div>
-                          <div className={'m-2 flex-1 bg-white p-2 dark:bg-gray-950'}>pattern</div>
-                          <div className={'m-2 flex-1 bg-white p-2 dark:bg-gray-950'}>multipleOf</div>
-                          <div className={'m-2 flex-1 bg-white p-2 dark:bg-gray-950'}>And all other properties</div>
-                        </div>
+      <Column title="AsyncAPI 2.x">
+        <div className='m-2 border border-yellow-300 p-2 dark:border-yellow-700'>
+          components | channels
+          <div className='flex flex-1 flex-wrap'>
+            <div className='m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'>
+              parameters
+              <div className='flex flex-1 flex-wrap'>
+                <div className='m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'>
+                  parameter
+                  <div className='flex flex-1 flex-wrap'>
+                    {renderFields()}
+                    <div className='m-2 flex-1 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'>
+                      schema
+                      <div className='flex flex-1 flex-wrap'>
+                        <div className='m-2 flex-1 bg-white p-2 dark:bg-gray-950'>type</div>
+                        <HoverBox<HoverState>
+                          label="enum"
+                          fieldKey="enum"
+                          hoverState={hoverState}
+                          setHoverState={setHoverState}
+                          activeClass="bg-orange-300 dark:bg-orange-900/60"
+                          borderClass="border-orange-300 dark:border-orange-700"
+                          className="flex-1"
+                          useMouseOver
+                        />
+                        <HoverBox<HoverState>
+                          label="examples"
+                          fieldKey="examples"
+                          hoverState={hoverState}
+                          setHoverState={setHoverState}
+                          activeClass="bg-orange-300 dark:bg-orange-900/60"
+                          borderClass="border-orange-300 dark:border-orange-700"
+                          className="flex-1"
+                          useMouseOver
+                        />
+                        <HoverBox<HoverState>
+                          label="default"
+                          fieldKey="default"
+                          hoverState={hoverState}
+                          setHoverState={setHoverState}
+                          activeClass="bg-orange-300 dark:bg-orange-900/60"
+                          borderClass="border-orange-300 dark:border-orange-700"
+                          className="flex-1"
+                          useMouseOver
+                        />
+                        <HoverBox<HoverState>
+                          label="description"
+                          fieldKey="description"
+                          hoverState={hoverState}
+                          setHoverState={setHoverState}
+                          activeClass="bg-orange-300 dark:bg-orange-900/60"
+                          borderClass="border-orange-300 dark:border-orange-700"
+                          className="flex-1"
+                          useMouseOver
+                        />
+                        <div className='m-2 flex-1 bg-white p-2 dark:bg-gray-950'>pattern</div>
+                        <div className='m-2 flex-1 bg-white p-2 dark:bg-gray-950'>multipleOf</div>
+                        <div className='m-2 flex-1 bg-white p-2 dark:bg-gray-950'>And all other properties</div>
                       </div>
                     </div>
                   </div>
@@ -149,112 +119,56 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
             </div>
           </div>
         </div>
-      </div>
-      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 3.0</h3>
-        <div>
-          <div className={'m-2 border border-yellow-300 p-2 dark:border-yellow-700'}>
-            components | channels
-            <div className='flex flex-1 flex-wrap'>
-              <div className={'m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'}>
-                parameters
-                <div className='flex flex-1 flex-wrap'>
-                  <div className={'m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'}>
-                    parameter
-                    <div className='flex flex-1 flex-wrap'>
-                      <div
-                        className={`${hoverState.location ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
-                        onMouseOver={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            location: true
-                          }))
-                        }
-                        onMouseLeave={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            location: false
-                          }))
-                        }
-                      >
-                        location
-                      </div>
-                      <div
-                        className={`${hoverState.description ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
-                        onMouseOver={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            description: true
-                          }))
-                        }
-                        onMouseLeave={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            description: false
-                          }))
-                        }
-                      >
-                        description
-                      </div>
-                      <div
-                        className={`${hoverState.enum ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
-                        onMouseOver={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            enum: true
-                          }))
-                        }
-                        onMouseLeave={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            enum: false
-                          }))
-                        }
-                      >
-                        enum
-                      </div>
-                      <div
-                        className={`${hoverState.examples ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
-                        onMouseOver={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            examples: true
-                          }))
-                        }
-                        onMouseLeave={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            examples: false
-                          }))
-                        }
-                      >
-                        examples
-                      </div>
-                      <div
-                        className={`${hoverState.default ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
-                        onMouseOver={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            default: true
-                          }))
-                        }
-                        onMouseLeave={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            default: false
-                          }))
-                        }
-                      >
-                        default
-                      </div>
-                    </div>
+      </Column>
+
+      <Column title="AsyncAPI 3.0">
+        <div className='m-2 border border-yellow-300 p-2 dark:border-yellow-700'>
+          components | channels
+          <div className='flex flex-1 flex-wrap'>
+            <div className='m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'>
+              parameters
+              <div className='flex flex-1 flex-wrap'>
+                <div className='m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'>
+                  parameter
+                  <div className='flex flex-1 flex-wrap'>
+                    {renderFields()}
+                    <HoverBox<HoverState>
+                      label="enum"
+                      fieldKey="enum"
+                      hoverState={hoverState}
+                      setHoverState={setHoverState}
+                      activeClass="bg-orange-300 dark:bg-orange-900/60"
+                      borderClass="border-orange-300 dark:border-orange-700"
+                      className="flex-1"
+                      useMouseOver
+                    />
+                    <HoverBox<HoverState>
+                      label="examples"
+                      fieldKey="examples"
+                      hoverState={hoverState}
+                      setHoverState={setHoverState}
+                      activeClass="bg-orange-300 dark:bg-orange-900/60"
+                      borderClass="border-orange-300 dark:border-orange-700"
+                      className="flex-1"
+                      useMouseOver
+                    />
+                    <HoverBox<HoverState>
+                      label="default"
+                      fieldKey="default"
+                      hoverState={hoverState}
+                      setHoverState={setHoverState}
+                      activeClass="bg-orange-300 dark:bg-orange-900/60"
+                      borderClass="border-orange-300 dark:border-orange-700"
+                      className="flex-1"
+                      useMouseOver
+                    />
                   </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      </Column>
     </div>
   );
 }

--- a/components/Asyncapi3Comparison/Asyncapi3ParameterComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ParameterComparison.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+
 import { Column, HoverBox } from './ComparisonCommon';
 
 export interface Asyncapi3ParameterComparisonProps {
@@ -29,23 +30,23 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
   const renderFields = () => (
     <>
       <HoverBox<HoverState>
-        label="location"
-        fieldKey="location"
+        label='location'
+        fieldKey='location'
         hoverState={hoverState}
         setHoverState={setHoverState}
-        activeClass="bg-orange-300 dark:bg-orange-900/60"
-        borderClass="border-orange-300 dark:border-orange-700"
-        className="flex-1"
+        activeClass='bg-orange-300 dark:bg-orange-900/60'
+        borderClass='border-orange-300 dark:border-orange-700'
+        className='flex-1'
         useMouseOver
       />
       <HoverBox<HoverState>
-        label="description"
-        fieldKey="description"
+        label='description'
+        fieldKey='description'
         hoverState={hoverState}
         setHoverState={setHoverState}
-        activeClass="bg-orange-300 dark:bg-orange-900/60"
-        borderClass="border-orange-300 dark:border-orange-700"
-        className="flex-1"
+        activeClass='bg-orange-300 dark:bg-orange-900/60'
+        borderClass='border-orange-300 dark:border-orange-700'
+        className='flex-1'
         useMouseOver
       />
     </>
@@ -53,7 +54,7 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
 
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <Column title="AsyncAPI 2.x">
+      <Column title='AsyncAPI 2.x'>
         <div className='m-2 border border-yellow-300 p-2 dark:border-yellow-700'>
           components | channels
           <div className='flex flex-1 flex-wrap'>
@@ -69,43 +70,43 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
                       <div className='flex flex-1 flex-wrap'>
                         <div className='m-2 flex-1 bg-white p-2 dark:bg-gray-950'>type</div>
                         <HoverBox<HoverState>
-                          label="enum"
-                          fieldKey="enum"
+                          label='enum'
+                          fieldKey='enum'
                           hoverState={hoverState}
                           setHoverState={setHoverState}
-                          activeClass="bg-orange-300 dark:bg-orange-900/60"
-                          borderClass="border-orange-300 dark:border-orange-700"
-                          className="flex-1"
+                          activeClass='bg-orange-300 dark:bg-orange-900/60'
+                          borderClass='border-orange-300 dark:border-orange-700'
+                          className='flex-1'
                           useMouseOver
                         />
                         <HoverBox<HoverState>
-                          label="examples"
-                          fieldKey="examples"
+                          label='examples'
+                          fieldKey='examples'
                           hoverState={hoverState}
                           setHoverState={setHoverState}
-                          activeClass="bg-orange-300 dark:bg-orange-900/60"
-                          borderClass="border-orange-300 dark:border-orange-700"
-                          className="flex-1"
+                          activeClass='bg-orange-300 dark:bg-orange-900/60'
+                          borderClass='border-orange-300 dark:border-orange-700'
+                          className='flex-1'
                           useMouseOver
                         />
                         <HoverBox<HoverState>
-                          label="default"
-                          fieldKey="default"
+                          label='default'
+                          fieldKey='default'
                           hoverState={hoverState}
                           setHoverState={setHoverState}
-                          activeClass="bg-orange-300 dark:bg-orange-900/60"
-                          borderClass="border-orange-300 dark:border-orange-700"
-                          className="flex-1"
+                          activeClass='bg-orange-300 dark:bg-orange-900/60'
+                          borderClass='border-orange-300 dark:border-orange-700'
+                          className='flex-1'
                           useMouseOver
                         />
                         <HoverBox<HoverState>
-                          label="description"
-                          fieldKey="description"
+                          label='description'
+                          fieldKey='description'
                           hoverState={hoverState}
                           setHoverState={setHoverState}
-                          activeClass="bg-orange-300 dark:bg-orange-900/60"
-                          borderClass="border-orange-300 dark:border-orange-700"
-                          className="flex-1"
+                          activeClass='bg-orange-300 dark:bg-orange-900/60'
+                          borderClass='border-orange-300 dark:border-orange-700'
+                          className='flex-1'
                           useMouseOver
                         />
                         <div className='m-2 flex-1 bg-white p-2 dark:bg-gray-950'>pattern</div>
@@ -121,7 +122,7 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
         </div>
       </Column>
 
-      <Column title="AsyncAPI 3.0">
+      <Column title='AsyncAPI 3.0'>
         <div className='m-2 border border-yellow-300 p-2 dark:border-yellow-700'>
           components | channels
           <div className='flex flex-1 flex-wrap'>
@@ -133,33 +134,33 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
                   <div className='flex flex-1 flex-wrap'>
                     {renderFields()}
                     <HoverBox<HoverState>
-                      label="enum"
-                      fieldKey="enum"
+                      label='enum'
+                      fieldKey='enum'
                       hoverState={hoverState}
                       setHoverState={setHoverState}
-                      activeClass="bg-orange-300 dark:bg-orange-900/60"
-                      borderClass="border-orange-300 dark:border-orange-700"
-                      className="flex-1"
+                      activeClass='bg-orange-300 dark:bg-orange-900/60'
+                      borderClass='border-orange-300 dark:border-orange-700'
+                      className='flex-1'
                       useMouseOver
                     />
                     <HoverBox<HoverState>
-                      label="examples"
-                      fieldKey="examples"
+                      label='examples'
+                      fieldKey='examples'
                       hoverState={hoverState}
                       setHoverState={setHoverState}
-                      activeClass="bg-orange-300 dark:bg-orange-900/60"
-                      borderClass="border-orange-300 dark:border-orange-700"
-                      className="flex-1"
+                      activeClass='bg-orange-300 dark:bg-orange-900/60'
+                      borderClass='border-orange-300 dark:border-orange-700'
+                      className='flex-1'
                       useMouseOver
                     />
                     <HoverBox<HoverState>
-                      label="default"
-                      fieldKey="default"
+                      label='default'
+                      fieldKey='default'
                       hoverState={hoverState}
                       setHoverState={setHoverState}
-                      activeClass="bg-orange-300 dark:bg-orange-900/60"
-                      borderClass="border-orange-300 dark:border-orange-700"
-                      className="flex-1"
+                      activeClass='bg-orange-300 dark:bg-orange-900/60'
+                      borderClass='border-orange-300 dark:border-orange-700'
+                      className='flex-1'
                       useMouseOver
                     />
                   </div>

--- a/components/Asyncapi3Comparison/Asyncapi3ParameterComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ParameterComparison.tsx
@@ -17,7 +17,23 @@ export interface HoverState {
 interface ParameterHoverBoxProps {
   label: string;
   fieldKey: keyof HoverState;
+  hoverState: HoverState;
+  setHoverState: React.Dispatch<React.SetStateAction<HoverState>>;
 }
+
+const ParameterHoverBox = ({ label, fieldKey, hoverState, setHoverState }: ParameterHoverBoxProps) => (
+  <HoverBox<HoverState>
+    label={label}
+    fieldKey={fieldKey}
+    hoverState={hoverState}
+    setHoverState={setHoverState}
+    activeClass='bg-orange-300 dark:bg-orange-900/60'
+    borderClass='border-orange-300 dark:border-orange-700'
+    className='flex-1'
+    useMouseOver
+    focusable
+  />
+);
 
 /**
  * @description React component for comparing AsyncAPI parameters between versions 2.x and 3.0.
@@ -32,24 +48,15 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
     default: false
   });
 
-  const ParameterHoverBox = ({ label, fieldKey }: ParameterHoverBoxProps) => (
-    <HoverBox<HoverState>
-      label={label}
-      fieldKey={fieldKey}
-      hoverState={hoverState}
-      setHoverState={setHoverState}
-      activeClass='bg-orange-300 dark:bg-orange-900/60'
-      borderClass='border-orange-300 dark:border-orange-700'
-      className='flex-1'
-      useMouseOver
-      focusable
-    />
-  );
-
   const renderFields = () => (
     <>
-      <ParameterHoverBox label='location' fieldKey='location' />
-      <ParameterHoverBox label='description' fieldKey='description' />
+      <ParameterHoverBox label='location' fieldKey='location' hoverState={hoverState} setHoverState={setHoverState} />
+      <ParameterHoverBox
+        label='description'
+        fieldKey='description'
+        hoverState={hoverState}
+        setHoverState={setHoverState}
+      />
     </>
   );
 
@@ -70,10 +77,30 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
                       schema
                       <div className='flex flex-1 flex-wrap'>
                         <div className='m-2 flex-1 bg-white p-2 dark:bg-gray-950'>type</div>
-                        <ParameterHoverBox label='enum' fieldKey='enum' />
-                        <ParameterHoverBox label='examples' fieldKey='examples' />
-                        <ParameterHoverBox label='default' fieldKey='default' />
-                        <ParameterHoverBox label='description' fieldKey='description' />
+                        <ParameterHoverBox
+                          label='enum'
+                          fieldKey='enum'
+                          hoverState={hoverState}
+                          setHoverState={setHoverState}
+                        />
+                        <ParameterHoverBox
+                          label='examples'
+                          fieldKey='examples'
+                          hoverState={hoverState}
+                          setHoverState={setHoverState}
+                        />
+                        <ParameterHoverBox
+                          label='default'
+                          fieldKey='default'
+                          hoverState={hoverState}
+                          setHoverState={setHoverState}
+                        />
+                        <ParameterHoverBox
+                          label='description'
+                          fieldKey='description'
+                          hoverState={hoverState}
+                          setHoverState={setHoverState}
+                        />
                         <div className='m-2 flex-1 bg-white p-2 dark:bg-gray-950'>pattern</div>
                         <div className='m-2 flex-1 bg-white p-2 dark:bg-gray-950'>multipleOf</div>
                         <div className='m-2 flex-1 bg-white p-2 dark:bg-gray-950'>And all other properties</div>
@@ -98,9 +125,24 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
                   parameter
                   <div className='flex flex-1 flex-wrap'>
                     {renderFields()}
-                    <ParameterHoverBox label='enum' fieldKey='enum' />
-                    <ParameterHoverBox label='examples' fieldKey='examples' />
-                    <ParameterHoverBox label='default' fieldKey='default' />
+                    <ParameterHoverBox
+                      label='enum'
+                      fieldKey='enum'
+                      hoverState={hoverState}
+                      setHoverState={setHoverState}
+                    />
+                    <ParameterHoverBox
+                      label='examples'
+                      fieldKey='examples'
+                      hoverState={hoverState}
+                      setHoverState={setHoverState}
+                    />
+                    <ParameterHoverBox
+                      label='default'
+                      fieldKey='default'
+                      hoverState={hoverState}
+                      setHoverState={setHoverState}
+                    />
                   </div>
                 </div>
               </div>

--- a/components/Asyncapi3Comparison/Asyncapi3ParameterComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ParameterComparison.tsx
@@ -19,67 +19,127 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
 
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <div className='ml-1 flex-1 border border-black p-2'>
+      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
         <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 2.x</h3>
         <div>
-          <div className={'m-2 border border-yellow-300 p-2'}>
+          <div className={'m-2 border border-yellow-300 p-2 dark:border-yellow-700'}>
             components | channels
             <div className='flex flex-1 flex-wrap'>
-              <div className={'m-2 border border-yellow-600 bg-white p-2'}>
+              <div className={'m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'}>
                 parameters
                 <div className='flex flex-1 flex-wrap'>
-                  <div className={'m-2 border border-yellow-600 bg-white p-2'}>
+                  <div className={'m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'}>
                     parameter
                     <div className='flex flex-1 flex-wrap'>
                       <div
-                        className={`${hoverState.location ? 'bg-orange-300' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
-                        onMouseOver={() => setHoverState((prevState) => ({ ...prevState, location: true }))}
-                        onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, location: false }))}
+                        className={`${hoverState.location ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
+                        onMouseOver={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            location: true
+                          }))
+                        }
+                        onMouseLeave={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            location: false
+                          }))
+                        }
                       >
                         location
                       </div>
                       <div
-                        className={`${hoverState.description ? 'bg-orange-300' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
-                        onMouseOver={() => setHoverState((prevState) => ({ ...prevState, description: true }))}
-                        onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, description: false }))}
+                        className={`${hoverState.description ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
+                        onMouseOver={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            description: true
+                          }))
+                        }
+                        onMouseLeave={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            description: false
+                          }))
+                        }
                       >
                         description
                       </div>
-                      <div className='m-2 flex-1 border border-yellow-600 bg-white p-2'>
+                      <div className='m-2 flex-1 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'>
                         schema
                         <div className='flex flex-1 flex-wrap'>
-                          <div className={'m-2 flex-1 bg-white p-2'}>type</div>
+                          <div className={'m-2 flex-1 bg-white p-2 dark:bg-gray-950'}>type</div>
                           <div
-                            className={`${hoverState.enum ? 'bg-orange-300' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
-                            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, enum: true }))}
-                            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, enum: false }))}
+                            className={`${hoverState.enum ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
+                            onMouseOver={() =>
+                              setHoverState((prevState) => ({
+                                ...prevState,
+                                enum: true
+                              }))
+                            }
+                            onMouseLeave={() =>
+                              setHoverState((prevState) => ({
+                                ...prevState,
+                                enum: false
+                              }))
+                            }
                           >
                             enum
                           </div>
                           <div
-                            className={`${hoverState.examples ? 'bg-orange-300' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
-                            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, examples: true }))}
-                            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, examples: false }))}
+                            className={`${hoverState.examples ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
+                            onMouseOver={() =>
+                              setHoverState((prevState) => ({
+                                ...prevState,
+                                examples: true
+                              }))
+                            }
+                            onMouseLeave={() =>
+                              setHoverState((prevState) => ({
+                                ...prevState,
+                                examples: false
+                              }))
+                            }
                           >
                             examples
                           </div>
                           <div
-                            className={`${hoverState.default ? 'bg-orange-300' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
-                            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, default: true }))}
-                            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, default: false }))}
+                            className={`${hoverState.default ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
+                            onMouseOver={() =>
+                              setHoverState((prevState) => ({
+                                ...prevState,
+                                default: true
+                              }))
+                            }
+                            onMouseLeave={() =>
+                              setHoverState((prevState) => ({
+                                ...prevState,
+                                default: false
+                              }))
+                            }
                           >
                             default
                           </div>
                           <div
-                            className={`${hoverState.description ? 'bg-orange-300' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
-                            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, description: true }))}
-                            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, description: false }))}
+                            className={`${hoverState.description ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
+                            onMouseOver={() =>
+                              setHoverState((prevState) => ({
+                                ...prevState,
+                                description: true
+                              }))
+                            }
+                            onMouseLeave={() =>
+                              setHoverState((prevState) => ({
+                                ...prevState,
+                                description: false
+                              }))
+                            }
                           >
                             description
                           </div>
-                          <div className={'m-2 flex-1 bg-white p-2'}>pattern</div>
-                          <div className={'m-2 flex-1 bg-white p-2'}>multipleOf</div>
-                          <div className={'m-2 flex-1 bg-white p-2'}>And all other properties</div>
+                          <div className={'m-2 flex-1 bg-white p-2 dark:bg-gray-950'}>pattern</div>
+                          <div className={'m-2 flex-1 bg-white p-2 dark:bg-gray-950'}>multipleOf</div>
+                          <div className={'m-2 flex-1 bg-white p-2 dark:bg-gray-950'}>And all other properties</div>
                         </div>
                       </div>
                     </div>
@@ -90,50 +150,100 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
           </div>
         </div>
       </div>
-      <div className='ml-1 flex-1 border border-black p-2'>
+      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
         <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 3.0</h3>
         <div>
-          <div className={'m-2 border border-yellow-300 p-2'}>
+          <div className={'m-2 border border-yellow-300 p-2 dark:border-yellow-700'}>
             components | channels
             <div className='flex flex-1 flex-wrap'>
-              <div className={'m-2 border border-yellow-600 bg-white p-2'}>
+              <div className={'m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'}>
                 parameters
                 <div className='flex flex-1 flex-wrap'>
-                  <div className={'m-2 border border-yellow-600 bg-white p-2'}>
+                  <div className={'m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'}>
                     parameter
                     <div className='flex flex-1 flex-wrap'>
                       <div
-                        className={`${hoverState.location ? 'bg-orange-300' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
-                        onMouseOver={() => setHoverState((prevState) => ({ ...prevState, location: true }))}
-                        onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, location: false }))}
+                        className={`${hoverState.location ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
+                        onMouseOver={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            location: true
+                          }))
+                        }
+                        onMouseLeave={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            location: false
+                          }))
+                        }
                       >
                         location
                       </div>
                       <div
-                        className={`${hoverState.description ? 'bg-orange-300' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
-                        onMouseOver={() => setHoverState((prevState) => ({ ...prevState, description: true }))}
-                        onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, description: false }))}
+                        className={`${hoverState.description ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
+                        onMouseOver={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            description: true
+                          }))
+                        }
+                        onMouseLeave={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            description: false
+                          }))
+                        }
                       >
                         description
                       </div>
                       <div
-                        className={`${hoverState.enum ? 'bg-orange-300' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
-                        onMouseOver={() => setHoverState((prevState) => ({ ...prevState, enum: true }))}
-                        onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, enum: false }))}
+                        className={`${hoverState.enum ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
+                        onMouseOver={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            enum: true
+                          }))
+                        }
+                        onMouseLeave={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            enum: false
+                          }))
+                        }
                       >
                         enum
                       </div>
                       <div
-                        className={`${hoverState.examples ? 'bg-orange-300' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
-                        onMouseOver={() => setHoverState((prevState) => ({ ...prevState, examples: true }))}
-                        onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, examples: false }))}
+                        className={`${hoverState.examples ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
+                        onMouseOver={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            examples: true
+                          }))
+                        }
+                        onMouseLeave={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            examples: false
+                          }))
+                        }
                       >
                         examples
                       </div>
                       <div
-                        className={`${hoverState.default ? 'bg-orange-300' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
-                        onMouseOver={() => setHoverState((prevState) => ({ ...prevState, default: true }))}
-                        onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, default: false }))}
+                        className={`${hoverState.default ? 'bg-orange-300 dark:bg-orange-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
+                        onMouseOver={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            default: true
+                          }))
+                        }
+                        onMouseLeave={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            default: false
+                          }))
+                        }
                       >
                         default
                       </div>

--- a/components/Asyncapi3Comparison/Asyncapi3ParameterComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ParameterComparison.tsx
@@ -14,6 +14,11 @@ export interface HoverState {
   default: boolean;
 }
 
+interface ParameterHoverBoxProps {
+  label: string;
+  fieldKey: keyof HoverState;
+}
+
 /**
  * @description React component for comparing AsyncAPI parameters between versions 2.x and 3.0.
  * @param {string} [props.className=''] - Additional CSS classes for styling.
@@ -27,30 +32,24 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
     default: false
   });
 
+  const ParameterHoverBox = ({ label, fieldKey }: ParameterHoverBoxProps) => (
+    <HoverBox<HoverState>
+      label={label}
+      fieldKey={fieldKey}
+      hoverState={hoverState}
+      setHoverState={setHoverState}
+      activeClass='bg-orange-300 dark:bg-orange-900/60'
+      borderClass='border-orange-300 dark:border-orange-700'
+      className='flex-1'
+      useMouseOver
+      focusable
+    />
+  );
+
   const renderFields = () => (
     <>
-      <HoverBox<HoverState>
-        label='location'
-        fieldKey='location'
-        hoverState={hoverState}
-        setHoverState={setHoverState}
-        activeClass='bg-orange-300 dark:bg-orange-900/60'
-        borderClass='border-orange-300 dark:border-orange-700'
-        className='flex-1'
-        useMouseOver
-        focusable
-      />
-      <HoverBox<HoverState>
-        label='description'
-        fieldKey='description'
-        hoverState={hoverState}
-        setHoverState={setHoverState}
-        activeClass='bg-orange-300 dark:bg-orange-900/60'
-        borderClass='border-orange-300 dark:border-orange-700'
-        className='flex-1'
-        useMouseOver
-        focusable
-      />
+      <ParameterHoverBox label='location' fieldKey='location' />
+      <ParameterHoverBox label='description' fieldKey='description' />
     </>
   );
 
@@ -71,50 +70,10 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
                       schema
                       <div className='flex flex-1 flex-wrap'>
                         <div className='m-2 flex-1 bg-white p-2 dark:bg-gray-950'>type</div>
-                        <HoverBox<HoverState>
-                          label='enum'
-                          fieldKey='enum'
-                          hoverState={hoverState}
-                          setHoverState={setHoverState}
-                          activeClass='bg-orange-300 dark:bg-orange-900/60'
-                          borderClass='border-orange-300 dark:border-orange-700'
-                          className='flex-1'
-                          useMouseOver
-                          focusable
-                        />
-                        <HoverBox<HoverState>
-                          label='examples'
-                          fieldKey='examples'
-                          hoverState={hoverState}
-                          setHoverState={setHoverState}
-                          activeClass='bg-orange-300 dark:bg-orange-900/60'
-                          borderClass='border-orange-300 dark:border-orange-700'
-                          className='flex-1'
-                          useMouseOver
-                          focusable
-                        />
-                        <HoverBox<HoverState>
-                          label='default'
-                          fieldKey='default'
-                          hoverState={hoverState}
-                          setHoverState={setHoverState}
-                          activeClass='bg-orange-300 dark:bg-orange-900/60'
-                          borderClass='border-orange-300 dark:border-orange-700'
-                          className='flex-1'
-                          useMouseOver
-                          focusable
-                        />
-                        <HoverBox<HoverState>
-                          label='description'
-                          fieldKey='description'
-                          hoverState={hoverState}
-                          setHoverState={setHoverState}
-                          activeClass='bg-orange-300 dark:bg-orange-900/60'
-                          borderClass='border-orange-300 dark:border-orange-700'
-                          className='flex-1'
-                          useMouseOver
-                          focusable
-                        />
+                        <ParameterHoverBox label='enum' fieldKey='enum' />
+                        <ParameterHoverBox label='examples' fieldKey='examples' />
+                        <ParameterHoverBox label='default' fieldKey='default' />
+                        <ParameterHoverBox label='description' fieldKey='description' />
                         <div className='m-2 flex-1 bg-white p-2 dark:bg-gray-950'>pattern</div>
                         <div className='m-2 flex-1 bg-white p-2 dark:bg-gray-950'>multipleOf</div>
                         <div className='m-2 flex-1 bg-white p-2 dark:bg-gray-950'>And all other properties</div>
@@ -139,39 +98,9 @@ export default function Asyncapi3ParameterComparison({ className = '' }: Asyncap
                   parameter
                   <div className='flex flex-1 flex-wrap'>
                     {renderFields()}
-                    <HoverBox<HoverState>
-                      label='enum'
-                      fieldKey='enum'
-                      hoverState={hoverState}
-                      setHoverState={setHoverState}
-                      activeClass='bg-orange-300 dark:bg-orange-900/60'
-                      borderClass='border-orange-300 dark:border-orange-700'
-                      className='flex-1'
-                      useMouseOver
-                      focusable
-                    />
-                    <HoverBox<HoverState>
-                      label='examples'
-                      fieldKey='examples'
-                      hoverState={hoverState}
-                      setHoverState={setHoverState}
-                      activeClass='bg-orange-300 dark:bg-orange-900/60'
-                      borderClass='border-orange-300 dark:border-orange-700'
-                      className='flex-1'
-                      useMouseOver
-                      focusable
-                    />
-                    <HoverBox<HoverState>
-                      label='default'
-                      fieldKey='default'
-                      hoverState={hoverState}
-                      setHoverState={setHoverState}
-                      activeClass='bg-orange-300 dark:bg-orange-900/60'
-                      borderClass='border-orange-300 dark:border-orange-700'
-                      className='flex-1'
-                      useMouseOver
-                      focusable
-                    />
+                    <ParameterHoverBox label='enum' fieldKey='enum' />
+                    <ParameterHoverBox label='examples' fieldKey='examples' />
+                    <ParameterHoverBox label='default' fieldKey='default' />
                   </div>
                 </div>
               </div>

--- a/components/Asyncapi3Comparison/Asyncapi3SchemaFormatComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3SchemaFormatComparison.tsx
@@ -17,36 +17,66 @@ export default function Asyncapi3SchemaFormatComparison({ className = '' }: Asyn
 
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <div className='ml-1 flex-1 border border-black p-2'>
+      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
         <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 2.x</h3>
         <div>
-          <div className={'m-2 border border-yellow-300 p-2'}>
+          <div className={'m-2 border border-yellow-300 p-2 dark:border-yellow-700'}>
             components | channels
             <div className='flex flex-1 flex-wrap'>
-              <div className={'m-2 border border-yellow-600 bg-white p-2'}>
+              <div className={'m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'}>
                 messages
                 <div className='flex flex-1 flex-wrap'>
-                  <div className={'m-2 border border-yellow-600 bg-white p-2'}>
+                  <div className={'m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'}>
                     message
                     <div className='flex flex-1 flex-wrap'>
                       <div
-                        className={`${hoverState.SchemaFormat ? 'bg-orange-100' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
-                        onMouseOver={() => setHoverState((prevState) => ({ ...prevState, SchemaFormat: true }))}
-                        onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, SchemaFormat: false }))}
+                        className={`${hoverState.SchemaFormat ? 'bg-orange-100 dark:bg-orange-900/40' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
+                        onMouseOver={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            SchemaFormat: true
+                          }))
+                        }
+                        onMouseLeave={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            SchemaFormat: false
+                          }))
+                        }
                       >
                         schemaFormat
                       </div>
                       <div
-                        className={`${hoverState.Payload ? 'bg-yellow-300' : 'bg-white'} m-2 flex-1 border border-yellow-600 p-2`}
-                        onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Payload: true }))}
-                        onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Payload: false }))}
+                        className={`${hoverState.Payload ? 'bg-yellow-300 dark:bg-yellow-800/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-yellow-600 p-2 dark:border-yellow-700`}
+                        onMouseOver={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            Payload: true
+                          }))
+                        }
+                        onMouseLeave={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            Payload: false
+                          }))
+                        }
                       >
                         payload
                         <div className='flex flex-1 flex-wrap'>
                           <div
-                            className={`${hoverState.Schema ? 'bg-blue-300' : 'bg-white'} m-2 flex-1 border border-orange-300 p-2`}
-                            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Schema: true }))}
-                            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Schema: false }))}
+                            className={`${hoverState.Schema ? 'bg-blue-300 dark:bg-blue-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
+                            onMouseOver={() =>
+                              setHoverState((prevState) => ({
+                                ...prevState,
+                                Schema: true
+                              }))
+                            }
+                            onMouseLeave={() =>
+                              setHoverState((prevState) => ({
+                                ...prevState,
+                                Schema: false
+                              }))
+                            }
                           >
                             schema
                           </div>
@@ -60,36 +90,66 @@ export default function Asyncapi3SchemaFormatComparison({ className = '' }: Asyn
           </div>
         </div>
       </div>
-      <div className='ml-1 flex-1 border border-black p-2'>
+      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
         <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 3.0</h3>
         <div>
-          <div className={'m-2 border border-yellow-300 p-2'}>
+          <div className={'m-2 border border-yellow-300 p-2 dark:border-yellow-700'}>
             components | channels
             <div className='flex flex-1 flex-wrap'>
-              <div className={'m-2 border border-yellow-600 bg-white p-2'}>
+              <div className={'m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'}>
                 messages
                 <div className='flex flex-1 flex-wrap'>
-                  <div className={'m-2 border border-yellow-600 bg-white p-2'}>
+                  <div className={'m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'}>
                     message
                     <div className='flex flex-1 flex-wrap'>
                       <div
-                        className={`${hoverState.Payload ? 'bg-yellow-300' : 'bg-white'} m-2 border border-yellow-600 p-2`}
-                        onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Payload: true }))}
-                        onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Payload: false }))}
+                        className={`${hoverState.Payload ? 'bg-yellow-300 dark:bg-yellow-800/60' : 'bg-white dark:bg-gray-900'} m-2 border border-yellow-600 p-2 dark:border-yellow-700`}
+                        onMouseOver={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            Payload: true
+                          }))
+                        }
+                        onMouseLeave={() =>
+                          setHoverState((prevState) => ({
+                            ...prevState,
+                            Payload: false
+                          }))
+                        }
                       >
                         payload
                         <div className='flex flex-1 flex-wrap'>
                           <div
-                            className={`${hoverState.SchemaFormat ? 'bg-orange-100' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
-                            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, SchemaFormat: true }))}
-                            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, SchemaFormat: false }))}
+                            className={`${hoverState.SchemaFormat ? 'bg-orange-100 dark:bg-orange-900/40' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
+                            onMouseOver={() =>
+                              setHoverState((prevState) => ({
+                                ...prevState,
+                                SchemaFormat: true
+                              }))
+                            }
+                            onMouseLeave={() =>
+                              setHoverState((prevState) => ({
+                                ...prevState,
+                                SchemaFormat: false
+                              }))
+                            }
                           >
                             schemaFormat
                           </div>
                           <div
-                            className={`${hoverState.Schema ? 'bg-blue-300' : 'bg-white'} m-2 flex-1 border border-orange-300 p-2`}
-                            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Schema: true }))}
-                            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Schema: false }))}
+                            className={`${hoverState.Schema ? 'bg-blue-300 dark:bg-blue-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
+                            onMouseOver={() =>
+                              setHoverState((prevState) => ({
+                                ...prevState,
+                                Schema: true
+                              }))
+                            }
+                            onMouseLeave={() =>
+                              setHoverState((prevState) => ({
+                                ...prevState,
+                                Schema: false
+                              }))
+                            }
                           >
                             schema
                           </div>

--- a/components/Asyncapi3Comparison/Asyncapi3SchemaFormatComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3SchemaFormatComparison.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+
 import { Column, HoverBox } from './ComparisonCommon';
 
 export interface Asyncapi3SchemaFormatComparisonProps {
@@ -24,33 +25,33 @@ export default function Asyncapi3SchemaFormatComparison({ className = '' }: Asyn
 
   const renderSchemaFormat = () => (
     <HoverBox<HoverState>
-      label="schemaFormat"
-      fieldKey="SchemaFormat"
+      label='schemaFormat'
+      fieldKey='SchemaFormat'
       hoverState={hoverState}
       setHoverState={setHoverState}
-      activeClass="bg-orange-100 dark:bg-orange-900/40"
-      borderClass="border-orange-300 dark:border-orange-700"
-      className="flex-1"
+      activeClass='bg-orange-100 dark:bg-orange-900/40'
+      borderClass='border-orange-300 dark:border-orange-700'
+      className='flex-1'
       useMouseOver
     />
   );
 
   const renderSchema = () => (
     <HoverBox<HoverState>
-      label="schema"
-      fieldKey="Schema"
+      label='schema'
+      fieldKey='Schema'
       hoverState={hoverState}
       setHoverState={setHoverState}
-      activeClass="bg-blue-300 dark:bg-blue-900/60"
-      borderClass="border-orange-300 dark:border-orange-700"
-      className="flex-1"
+      activeClass='bg-blue-300 dark:bg-blue-900/60'
+      borderClass='border-orange-300 dark:border-orange-700'
+      className='flex-1'
       useMouseOver
     />
   );
 
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <Column title="AsyncAPI 2.x">
+      <Column title='AsyncAPI 2.x'>
         <div className='m-2 border border-yellow-300 p-2 dark:border-yellow-700'>
           components | channels
           <div className='flex flex-1 flex-wrap'>
@@ -62,18 +63,16 @@ export default function Asyncapi3SchemaFormatComparison({ className = '' }: Asyn
                   <div className='flex flex-1 flex-wrap'>
                     {renderSchemaFormat()}
                     <HoverBox<HoverState>
-                      label="payload"
-                      fieldKey="Payload"
+                      label='payload'
+                      fieldKey='Payload'
                       hoverState={hoverState}
                       setHoverState={setHoverState}
-                      activeClass="bg-yellow-300 dark:bg-yellow-800/60"
-                      borderClass="border-yellow-600 dark:border-yellow-700"
-                      className="flex-1"
+                      activeClass='bg-yellow-300 dark:bg-yellow-800/60'
+                      borderClass='border-yellow-600 dark:border-yellow-700'
+                      className='flex-1'
                       useMouseOver
                     >
-                      <div className='flex flex-1 flex-wrap'>
-                        {renderSchema()}
-                      </div>
+                      <div className='flex flex-1 flex-wrap'>{renderSchema()}</div>
                     </HoverBox>
                   </div>
                 </div>
@@ -83,7 +82,7 @@ export default function Asyncapi3SchemaFormatComparison({ className = '' }: Asyn
         </div>
       </Column>
 
-      <Column title="AsyncAPI 3.0">
+      <Column title='AsyncAPI 3.0'>
         <div className='m-2 border border-yellow-300 p-2 dark:border-yellow-700'>
           components | channels
           <div className='flex flex-1 flex-wrap'>
@@ -94,13 +93,13 @@ export default function Asyncapi3SchemaFormatComparison({ className = '' }: Asyn
                   message
                   <div className='flex flex-1 flex-wrap'>
                     <HoverBox<HoverState>
-                      label="payload"
-                      fieldKey="Payload"
+                      label='payload'
+                      fieldKey='Payload'
                       hoverState={hoverState}
                       setHoverState={setHoverState}
-                      activeClass="bg-yellow-300 dark:bg-yellow-800/60"
-                      borderClass="border-yellow-600 dark:border-yellow-700"
-                      className="flex-1"
+                      activeClass='bg-yellow-300 dark:bg-yellow-800/60'
+                      borderClass='border-yellow-600 dark:border-yellow-700'
+                      className='flex-1'
                       useMouseOver
                     >
                       <div className='flex flex-1 flex-wrap'>

--- a/components/Asyncapi3Comparison/Asyncapi3SchemaFormatComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3SchemaFormatComparison.tsx
@@ -33,6 +33,7 @@ export default function Asyncapi3SchemaFormatComparison({ className = '' }: Asyn
       borderClass='border-orange-300 dark:border-orange-700'
       className='flex-1'
       useMouseOver
+      focusable
     />
   );
 
@@ -46,6 +47,7 @@ export default function Asyncapi3SchemaFormatComparison({ className = '' }: Asyn
       borderClass='border-orange-300 dark:border-orange-700'
       className='flex-1'
       useMouseOver
+      focusable
     />
   );
 
@@ -70,7 +72,6 @@ export default function Asyncapi3SchemaFormatComparison({ className = '' }: Asyn
                       activeClass='bg-yellow-300 dark:bg-yellow-800/60'
                       borderClass='border-yellow-600 dark:border-yellow-700'
                       className='flex-1'
-                      useMouseOver
                     >
                       <div className='flex flex-1 flex-wrap'>{renderSchema()}</div>
                     </HoverBox>
@@ -100,7 +101,6 @@ export default function Asyncapi3SchemaFormatComparison({ className = '' }: Asyn
                       activeClass='bg-yellow-300 dark:bg-yellow-800/60'
                       borderClass='border-yellow-600 dark:border-yellow-700'
                       className='flex-1'
-                      useMouseOver
                     >
                       <div className='flex flex-1 flex-wrap'>
                         {renderSchemaFormat()}

--- a/components/Asyncapi3Comparison/Asyncapi3SchemaFormatComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3SchemaFormatComparison.tsx
@@ -1,7 +1,14 @@
 import React, { useState } from 'react';
+import { Column, HoverBox } from './ComparisonCommon';
 
 export interface Asyncapi3SchemaFormatComparisonProps {
   className?: string;
+}
+
+export interface HoverState {
+  SchemaFormat: boolean;
+  Payload: boolean;
+  Schema: boolean;
 }
 
 /**
@@ -9,160 +16,105 @@ export interface Asyncapi3SchemaFormatComparisonProps {
  * @param {string} [props.className=''] - Additional CSS classes for styling.
  */
 export default function Asyncapi3SchemaFormatComparison({ className = '' }: Asyncapi3SchemaFormatComparisonProps) {
-  const [hoverState, setHoverState] = useState({
+  const [hoverState, setHoverState] = useState<HoverState>({
     SchemaFormat: false,
     Payload: false,
     Schema: false
   });
 
+  const renderSchemaFormat = () => (
+    <HoverBox<HoverState>
+      label="schemaFormat"
+      fieldKey="SchemaFormat"
+      hoverState={hoverState}
+      setHoverState={setHoverState}
+      activeClass="bg-orange-100 dark:bg-orange-900/40"
+      borderClass="border-orange-300 dark:border-orange-700"
+      className="flex-1"
+      useMouseOver
+    />
+  );
+
+  const renderSchema = () => (
+    <HoverBox<HoverState>
+      label="schema"
+      fieldKey="Schema"
+      hoverState={hoverState}
+      setHoverState={setHoverState}
+      activeClass="bg-blue-300 dark:bg-blue-900/60"
+      borderClass="border-orange-300 dark:border-orange-700"
+      className="flex-1"
+      useMouseOver
+    />
+  );
+
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 2.x</h3>
-        <div>
-          <div className={'m-2 border border-yellow-300 p-2 dark:border-yellow-700'}>
-            components | channels
-            <div className='flex flex-1 flex-wrap'>
-              <div className={'m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'}>
-                messages
-                <div className='flex flex-1 flex-wrap'>
-                  <div className={'m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'}>
-                    message
-                    <div className='flex flex-1 flex-wrap'>
-                      <div
-                        className={`${hoverState.SchemaFormat ? 'bg-orange-100 dark:bg-orange-900/40' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
-                        onMouseOver={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            SchemaFormat: true
-                          }))
-                        }
-                        onMouseLeave={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            SchemaFormat: false
-                          }))
-                        }
-                      >
-                        schemaFormat
+      <Column title="AsyncAPI 2.x">
+        <div className='m-2 border border-yellow-300 p-2 dark:border-yellow-700'>
+          components | channels
+          <div className='flex flex-1 flex-wrap'>
+            <div className='m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'>
+              messages
+              <div className='flex flex-1 flex-wrap'>
+                <div className='m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'>
+                  message
+                  <div className='flex flex-1 flex-wrap'>
+                    {renderSchemaFormat()}
+                    <HoverBox<HoverState>
+                      label="payload"
+                      fieldKey="Payload"
+                      hoverState={hoverState}
+                      setHoverState={setHoverState}
+                      activeClass="bg-yellow-300 dark:bg-yellow-800/60"
+                      borderClass="border-yellow-600 dark:border-yellow-700"
+                      className="flex-1"
+                      useMouseOver
+                    >
+                      <div className='flex flex-1 flex-wrap'>
+                        {renderSchema()}
                       </div>
-                      <div
-                        className={`${hoverState.Payload ? 'bg-yellow-300 dark:bg-yellow-800/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-yellow-600 p-2 dark:border-yellow-700`}
-                        onMouseOver={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            Payload: true
-                          }))
-                        }
-                        onMouseLeave={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            Payload: false
-                          }))
-                        }
-                      >
-                        payload
-                        <div className='flex flex-1 flex-wrap'>
-                          <div
-                            className={`${hoverState.Schema ? 'bg-blue-300 dark:bg-blue-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
-                            onMouseOver={() =>
-                              setHoverState((prevState) => ({
-                                ...prevState,
-                                Schema: true
-                              }))
-                            }
-                            onMouseLeave={() =>
-                              setHoverState((prevState) => ({
-                                ...prevState,
-                                Schema: false
-                              }))
-                            }
-                          >
-                            schema
-                          </div>
-                        </div>
-                      </div>
-                    </div>
+                    </HoverBox>
                   </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 3.0</h3>
-        <div>
-          <div className={'m-2 border border-yellow-300 p-2 dark:border-yellow-700'}>
-            components | channels
-            <div className='flex flex-1 flex-wrap'>
-              <div className={'m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'}>
-                messages
-                <div className='flex flex-1 flex-wrap'>
-                  <div className={'m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'}>
-                    message
-                    <div className='flex flex-1 flex-wrap'>
-                      <div
-                        className={`${hoverState.Payload ? 'bg-yellow-300 dark:bg-yellow-800/60' : 'bg-white dark:bg-gray-900'} m-2 border border-yellow-600 p-2 dark:border-yellow-700`}
-                        onMouseOver={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            Payload: true
-                          }))
-                        }
-                        onMouseLeave={() =>
-                          setHoverState((prevState) => ({
-                            ...prevState,
-                            Payload: false
-                          }))
-                        }
-                      >
-                        payload
-                        <div className='flex flex-1 flex-wrap'>
-                          <div
-                            className={`${hoverState.SchemaFormat ? 'bg-orange-100 dark:bg-orange-900/40' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
-                            onMouseOver={() =>
-                              setHoverState((prevState) => ({
-                                ...prevState,
-                                SchemaFormat: true
-                              }))
-                            }
-                            onMouseLeave={() =>
-                              setHoverState((prevState) => ({
-                                ...prevState,
-                                SchemaFormat: false
-                              }))
-                            }
-                          >
-                            schemaFormat
-                          </div>
-                          <div
-                            className={`${hoverState.Schema ? 'bg-blue-300 dark:bg-blue-900/60' : 'bg-white dark:bg-gray-900'} m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700`}
-                            onMouseOver={() =>
-                              setHoverState((prevState) => ({
-                                ...prevState,
-                                Schema: true
-                              }))
-                            }
-                            onMouseLeave={() =>
-                              setHoverState((prevState) => ({
-                                ...prevState,
-                                Schema: false
-                              }))
-                            }
-                          >
-                            schema
-                          </div>
-                        </div>
+      </Column>
+
+      <Column title="AsyncAPI 3.0">
+        <div className='m-2 border border-yellow-300 p-2 dark:border-yellow-700'>
+          components | channels
+          <div className='flex flex-1 flex-wrap'>
+            <div className='m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'>
+              messages
+              <div className='flex flex-1 flex-wrap'>
+                <div className='m-2 border border-yellow-600 bg-white p-2 dark:border-yellow-700 dark:bg-gray-900'>
+                  message
+                  <div className='flex flex-1 flex-wrap'>
+                    <HoverBox<HoverState>
+                      label="payload"
+                      fieldKey="Payload"
+                      hoverState={hoverState}
+                      setHoverState={setHoverState}
+                      activeClass="bg-yellow-300 dark:bg-yellow-800/60"
+                      borderClass="border-yellow-600 dark:border-yellow-700"
+                      className="flex-1"
+                      useMouseOver
+                    >
+                      <div className='flex flex-1 flex-wrap'>
+                        {renderSchemaFormat()}
+                        {renderSchema()}
                       </div>
-                    </div>
+                    </HoverBox>
                   </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      </Column>
     </div>
   );
 }

--- a/components/Asyncapi3Comparison/Asyncapi3ServerComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ServerComparison.tsx
@@ -30,8 +30,9 @@ export default function Asyncapi3ServerComparison({ className = '' }: Asyncapi3S
               <div className='m-2 border border-blue-600 p-2 dark:border-blue-700'>
                 Server
                 <div className='flex flex-1 flex-wrap'>
-                  <div
-                    className={`${hoverState.Host || hoverState.Path ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600`}
+                  <button
+                    type='button'
+                    className={`${hoverState.Host || hoverState.Path ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600 focus:outline-none`}
                     onMouseOver={() =>
                       setHoverState((prevState) => ({
                         ...prevState,
@@ -62,7 +63,7 @@ export default function Asyncapi3ServerComparison({ className = '' }: Asyncapi3S
                     }
                   >
                     <p>Url</p>
-                  </div>
+                  </button>
                 </div>
               </div>
             </div>
@@ -78,8 +79,9 @@ export default function Asyncapi3ServerComparison({ className = '' }: Asyncapi3S
               <div className='m-2 border border-blue-600 p-2 dark:border-blue-700'>
                 Server
                 <div className='flex flex-1 flex-wrap'>
-                  <div
-                    className={`${hoverState.Host ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600`}
+                  <button
+                    type='button'
+                    className={`${hoverState.Host ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600 focus:outline-none`}
                     onMouseOver={() =>
                       setHoverState((prevState) => ({
                         ...prevState,
@@ -106,9 +108,10 @@ export default function Asyncapi3ServerComparison({ className = '' }: Asyncapi3S
                     }
                   >
                     <p>Host</p>
-                  </div>
-                  <div
-                    className={`${hoverState.Path ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600`}
+                  </button>
+                  <button
+                    type='button'
+                    className={`${hoverState.Path ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600 focus:outline-none`}
                     onMouseOver={() =>
                       setHoverState((prevState) => ({
                         ...prevState,
@@ -135,7 +138,7 @@ export default function Asyncapi3ServerComparison({ className = '' }: Asyncapi3S
                     }
                   >
                     <p>Pathname</p>
-                  </div>
+                  </button>
                 </div>
               </div>
             </div>

--- a/components/Asyncapi3Comparison/Asyncapi3ServerComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ServerComparison.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 
+import { Column } from './ComparisonCommon';
+
 export interface Asyncapi3ServerComparisonProps {
   className?: string;
 }
@@ -8,6 +10,26 @@ export interface HoverState {
   Host: boolean;
   Path: boolean;
 }
+
+interface ServerButtonProps {
+  label: string;
+  active: boolean;
+  onHover: (val: boolean) => void;
+  className?: string;
+}
+
+const ServerButton = ({ label, active, onHover, className = '' }: ServerButtonProps) => (
+  <button
+    type='button'
+    className={`${active ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 border border-black p-2 dark:border-gray-600 focus:outline-none ${className}`}
+    onMouseEnter={() => onHover(true)}
+    onMouseLeave={() => onHover(false)}
+    onFocus={() => onHover(true)}
+    onBlur={() => onHover(false)}
+  >
+    <p>{label}</p>
+  </button>
+);
 
 /**
  * @description React component for comparing AsyncAPI servers between versions 2.x and 3.0.
@@ -21,130 +43,49 @@ export default function Asyncapi3ServerComparison({ className = '' }: Asyncapi3S
 
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 2.x</h3>
-        <div>
-          <div className='m-2 border border-blue-300 p-2 dark:border-blue-700'>
-            Servers
-            <div className='flex flex-1 flex-col flex-wrap'>
-              <div className='m-2 border border-blue-600 p-2 dark:border-blue-700'>
-                Server
-                <div className='flex flex-1 flex-wrap'>
-                  <button
-                    type='button'
-                    className={`${hoverState.Host || hoverState.Path ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600 focus:outline-none`}
-                    onMouseOver={() =>
-                      setHoverState((prevState) => ({
-                        ...prevState,
-                        Host: true,
-                        Path: true
-                      }))
-                    }
-                    onMouseLeave={() =>
-                      setHoverState((prevState) => ({
-                        ...prevState,
-                        Host: false,
-                        Path: false
-                      }))
-                    }
-                    onFocus={() =>
-                      setHoverState((prevState) => ({
-                        ...prevState,
-                        Host: true,
-                        Path: true
-                      }))
-                    }
-                    onBlur={() =>
-                      setHoverState((prevState) => ({
-                        ...prevState,
-                        Host: false,
-                        Path: false
-                      }))
-                    }
-                  >
-                    <p>Url</p>
-                  </button>
-                </div>
+      <Column title='AsyncAPI 2.x'>
+        <div className='m-2 border border-blue-300 p-2 dark:border-blue-700'>
+          Servers
+          <div className='flex flex-1 flex-col flex-wrap'>
+            <div className='m-2 border border-blue-600 p-2 dark:border-blue-700'>
+              Server
+              <div className='flex flex-1 flex-wrap'>
+                <ServerButton
+                  label='Url'
+                  active={hoverState.Host || hoverState.Path}
+                  onHover={(val) => setHoverState({ Host: val, Path: val })}
+                  className='flex flex-1 items-center justify-center'
+                />
               </div>
             </div>
           </div>
         </div>
-      </div>
-      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 3.0</h3>
-        <div>
-          <div className='m-2 border border-blue-300 p-2 dark:border-blue-700'>
-            Servers
-            <div className='flex flex-1 flex-col flex-wrap'>
-              <div className='m-2 border border-blue-600 p-2 dark:border-blue-700'>
-                Server
-                <div className='flex flex-1 flex-wrap'>
-                  <button
-                    type='button'
-                    className={`${hoverState.Host ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600 focus:outline-none`}
-                    onMouseOver={() =>
-                      setHoverState((prevState) => ({
-                        ...prevState,
-                        Host: true
-                      }))
-                    }
-                    onMouseLeave={() =>
-                      setHoverState((prevState) => ({
-                        ...prevState,
-                        Host: false
-                      }))
-                    }
-                    onFocus={() =>
-                      setHoverState((prevState) => ({
-                        ...prevState,
-                        Host: true
-                      }))
-                    }
-                    onBlur={() =>
-                      setHoverState((prevState) => ({
-                        ...prevState,
-                        Host: false
-                      }))
-                    }
-                  >
-                    <p>Host</p>
-                  </button>
-                  <button
-                    type='button'
-                    className={`${hoverState.Path ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600 focus:outline-none`}
-                    onMouseOver={() =>
-                      setHoverState((prevState) => ({
-                        ...prevState,
-                        Path: true
-                      }))
-                    }
-                    onMouseLeave={() =>
-                      setHoverState((prevState) => ({
-                        ...prevState,
-                        Path: false
-                      }))
-                    }
-                    onFocus={() =>
-                      setHoverState((prevState) => ({
-                        ...prevState,
-                        Path: true
-                      }))
-                    }
-                    onBlur={() =>
-                      setHoverState((prevState) => ({
-                        ...prevState,
-                        Path: false
-                      }))
-                    }
-                  >
-                    <p>Pathname</p>
-                  </button>
-                </div>
+      </Column>
+
+      <Column title='AsyncAPI 3.0'>
+        <div className='m-2 border border-blue-300 p-2 dark:border-blue-700'>
+          Servers
+          <div className='flex flex-1 flex-col flex-wrap'>
+            <div className='m-2 border border-blue-600 p-2 dark:border-blue-700'>
+              Server
+              <div className='flex flex-1 flex-wrap'>
+                <ServerButton
+                  label='Host'
+                  active={hoverState.Host}
+                  onHover={(val) => setHoverState((prev) => ({ ...prev, Host: val }))}
+                  className='mr-1 box-border flex-1'
+                />
+                <ServerButton
+                  label='Pathname'
+                  active={hoverState.Path}
+                  onHover={(val) => setHoverState((prev) => ({ ...prev, Path: val }))}
+                  className='mr-1 box-border flex-1'
+                />
               </div>
             </div>
           </div>
         </div>
-      </div>
+      </Column>
     </div>
   );
 }

--- a/components/Asyncapi3Comparison/Asyncapi3ServerComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ServerComparison.tsx
@@ -32,6 +32,7 @@ export default function Asyncapi3ServerComparison({ className = '' }: Asyncapi3S
                 <div className='flex flex-1 flex-wrap'>
                   <div
                     className={`${hoverState.Host || hoverState.Path ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600`}
+                    tabIndex={0}
                     onMouseOver={() =>
                       setHoverState((prevState) => ({
                         ...prevState,
@@ -40,6 +41,20 @@ export default function Asyncapi3ServerComparison({ className = '' }: Asyncapi3S
                       }))
                     }
                     onMouseLeave={() =>
+                      setHoverState((prevState) => ({
+                        ...prevState,
+                        Host: false,
+                        Path: false
+                      }))
+                    }
+                    onFocus={() =>
+                      setHoverState((prevState) => ({
+                        ...prevState,
+                        Host: true,
+                        Path: true
+                      }))
+                    }
+                    onBlur={() =>
                       setHoverState((prevState) => ({
                         ...prevState,
                         Host: false,
@@ -66,6 +81,7 @@ export default function Asyncapi3ServerComparison({ className = '' }: Asyncapi3S
                 <div className='flex flex-1 flex-wrap'>
                   <div
                     className={`${hoverState.Host ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600`}
+                    tabIndex={0}
                     onMouseOver={() =>
                       setHoverState((prevState) => ({
                         ...prevState,
@@ -78,11 +94,24 @@ export default function Asyncapi3ServerComparison({ className = '' }: Asyncapi3S
                         Host: false
                       }))
                     }
+                    onFocus={() =>
+                      setHoverState((prevState) => ({
+                        ...prevState,
+                        Host: true
+                      }))
+                    }
+                    onBlur={() =>
+                      setHoverState((prevState) => ({
+                        ...prevState,
+                        Host: false
+                      }))
+                    }
                   >
                     <p>Host</p>
                   </div>
                   <div
                     className={`${hoverState.Path ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600`}
+                    tabIndex={0}
                     onMouseOver={() =>
                       setHoverState((prevState) => ({
                         ...prevState,
@@ -90,6 +119,18 @@ export default function Asyncapi3ServerComparison({ className = '' }: Asyncapi3S
                       }))
                     }
                     onMouseLeave={() =>
+                      setHoverState((prevState) => ({
+                        ...prevState,
+                        Path: false
+                      }))
+                    }
+                    onFocus={() =>
+                      setHoverState((prevState) => ({
+                        ...prevState,
+                        Path: true
+                      }))
+                    }
+                    onBlur={() =>
                       setHoverState((prevState) => ({
                         ...prevState,
                         Path: false

--- a/components/Asyncapi3Comparison/Asyncapi3ServerComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ServerComparison.tsx
@@ -21,19 +21,31 @@ export default function Asyncapi3ServerComparison({ className = '' }: Asyncapi3S
 
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <div className='ml-1 flex-1 border border-black p-2'>
+      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
         <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 2.x</h3>
         <div>
-          <div className='m-2 border border-blue-300 p-2'>
+          <div className='m-2 border border-blue-300 p-2 dark:border-blue-700'>
             Servers
             <div className='flex flex-1 flex-col flex-wrap'>
-              <div className='m-2 border border-blue-600 p-2'>
+              <div className='m-2 border border-blue-600 p-2 dark:border-blue-700'>
                 Server
                 <div className='flex flex-1 flex-wrap'>
                   <div
-                    className={`${hoverState.Host || hoverState.Path ? 'bg-pink-300' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2`}
-                    onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Host: true, Path: true }))}
-                    onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Host: false, Path: false }))}
+                    className={`${hoverState.Host || hoverState.Path ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600`}
+                    onMouseOver={() =>
+                      setHoverState((prevState) => ({
+                        ...prevState,
+                        Host: true,
+                        Path: true
+                      }))
+                    }
+                    onMouseLeave={() =>
+                      setHoverState((prevState) => ({
+                        ...prevState,
+                        Host: false,
+                        Path: false
+                      }))
+                    }
                   >
                     <p>Url</p>
                   </div>
@@ -43,26 +55,46 @@ export default function Asyncapi3ServerComparison({ className = '' }: Asyncapi3S
           </div>
         </div>
       </div>
-      <div className='ml-1 flex-1 border border-black p-2'>
+      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
         <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 3.0</h3>
         <div>
-          <div className='m-2 border border-blue-300 p-2'>
+          <div className='m-2 border border-blue-300 p-2 dark:border-blue-700'>
             Servers
             <div className='flex flex-1 flex-col flex-wrap'>
-              <div className='m-2 border border-blue-600 p-2'>
+              <div className='m-2 border border-blue-600 p-2 dark:border-blue-700'>
                 Server
                 <div className='flex flex-1 flex-wrap'>
                   <div
-                    className={`${hoverState.Host ? 'bg-pink-300' : ' '} m-2 mr-1 box-border flex-1 border border-black p-2`}
-                    onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Host: true }))}
-                    onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Host: false }))}
+                    className={`${hoverState.Host ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600`}
+                    onMouseOver={() =>
+                      setHoverState((prevState) => ({
+                        ...prevState,
+                        Host: true
+                      }))
+                    }
+                    onMouseLeave={() =>
+                      setHoverState((prevState) => ({
+                        ...prevState,
+                        Host: false
+                      }))
+                    }
                   >
                     <p>Host</p>
                   </div>
                   <div
-                    className={`${hoverState.Path ? 'bg-pink-300' : ' '} m-2 mr-1 box-border flex-1 border border-black p-2`}
-                    onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Path: true }))}
-                    onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Path: false }))}
+                    className={`${hoverState.Path ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600`}
+                    onMouseOver={() =>
+                      setHoverState((prevState) => ({
+                        ...prevState,
+                        Path: true
+                      }))
+                    }
+                    onMouseLeave={() =>
+                      setHoverState((prevState) => ({
+                        ...prevState,
+                        Path: false
+                      }))
+                    }
                   >
                     <p>Pathname</p>
                   </div>

--- a/components/Asyncapi3Comparison/Asyncapi3ServerComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ServerComparison.tsx
@@ -32,7 +32,6 @@ export default function Asyncapi3ServerComparison({ className = '' }: Asyncapi3S
                 <div className='flex flex-1 flex-wrap'>
                   <div
                     className={`${hoverState.Host || hoverState.Path ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2 dark:border-gray-600`}
-                    tabIndex={0}
                     onMouseOver={() =>
                       setHoverState((prevState) => ({
                         ...prevState,
@@ -81,7 +80,6 @@ export default function Asyncapi3ServerComparison({ className = '' }: Asyncapi3S
                 <div className='flex flex-1 flex-wrap'>
                   <div
                     className={`${hoverState.Host ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600`}
-                    tabIndex={0}
                     onMouseOver={() =>
                       setHoverState((prevState) => ({
                         ...prevState,
@@ -111,7 +109,6 @@ export default function Asyncapi3ServerComparison({ className = '' }: Asyncapi3S
                   </div>
                   <div
                     className={`${hoverState.Path ? 'bg-pink-300 dark:bg-pink-900/60' : ' '} m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600`}
-                    tabIndex={0}
                     onMouseOver={() =>
                       setHoverState((prevState) => ({
                         ...prevState,

--- a/components/Asyncapi3Comparison/ComparisonCommon.tsx
+++ b/components/Asyncapi3Comparison/ComparisonCommon.tsx
@@ -26,6 +26,7 @@ interface HoverBoxProps<T> {
   useMouseOver?: boolean;
   children?: React.ReactNode;
   className?: string;
+  focusable?: boolean;
 }
 
 /**
@@ -41,7 +42,8 @@ export function HoverBox<T>({
   borderClass,
   useMouseOver = false,
   children,
-  className = ''
+  className = '',
+  focusable = false
 }: Readonly<HoverBoxProps<T>>) {
   const hovered = hoverState[fieldKey];
   const setHover = (val: boolean) => setHoverState((prev) => ({ ...prev, [fieldKey]: val }));
@@ -50,11 +52,24 @@ export function HoverBox<T>({
     ? { onMouseOver: () => setHover(true), onMouseLeave: () => setHover(false) }
     : { onMouseEnter: () => setHover(true), onMouseLeave: () => setHover(false) };
 
+  if (focusable) {
+    return (
+      <button
+        type='button'
+        className={`${hovered ? activeClass : defaultClass} m-2 border ${borderClass} p-2 focus:outline-none text-left block w-full ${className}`}
+        onFocus={() => setHover(true)}
+        onBlur={() => setHover(false)}
+        {...hoverProps}
+      >
+        {label}
+        {children}
+      </button>
+    );
+  }
+
   return (
     <div
       className={`${hovered ? activeClass : defaultClass} m-2 border ${borderClass} p-2 ${className}`}
-      onFocus={() => setHover(true)}
-      onBlur={() => setHover(false)}
       {...hoverProps}
     >
       {label}

--- a/components/Asyncapi3Comparison/ComparisonCommon.tsx
+++ b/components/Asyncapi3Comparison/ComparisonCommon.tsx
@@ -15,7 +15,7 @@ export const Column = ({ title, children }: ColumnProps) => (
   </div>
 );
 
-interface HoverBoxProps<T> {
+interface HoverBoxProps<T extends { [K in keyof T]: boolean }> {
   label: string | React.ReactNode;
   fieldKey: keyof T;
   hoverState: T;
@@ -32,7 +32,7 @@ interface HoverBoxProps<T> {
 /**
  * Reusable wrapper that manages hover states, hover event handlers, and styling dynamically.
  */
-export function HoverBox<T>({
+export function HoverBox<T extends { [K in keyof T]: boolean }>({
   label,
   fieldKey,
   hoverState,

--- a/components/Asyncapi3Comparison/ComparisonCommon.tsx
+++ b/components/Asyncapi3Comparison/ComparisonCommon.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+interface ColumnProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Standard side-by-side comparison column.
+ */
+export const Column = ({ title, children }: ColumnProps) => (
+  <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
+    <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>{title}</h3>
+    <div>{children}</div>
+  </div>
+);
+
+interface HoverBoxProps<T> {
+  label: string | React.ReactNode;
+  fieldKey: keyof T;
+  hoverState: T;
+  setHoverState: React.Dispatch<React.SetStateAction<T>>;
+  activeClass: string;
+  defaultClass?: string;
+  borderClass: string;
+  useMouseOver?: boolean;
+  children?: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Reusable wrapper that manages hover states, hover event handlers, and styling dynamically.
+ */
+export function HoverBox<T>({
+  label,
+  fieldKey,
+  hoverState,
+  setHoverState,
+  activeClass,
+  defaultClass = 'bg-white dark:bg-gray-900',
+  borderClass,
+  useMouseOver = false,
+  children,
+  className = ''
+}: HoverBoxProps<T>) {
+  const hovered = hoverState[fieldKey];
+  const setHover = (val: boolean) => setHoverState((prev) => ({ ...prev, [fieldKey]: val }));
+
+  const hoverProps = useMouseOver
+    ? { onMouseOver: () => setHover(true), onMouseLeave: () => setHover(false) }
+    : { onMouseEnter: () => setHover(true), onMouseLeave: () => setHover(false) };
+
+  return (
+    <div
+      className={`${hovered ? activeClass : defaultClass} m-2 border ${borderClass} p-2 ${className}`}
+      tabIndex={0}
+      onFocus={() => setHover(true)}
+      onBlur={() => setHover(false)}
+      {...hoverProps}
+    >
+      {label}
+      {children}
+    </div>
+  );
+}

--- a/components/Asyncapi3Comparison/ComparisonCommon.tsx
+++ b/components/Asyncapi3Comparison/ComparisonCommon.tsx
@@ -42,7 +42,7 @@ export function HoverBox<T>({
   useMouseOver = false,
   children,
   className = ''
-}: HoverBoxProps<T>) {
+}: Readonly<HoverBoxProps<T>>) {
   const hovered = hoverState[fieldKey];
   const setHover = (val: boolean) => setHoverState((prev) => ({ ...prev, [fieldKey]: val }));
 
@@ -53,7 +53,6 @@ export function HoverBox<T>({
   return (
     <div
       className={`${hovered ? activeClass : defaultClass} m-2 border ${borderClass} p-2 ${className}`}
-      tabIndex={0}
       onFocus={() => setHover(true)}
       onBlur={() => setHover(false)}
       {...hoverProps}


### PR DESCRIPTION
ref - https://github.com/asyncapi/website/pull/5253#issuecomment-4556732392

## Description

- Updated AsyncAPI v3 migration comparison components to support dark mode styling.
- Added dark mode classes for borders, backgrounds, text colors, and hover states.
- Improved readability and visual consistency of comparison diagrams on the v3 migration docs page.

## Screenshots

### Before : Dark theme

<img width="983" height="219" alt="Screenshot 2026-05-27 at 22 56 40" src="https://github.com/user-attachments/assets/04ca67ba-d751-48d4-8f89-e6308f7bbd74" />

<img width="978" height="279" alt="Screenshot 2026-05-27 at 22 56 46" src="https://github.com/user-attachments/assets/d9c47129-2a19-4d2e-a17f-45c29495a9c4" />

<img width="974" height="271" alt="Screenshot 2026-05-27 at 22 57 07" src="https://github.com/user-attachments/assets/719f8fbc-9fcc-46e0-8177-c3005d3f0f7e" />

<img width="960" height="551" alt="Screenshot 2026-05-27 at 22 57 31" src="https://github.com/user-attachments/assets/e4ccd937-4d9a-4b74-884d-1aa1d1144aa6" />

### After : Dark theme

<img width="971" height="211" alt="Screenshot 2026-05-27 at 22 54 18" src="https://github.com/user-attachments/assets/4686b1e9-a8d8-4211-9d71-d9c5bad177b5" />

<img width="978" height="264" alt="Screenshot 2026-05-27 at 22 54 24" src="https://github.com/user-attachments/assets/ca98a1eb-68d3-4560-b127-6913c99c5e44" />

<img width="967" height="701" alt="Screenshot 2026-05-27 at 22 54 32" src="https://github.com/user-attachments/assets/826b0b35-2f2a-42de-ac9b-0c64a6228082" />

<img width="966" height="257" alt="Screenshot 2026-05-27 at 22 54 41" src="https://github.com/user-attachments/assets/a33c154e-aea5-427b-a156-eb5bf87244b3" />

<img width="968" height="262" alt="Screenshot 2026-05-27 at 22 54 48" src="https://github.com/user-attachments/assets/f978cbf7-70bb-4732-8f03-da81f5ca9286" />

<img width="982" height="387" alt="Screenshot 2026-05-27 at 22 54 57" src="https://github.com/user-attachments/assets/c4dc5bb3-a7a6-4ae0-8750-0be0964be14b" />

<img width="986" height="587" alt="Screenshot 2026-05-27 at 22 55 05" src="https://github.com/user-attachments/assets/65e0a95c-6727-4d55-9d94-d3d9f5fed2f5" />

## Reproduce Guide

Navigate to:

https://deploy-preview-5499--asyncapi-website.netlify.app/docs/migration/migrating-to-v3

1. Switch the website to dark mode.
2. Scroll to the comparison sections on the page.
3. Hover over the interactive comparison boxes to verify their dark mode hover states.

## Related issue(s)

- https://github.com/asyncapi/website/pull/5253#issuecomment-4556732392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable comparison panels and a generic hover-enabled tile component used across AsyncAPI comparisons.
* **Refactor**
  * Consolidated many comparison views onto the shared components, unifying hover behavior, focus handling, and interaction wiring.
* **Style**
  * Expanded dark-mode styling and refined hover/active visuals across channels, operations, parameters, servers, metadata, schema, and ID/address comparisons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->