### PR TITLE
fix: remove unwanted white background from FlyoutMenu component

### DIFF
--- a/components/navigation/FlyoutMenu.tsx
+++ b/components/navigation/FlyoutMenu.tsx
@@ -14,7 +14,7 @@ interface FlyoutProps {
 export default function Flyout({ items = [] }: FlyoutProps) {
   return (
     <div
-      className='absolute z-50 bg-white rounded-lg -ml-4 shadow-lg overflow-x-auto
+      className='absolute z-50 rounded-lg -ml-4 shadow-lg overflow-x-auto
         w-screen max-w-md pt-3 md:max-h-[80vh] md:ml-12 md:-translate-x-1/2
         lg:left-1/2 lg:max-w-3xl lg:-translate-x-1/2'
       data-testid='Flyout-main'


### PR DESCRIPTION
ref - https://github.com/asyncapi/website/pull/5253#issuecomment-4567131374

**Description:**

- Removed the `bg-white` utility class from the outermost wrapper `<div>` of the `FlyoutMenu` component.
- Fixed a visual issue where a white rectangular block awkwardly appeared above the dropdown menu content.

**Steps to Reproduce:**

1. Open the website and locate the main navigation bar.
2. Open a dropdown menu that uses the flyout component (e.g., click/hover on the "Tools" option).
3. Observe the space just above the opened dropdown container.
4. Notice that there is no longer a white block sitting on top of the menu; the gap is now perfectly transparent.
5. Toggle between light and dark themes to verify the gap properly remains transparent in both modes.

**Screenshots:**

| Before | After |
|--------|--------|
| <img width="450" alt="Before Light" src="https://github.com/user-attachments/assets/36055874-55c9-49a6-8e71-d43ab673c4c5" /> | <img width="450" alt="After Light" src="https://github.com/user-attachments/assets/d667c643-f070-4f45-8920-1daae6ce78a7" /> |
| <img width="450" alt="Before Dark" src="https://github.com/user-attachments/assets/ecea4b99-805c-4126-84a8-c3bde8dd6858" /> | <img width="450" alt="After Dark" src="https://github.com/user-attachments/assets/a372d7ce-4fec-4d1c-aece-9a2eddbaacd3" /> |

