### PR TITLE
fix: mermaid dark theme 

### DIFF
--- a/components/MDX/MDX.tsx
+++ b/components/MDX/MDX.tsx
@@ -72,10 +72,17 @@ const MERMAID_THEME_VARIABLES: Record<MermaidTheme, Record<string, string>> = {
     primaryTextColor: '#F8FAFC',
     tertiaryColor: '#121825',
     tertiaryBorderColor: '#475569',
-    lineColor: '#94A3B8'
+    lineColor: '#94A3B8',
+    mainBkg: '#1E293B',
+    secondBkg: '#2E2459',
+    tertiaryBkg: '#121825',
+    clusterBkg: '#121825',
+    clusterBorder: '#475569',
+    edgeLabelBackground: '#1E293B'
   }
 };
 
+// Cache the theme Mermaid was initialized with across client-side page transitions.
 let initializedMermaidTheme: MermaidTheme | null = null;
 
 /**
@@ -102,6 +109,7 @@ function initializeMermaid(theme: MermaidTheme) {
     startOnLoad: false,
     theme: 'base',
     securityLevel: 'strict',
+    // Keep Mermaid styling fully controlled by MERMAID_THEME_VARIABLES.
     themeCSS: '',
     themeVariables: MERMAID_THEME_VARIABLES[theme]
   });
@@ -145,20 +153,30 @@ function MermaidDiagram({ graph }: MermaidDiagramProps) {
    * @description Renders the Mermaid diagram.
    */
   useEffect(() => {
+    let mounted = true;
+
     if (graph) {
       try {
         initializeMermaid(theme);
-        mermaid.mermaidAPI.render(uuid(), graph, (svgGraph) => {
-          setSvg(svgGraph);
+        mermaid.mermaidAPI.render(uuid(), graph.trim(), (svgGraph) => {
+          if (mounted) {
+            setSvg(svgGraph);
+          }
         });
       } catch (e) {
-        setSvg(null);
+        if (mounted) {
+          setSvg(null);
+        }
         // eslint-disable-next-line no-console
         console.error(e);
       }
     } else {
       setSvg(null);
     }
+
+    return () => {
+      mounted = false;
+    };
   }, [graph, theme]);
 
   return <div dangerouslySetInnerHTML={{ __html: svg || '' }} />;

--- a/components/MDX/MDX.tsx
+++ b/components/MDX/MDX.tsx
@@ -41,38 +41,71 @@ import Sponsors from '../sponsors/PlatinumSponsors';
 import Warning from '../Warning';
 import { Table, TableBody, TableCell, TableHeader, TableRow, Thead } from './MDXTable';
 
-let mermaidInitialized = false;
+type MermaidTheme = 'light' | 'dark';
+
+const MERMAID_THEME_VARIABLES: Record<MermaidTheme, Record<string, string>> = {
+  light: {
+    primaryColor: '#EDFAFF',
+    primaryBorderColor: '#47BCEE',
+    secondaryColor: '#F4EFFC',
+    secondaryBorderColor: '#875AE2',
+    fontFamily: 'Inter, sans-serif',
+    fontSize: '18px',
+    primaryTextColor: '#242929',
+    tertiaryColor: '#F7F9FA',
+    tertiaryBorderColor: '#BFC6C7',
+    lineColor: '#BFC6C7',
+    mainBkg: '#EDFAFF',
+    secondBkg: '#F4EFFC',
+    tertiaryBkg: '#F7F9FA',
+    clusterBkg: '#F7F9FA',
+    clusterBorder: '#BFC6C7',
+    edgeLabelBackground: '#FFFFFF'
+  },
+  dark: {
+    primaryColor: '#1E293B',
+    primaryBorderColor: '#38BDF8',
+    secondaryColor: '#2E2459',
+    secondaryBorderColor: '#A87EFC',
+    fontFamily: 'Inter, sans-serif',
+    fontSize: '18px',
+    primaryTextColor: '#F8FAFC',
+    tertiaryColor: '#121825',
+    tertiaryBorderColor: '#475569',
+    lineColor: '#94A3B8'
+  }
+};
+
+let initializedMermaidTheme: MermaidTheme | null = null;
 
 /**
- * @description Initializes the Mermaid library if not already initialized.
+ * @description Returns the Mermaid theme that matches the current website theme.
  */
-function initializeMermaid() {
-  if (mermaidInitialized) {
+function getMermaidTheme(): MermaidTheme {
+  if (typeof document === 'undefined') {
+    return 'light';
+  }
+
+  return document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+}
+
+/**
+ * @description Initializes the Mermaid library for the selected theme.
+ */
+function initializeMermaid(theme: MermaidTheme) {
+  if (initializedMermaidTheme === theme) {
     return;
   }
 
-  mermaidInitialized = true;
+  initializedMermaidTheme = theme;
   mermaid.initialize({
-    startOnLoad: true,
+    startOnLoad: false,
     theme: 'base',
     securityLevel: 'loose',
     themeCSS: '',
-    themeVariables: {
-      primaryColor: '#EDFAFF',
-      primaryBorderColor: '#47BCEE',
-      secondaryColor: '#F4EFFC',
-      secondaryBorderColor: '#875AE2',
-      fontFamily: 'Inter, sans-serif',
-      fontSize: '18px',
-      primaryTextColor: '#242929',
-      tertiaryColor: '#F7F9FA',
-      tertiaryBorderColor: '#BFC6C7',
-      lineColor: '#BFC6C7'
-    }
+    themeVariables: MERMAID_THEME_VARIABLES[theme]
   });
 }
-
-initializeMermaid();
 
 let currentId = 0;
 
@@ -94,27 +127,41 @@ interface MermaidDiagramProps {
  */
 function MermaidDiagram({ graph }: MermaidDiagramProps) {
   const [svg, setSvg] = useState<string | null>(null);
+  const [theme, setTheme] = useState<MermaidTheme>('light');
+
+  useEffect(() => {
+    setTheme(getMermaidTheme());
+
+    const observer = new MutationObserver(() => {
+      setTheme(getMermaidTheme());
+    });
+
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+
+    return () => observer.disconnect();
+  }, []);
 
   /**
    * @description Renders the Mermaid diagram.
    */
   useEffect(() => {
-    if (!graph) {
-      return;
-    }
-
-    try {
-      mermaid.mermaidAPI.render(uuid(), graph, (svgGraph) => {
-        setSvg(svgGraph);
-      });
-    } catch (e) {
+    if (graph) {
+      try {
+        initializeMermaid(theme);
+        mermaid.mermaidAPI.render(uuid(), graph, (svgGraph) => {
+          setSvg(svgGraph);
+        });
+      } catch (e) {
+        setSvg(null);
+        // eslint-disable-next-line no-console
+        console.error(e);
+      }
+    } else {
       setSvg(null);
-      // eslint-disable-next-line no-console
-      console.error(e);
     }
-  }, [graph]);
+  }, [graph, theme]);
 
-  return svg ? <div dangerouslySetInnerHTML={{ __html: svg }} /> : null;
+  return <div dangerouslySetInnerHTML={{ __html: svg || '' }} />;
 }
 
 interface CodeComponentProps {

--- a/components/MDX/MDX.tsx
+++ b/components/MDX/MDX.tsx
@@ -101,7 +101,7 @@ function initializeMermaid(theme: MermaidTheme) {
   mermaid.initialize({
     startOnLoad: false,
     theme: 'base',
-    securityLevel: 'loose',
+    securityLevel: 'strict',
     themeCSS: '',
     themeVariables: MERMAID_THEME_VARIABLES[theme]
   });


### PR DESCRIPTION
ref - https://github.com/asyncapi/website/pull/5253#issuecomment-4533042338
## Description

* Adds dark theme support for Mermaid diagrams rendered from MDX code blocks.
* Reinitializes Mermaid with light or dark theme variables based on the `html.dark` class.
* Re-renders Mermaid diagrams when the site theme changes, while keeping the initial render hydration-safe.

## Screenshots

| Theme | Before | After |
| :--- | :--- | :--- |
| **Light Theme** | <img width="969" height="468" alt="Screenshot 2026-05-29 at 01 23 21" src="https://github.com/user-attachments/assets/fe4e999e-7938-4c6f-aa91-805b1f8902a2" /> | <img width="969" height="468" alt="Screenshot 2026-05-29 at 01 23 21" src="https://github.com/user-attachments/assets/fe4e999e-7938-4c6f-aa91-805b1f8902a2" /> |
| **Dark Theme** | <img width="1000" height="576" alt="Screenshot 2026-05-29 at 01 16 05" src="https://github.com/user-attachments/assets/b27701fa-bedf-49a1-9c7e-f08590ef5572" /> | <img width="963" height="542" alt="Screenshot 2026-05-29 at 01 15 38" src="https://github.com/user-attachments/assets/b0c0638d-e65b-472a-b1c1-701ef003d704" /> |

## Steps to Reproduce

1. Navigate to the Deploy Preview: [https://deploy-preview-5512--asyncapi-website.netlify.app/docs/guides/message-validation](https://deploy-preview-5512--asyncapi-website.netlify.app/docs/guides/message-validation)
2. Check the diagrams by toggling between light and dark themes.
3. Resize the viewport to ensure the diagrams render correctly across different screen sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mermaid diagrams now properly display in light and dark modes, automatically adapting to your current site theme preference
  * Diagrams update dynamically when you switch between light and dark themes, ensuring consistent visual appearance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->