### PR TITLE
fix(e2e): make events page test resilient to empty states

### DIFF
--- a/cypress/pages/events.js
+++ b/cypress/pages/events.js
@@ -31,18 +31,25 @@ class EventsPage extends BasePage {
         new RegExp(`^${label}$`, 'i'),
       )
       .click();
-    cy.get('[data-testid="EventPostItem-main"]').should('be.visible');
   }
 
   verifyEventCards() {
-    cy.get('[data-testid="EventPostItem-main"]')
-      .should('have.length.greaterThan', 0)
-      .each(($card) => {
-        cy.wrap($card)
-          .find('a[data-testid="EventPostItem-link"]')
-          .should('have.attr', 'href')
-          .and('match', /github\.com\/asyncapi\/community\/issues\/\d+/);
-      });
+    cy.get('body').should(($body) => {
+      const hasEvents = $body.find('[data-testid="EventPostItem-main"]').length > 0;
+      const hasNoEventsMsg = $body.text().includes('No Events. Check back later!');
+      expect(hasEvents || hasNoEventsMsg).to.be.true;
+    }).then(($body) => {
+      const hasEvents = $body.find('[data-testid="EventPostItem-main"]').length > 0;
+      if (hasEvents) {
+        cy.get('[data-testid="EventPostItem-main"]')
+          .each(($card) => {
+            cy.wrap($card)
+              .find('a[data-testid="EventPostItem-link"]')
+              .should('have.attr', 'href')
+              .and('match', /github\.com\/asyncapi\/community\/issues\/\d+/);
+          });
+      }
+    });
   }
 
   switchToAll() {


### PR DESCRIPTION
This PR fixes a CI flakiness issue where the `events.cy.js` test would fail if there are no upcoming events in the configuration. 

The test previously expected event cards to always be visible after clicking the 'Upcoming' filter. It has been updated to check for either the presence of event cards or the 'No Events. Check back later!' message, ensuring the test passes consistently regardless of the time-dependent mock data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved event display test validation to properly handle both populated and empty event list states, ensuring comprehensive coverage of edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->