### PR TITLE
fix: improve OpenAPI comparison diagram dark mode styling

### DIFF
--- a/components/Asyncapi3Comparison/Asyncapi3ChannelComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ChannelComparison.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Column, HoverBox } from './ComparisonCommon';
+import { Column, HoverBox } from '../ComparisonCommon';
 
 export interface HoverState {
   Paths: boolean;

--- a/components/Asyncapi3Comparison/Asyncapi3ChannelComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ChannelComparison.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Column, HoverBox } from '../ComparisonCommon';
+import { Column, ComparisonBox, HoverBox } from '../ComparisonCommon';
 
 export interface HoverState {
   Paths: boolean;
@@ -13,12 +13,16 @@ export interface AsyncAPI3ChannelComparisonProps {
   className?: string;
 }
 
+/**
+ * Static nested box showing the Message structure (Headers + Payload).
+ * Used identically in both the AsyncAPI 2.x and AsyncAPI 3.0 columns.
+ */
 const MessageDetails = () => (
-  <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>
+  <ComparisonBox className='mr-1 box-border flex-1'>
     Message
-    <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>Headers</div>
-    <div className='m-2 mr-1 box-border flex-1 border border-black p-2 dark:border-gray-600'>Payload</div>
-  </div>
+    <ComparisonBox className='mr-1 box-border flex-1'>Headers</ComparisonBox>
+    <ComparisonBox className='mr-1 box-border flex-1'>Payload</ComparisonBox>
+  </ComparisonBox>
 );
 
 /**

--- a/components/Asyncapi3Comparison/Asyncapi3ChannelComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ChannelComparison.tsx
@@ -46,7 +46,7 @@ export default function Asyncapi3ChannelComparison({ className = '' }: AsyncAPI3
           hoverState={hoverState}
           setHoverState={setHoverState}
           activeClass='bg-yellow-100 dark:bg-yellow-900/40'
-          defaultClass=' '
+          defaultClass=''
           borderClass='border-yellow-300 dark:border-yellow-700'
         >
           <div className='flex flex-1 flex-wrap'>
@@ -99,7 +99,7 @@ export default function Asyncapi3ChannelComparison({ className = '' }: AsyncAPI3
           hoverState={hoverState}
           setHoverState={setHoverState}
           activeClass='bg-yellow-100 dark:bg-yellow-900/40'
-          defaultClass=' '
+          defaultClass=''
           borderClass='border-yellow-300 dark:border-yellow-700'
         >
           <HoverBox<HoverState>
@@ -133,24 +133,50 @@ export default function Asyncapi3ChannelComparison({ className = '' }: AsyncAPI3
           hoverState={hoverState}
           setHoverState={setHoverState}
           activeClass='bg-yellow-100 dark:bg-yellow-900/40'
-          defaultClass=' '
+          defaultClass=''
           borderClass='border-yellow-300 dark:border-yellow-700'
         >
           <div className='flex flex-1 flex-wrap'>
-            <div className='m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700'>
-              Operation
+            <HoverBox<HoverState>
+              label='Operation'
+              fieldKey='Operation'
+              hoverState={hoverState}
+              setHoverState={setHoverState}
+              activeClass='bg-orange-100 dark:bg-orange-900/40'
+              borderClass='border-orange-300 dark:border-orange-700'
+              className='flex-1'
+              useMouseOver
+            >
               <div className='flex flex-1 flex-col flex-wrap'>
-                <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200 dark:border-blue-400 dark:bg-gray-900 dark:hover:bg-blue-900/50'>
-                  action (send or receive)
-                </div>
-                <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200 dark:border-blue-400 dark:bg-gray-900 dark:hover:bg-blue-900/50'>
-                  channel
-                </div>
-                <div className='m-2 border border-blue-500 bg-white p-2 hover:bg-blue-200 dark:border-blue-400 dark:bg-gray-900 dark:hover:bg-blue-900/50'>
-                  messages
-                </div>
+                <HoverBox<HoverState>
+                  label='action (send or receive)'
+                  fieldKey='Operation'
+                  hoverState={hoverState}
+                  setHoverState={setHoverState}
+                  activeClass='bg-blue-200 dark:bg-blue-900/50'
+                  borderClass='border-blue-500 dark:border-blue-400'
+                  useMouseOver
+                />
+                <HoverBox<HoverState>
+                  label='channel'
+                  fieldKey='PathItem'
+                  hoverState={hoverState}
+                  setHoverState={setHoverState}
+                  activeClass='bg-yellow-300 dark:bg-yellow-800/60'
+                  borderClass='border-yellow-600 dark:border-yellow-700'
+                  useMouseOver
+                />
+                <HoverBox<HoverState>
+                  label='messages'
+                  fieldKey='Message'
+                  hoverState={hoverState}
+                  setHoverState={setHoverState}
+                  activeClass='bg-red-400 dark:bg-red-900/60'
+                  borderClass='border-red-600 dark:border-red-700'
+                  useMouseOver
+                />
               </div>
-            </div>
+            </HoverBox>
           </div>
         </HoverBox>
       </Column>

--- a/components/Asyncapi3Comparison/Asyncapi3IdAndAddressComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3IdAndAddressComparison.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Column, HoverBox } from './ComparisonCommon';
+import { Column, HoverBox } from '../ComparisonCommon';
 
 export interface HoverState {
   Paths: boolean;

--- a/components/Asyncapi3Comparison/Asyncapi3IdAndAddressComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3IdAndAddressComparison.tsx
@@ -30,7 +30,7 @@ export default function Asyncapi3IdAndAddressComparison({ className = '' }: Asyn
           hoverState={hoverState}
           setHoverState={setHoverState}
           activeClass='bg-yellow-100 dark:bg-yellow-900/40'
-          defaultClass=' '
+          defaultClass=''
           borderClass='border-yellow-300 dark:border-yellow-700'
         >
           <HoverBox<HoverState>
@@ -52,7 +52,7 @@ export default function Asyncapi3IdAndAddressComparison({ className = '' }: Asyn
           hoverState={hoverState}
           setHoverState={setHoverState}
           activeClass='bg-yellow-100 dark:bg-yellow-900/40'
-          defaultClass=' '
+          defaultClass=''
           borderClass='border-yellow-300 dark:border-yellow-700'
         >
           <HoverBox<HoverState>

--- a/components/Asyncapi3Comparison/Asyncapi3MetaComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3MetaComparison.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Column, HoverBox } from './ComparisonCommon';
+import { Column, HoverBox } from '../ComparisonCommon';
 
 export interface Asyncapi3MetaComparisonProps {
   className?: string;

--- a/components/Asyncapi3Comparison/Asyncapi3OperationComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3OperationComparison.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { Column } from '../ComparisonCommon';
+
 export interface Asyncapi3OperationComparisonProps {
   className?: string;
 }
@@ -11,42 +13,36 @@ export interface Asyncapi3OperationComparisonProps {
 export default function Asyncapi3OperationComparison({ className = '' }: Asyncapi3OperationComparisonProps) {
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
-      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 2.x</h3>
-        <div>
-          <div className='m-2 border border-yellow-300 p-2 dark:border-yellow-700'>
-            Channels
-            <div className='flex flex-1 flex-wrap'>
-              <div className='m-2 border border-yellow-600 p-2 dark:border-yellow-700'>
-                Channel Item
-                <div className='flex flex-1 flex-wrap'>
-                  <div className='m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700'>
-                    Operation (Publish and Subscribe)
-                  </div>
+      <Column title='AsyncAPI 2.x'>
+        <div className='m-2 border border-yellow-300 p-2 dark:border-yellow-700'>
+          Channels
+          <div className='flex flex-1 flex-wrap'>
+            <div className='m-2 border border-yellow-600 p-2 dark:border-yellow-700'>
+              Channel Item
+              <div className='flex flex-1 flex-wrap'>
+                <div className='m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700'>
+                  Operation (Publish and Subscribe)
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-      <div className='ml-1 flex-1 border border-black p-2 dark:border-gray-600 dark:text-gray-100'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 3.0</h3>
-        <div>
-          <div className='m-2 border border-yellow-300 p-2 dark:border-yellow-700'>
-            Operations
-            <div className='flex flex-1 flex-wrap'>
-              <div className='m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700'>
-                Operation
-                <div className='flex flex-1 flex-col flex-wrap'>
-                  <div className='m-2 border border-blue-500 bg-white p-2 dark:border-blue-400 dark:bg-gray-900'>
-                    action (send or receive)
-                  </div>
+      </Column>
+      <Column title='AsyncAPI 3.0'>
+        <div className='m-2 border border-yellow-300 p-2 dark:border-yellow-700'>
+          Operations
+          <div className='flex flex-1 flex-wrap'>
+            <div className='m-2 flex-1 border border-orange-300 p-2 dark:border-orange-700'>
+              Operation
+              <div className='flex flex-1 flex-col flex-wrap'>
+                <div className='m-2 border border-blue-500 bg-white p-2 dark:border-blue-400 dark:bg-gray-900'>
+                  action (send or receive)
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      </Column>
     </div>
   );
 }

--- a/components/Asyncapi3Comparison/Asyncapi3ParameterComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ParameterComparison.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Column, HoverBox } from './ComparisonCommon';
+import { Column, HoverBox } from '../ComparisonCommon';
 
 export interface Asyncapi3ParameterComparisonProps {
   className?: string;

--- a/components/Asyncapi3Comparison/Asyncapi3SchemaFormatComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3SchemaFormatComparison.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Column, HoverBox } from './ComparisonCommon';
+import { Column, HoverBox } from '../ComparisonCommon';
 
 export interface Asyncapi3SchemaFormatComparisonProps {
   className?: string;

--- a/components/Asyncapi3Comparison/Asyncapi3ServerComparison.tsx
+++ b/components/Asyncapi3Comparison/Asyncapi3ServerComparison.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Column } from './ComparisonCommon';
+import { Column } from '../ComparisonCommon';
 
 export interface Asyncapi3ServerComparisonProps {
   className?: string;

--- a/components/ComparisonCommon.tsx
+++ b/components/ComparisonCommon.tsx
@@ -74,9 +74,6 @@ export function HoverBox<T extends { [K in keyof T]: boolean }>({
     <div
       className={`${hovered ? activeClass : defaultClass} m-2 border ${borderClass} p-2 ${className}`}
       data-testid={testId}
-      tabIndex={0}
-      onFocus={() => setHover(true)}
-      onBlur={() => setHover(false)}
       {...hoverProps}
     >
       {label}

--- a/components/ComparisonCommon.tsx
+++ b/components/ComparisonCommon.tsx
@@ -81,3 +81,39 @@ export function HoverBox<T extends { [K in keyof T]: boolean }>({
     </div>
   );
 }
+
+/**
+ * A plain bordered box used for non-interactive specification sections
+ * (e.g. "Security", "Id (application identifier)").
+ */
+export const ComparisonBox = ({ children, className = '' }: { children: React.ReactNode; className?: string }) => (
+  <div className={`m-2 border border-black p-2 dark:border-gray-600 ${className}`}>{children}</div>
+);
+
+/**
+ * Two-column grid wrapper that holds a list of ComponentsGridItem entries.
+ */
+export const ComponentsGrid = ({ children }: { children: React.ReactNode }) => (
+  <div className='grid-gap-2 mt-2 grid flex-1 grid-cols-2 flex-wrap'>{children}</div>
+);
+
+/**
+ * A single cell inside a ComponentsGrid — represents one spec component entry.
+ */
+export const ComponentsGridItem = ({ children }: { children: React.ReactNode }) => (
+  <div className='m-2 box-border border border-black bg-gray-100 p-2 dark:border-gray-600 dark:bg-gray-800'>
+    {children}
+  </div>
+);
+
+/**
+ * Renders a ComponentsGrid populated from a plain string array.
+ * Use this instead of repeating <ComponentsGridItem> calls manually.
+ */
+export const ComponentsGridList = ({ items }: { items: string[] }) => (
+  <ComponentsGrid>
+    {items.map((item) => (
+      <ComponentsGridItem key={item}>{item}</ComponentsGridItem>
+    ))}
+  </ComponentsGrid>
+);

--- a/components/ComparisonCommon.tsx
+++ b/components/ComparisonCommon.tsx
@@ -27,6 +27,7 @@ interface HoverBoxProps<T extends { [K in keyof T]: boolean }> {
   children?: React.ReactNode;
   className?: string;
   focusable?: boolean;
+  testId?: string;
 }
 
 /**
@@ -43,7 +44,8 @@ export function HoverBox<T extends { [K in keyof T]: boolean }>({
   useMouseOver = false,
   children,
   className = '',
-  focusable = false
+  focusable = false,
+  testId
 }: Readonly<HoverBoxProps<T>>) {
   const hovered = hoverState[fieldKey];
   const setHover = (val: boolean) => setHoverState((prev) => ({ ...prev, [fieldKey]: val }));
@@ -59,6 +61,7 @@ export function HoverBox<T extends { [K in keyof T]: boolean }>({
         className={`${hovered ? activeClass : defaultClass} m-2 border ${borderClass} p-2 focus:outline-none text-left block w-full ${className}`}
         onFocus={() => setHover(true)}
         onBlur={() => setHover(false)}
+        data-testid={testId}
         {...hoverProps}
       >
         {label}
@@ -70,6 +73,7 @@ export function HoverBox<T extends { [K in keyof T]: boolean }>({
   return (
     <div
       className={`${hovered ? activeClass : defaultClass} m-2 border ${borderClass} p-2 ${className}`}
+      data-testid={testId}
       {...hoverProps}
     >
       {label}

--- a/components/ComparisonCommon.tsx
+++ b/components/ComparisonCommon.tsx
@@ -74,6 +74,10 @@ export function HoverBox<T extends { [K in keyof T]: boolean }>({
     <div
       className={`${hovered ? activeClass : defaultClass} m-2 border ${borderClass} p-2 ${className}`}
       data-testid={testId}
+      tabIndex={0}
+      role='button'
+      onFocus={() => setHover(true)}
+      onBlur={() => setHover(false)}
       {...hoverProps}
     >
       {label}
@@ -94,7 +98,7 @@ export const ComparisonBox = ({ children, className = '' }: { children: React.Re
  * Two-column grid wrapper that holds a list of ComponentsGridItem entries.
  */
 export const ComponentsGrid = ({ children }: { children: React.ReactNode }) => (
-  <div className='grid-gap-2 mt-2 grid flex-1 grid-cols-2 flex-wrap'>{children}</div>
+  <div className='gap-2 mt-2 grid flex-1 grid-cols-2 flex-wrap'>{children}</div>
 );
 
 /**

--- a/components/ComparisonCommon.tsx
+++ b/components/ComparisonCommon.tsx
@@ -75,7 +75,6 @@ export function HoverBox<T extends { [K in keyof T]: boolean }>({
       className={`${hovered ? activeClass : defaultClass} m-2 border ${borderClass} p-2 ${className}`}
       data-testid={testId}
       tabIndex={0}
-      role='button'
       onFocus={() => setHover(true)}
       onBlur={() => setHover(false)}
       {...hoverProps}

--- a/components/OpenAPIComparison.tsx
+++ b/components/OpenAPIComparison.tsx
@@ -47,6 +47,84 @@ const ASYNCAPI_V2_COMPONENT_NAMES = [
   'Message Bindings'
 ];
 
+interface SharedSectionProps {
+  hoverState: HoverState;
+  setHoverState: React.Dispatch<React.SetStateAction<HoverState>>;
+}
+
+/**
+ * The "Info" hover box that appears at the top of both spec columns.
+ * Hovering on one column highlights the matching box in the other column.
+ */
+const SpecInfoSection = ({ hoverState, setHoverState }: SharedSectionProps) => (
+  <HoverBox<HoverState>
+    label='Info'
+    fieldKey='Info'
+    hoverState={hoverState}
+    setHoverState={setHoverState}
+    activeClass='bg-blue-100 dark:bg-blue-900/40'
+    defaultClass=' '
+    borderClass='border-blue-300 dark:border-blue-700'
+    useMouseOver
+  />
+);
+
+/**
+ * The "Tags" and "External Docs" row that appears at the bottom of both spec columns.
+ * Both boxes share the same hover state so hovering one highlights the other.
+ */
+const TagsAndExternalDocsSection = ({ hoverState, setHoverState }: SharedSectionProps) => (
+  <div className='flex flex-1 flex-wrap'>
+    <HoverBox<HoverState>
+      label='Tags'
+      fieldKey='Tags'
+      hoverState={hoverState}
+      setHoverState={setHoverState}
+      activeClass='bg-pink-300 dark:bg-pink-900/60'
+      defaultClass=' '
+      borderClass='border-black dark:border-gray-600'
+      className='flex flex-1 items-center justify-center'
+      useMouseOver
+    />
+    <HoverBox<HoverState>
+      label='External Docs'
+      fieldKey='External'
+      hoverState={hoverState}
+      setHoverState={setHoverState}
+      activeClass='bg-green-500 dark:bg-green-900/60'
+      defaultClass=' '
+      borderClass='border-black dark:border-gray-600'
+      className='flex flex-1 items-center justify-center'
+      useMouseOver
+    />
+  </div>
+);
+
+interface SpecComponentsSectionProps extends SharedSectionProps {
+  /** List of component names to display in the two-column grid. */
+  componentNames: string[];
+}
+
+/**
+ * The "Components" hover box that wraps a grid of spec component names.
+ * Each column passes its own component name list; hover state is still shared.
+ */
+const SpecComponentsSection = ({ hoverState, setHoverState, componentNames }: SpecComponentsSectionProps) => (
+  <HoverBox<HoverState>
+    label='Components'
+    fieldKey='Components'
+    hoverState={hoverState}
+    setHoverState={setHoverState}
+    activeClass='bg-gray-100 dark:bg-gray-800'
+    defaultClass=' '
+    borderClass='border-black dark:border-gray-600'
+    className='flex-1'
+    useMouseOver
+  >
+    <ComponentsGridList items={componentNames} />
+  </HoverBox>
+);
+
 /**
  * @description React component for comparing OpenAPI 3.0 and AsyncAPI 2.0.
  * @param {string} [props.className=''] - Additional CSS classes for styling.
@@ -68,17 +146,7 @@ export default function OpenAPIComparison({ className = '' }: OpenAPIComparisonP
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
       <Column title='OpenAPI 3.0'>
-        <HoverBox<HoverState>
-          label='Info'
-          fieldKey='Info'
-          hoverState={hoverState}
-          setHoverState={setHoverState}
-          activeClass='bg-blue-100 dark:bg-blue-900/40'
-          defaultClass=' '
-          borderClass='border-blue-300 dark:border-blue-700'
-          testId='OpenAPI-sec-info'
-          useMouseOver
-        />
+        <SpecInfoSection hoverState={hoverState} setHoverState={setHoverState} />
         <div className='flex flex-1 flex-wrap'>
           <HoverBox<HoverState>
             label='Servers'
@@ -163,59 +231,16 @@ export default function OpenAPIComparison({ className = '' }: OpenAPIComparisonP
             </HoverBox>
           </div>
         </HoverBox>
-        <div className='flex flex-1 flex-wrap'>
-          <HoverBox<HoverState>
-            label='Tags'
-            fieldKey='Tags'
-            hoverState={hoverState}
-            setHoverState={setHoverState}
-            activeClass='bg-pink-300 dark:bg-pink-900/60'
-            defaultClass=' '
-            borderClass='border-black dark:border-gray-600'
-            className='flex flex-1 items-center justify-center'
-            testId='OpenAPI-tags'
-            useMouseOver
-          />
-          <HoverBox<HoverState>
-            label='External Docs'
-            fieldKey='External'
-            hoverState={hoverState}
-            setHoverState={setHoverState}
-            activeClass='bg-green-500 dark:bg-green-900/60'
-            defaultClass=' '
-            borderClass='border-black dark:border-gray-600'
-            className='flex flex-1 items-center justify-center'
-            testId='OpenAPI-external'
-            useMouseOver
-          />
-        </div>
-        <HoverBox<HoverState>
-          label='Components'
-          fieldKey='Components'
+        <TagsAndExternalDocsSection hoverState={hoverState} setHoverState={setHoverState} />
+        <SpecComponentsSection
           hoverState={hoverState}
           setHoverState={setHoverState}
-          activeClass='bg-gray-100 dark:bg-gray-800'
-          defaultClass=' '
-          borderClass='border-black dark:border-gray-600'
-          className='flex-1'
-          testId='OpenAPI-components'
-          useMouseOver
-        >
-          <ComponentsGridList items={OPENAPI_V2_COMPONENT_NAMES} />
-        </HoverBox>
+          componentNames={OPENAPI_V2_COMPONENT_NAMES}
+        />
       </Column>
 
       <Column title='AsyncAPI 2.0'>
-        <HoverBox<HoverState>
-          label='Info'
-          fieldKey='Info'
-          hoverState={hoverState}
-          setHoverState={setHoverState}
-          activeClass='bg-blue-100 dark:bg-blue-900/40'
-          defaultClass=' '
-          borderClass='border-blue-300 dark:border-blue-700'
-          useMouseOver
-        />
+        <SpecInfoSection hoverState={hoverState} setHoverState={setHoverState} />
         <div className='flex flex-1 flex-wrap'>
           <HoverBox<HoverState>
             label='Servers (hosts + security)'
@@ -296,43 +321,12 @@ export default function OpenAPIComparison({ className = '' }: OpenAPIComparisonP
             Id (application identifier)
           </ComparisonBox>
         </div>
-        <div className='flex flex-1 flex-wrap'>
-          <HoverBox<HoverState>
-            label='Tags'
-            fieldKey='Tags'
-            hoverState={hoverState}
-            setHoverState={setHoverState}
-            activeClass='bg-pink-300 dark:bg-pink-900/60'
-            defaultClass=' '
-            borderClass='border-black dark:border-gray-600'
-            className='flex flex-1 items-center justify-center'
-            useMouseOver
-          />
-          <HoverBox<HoverState>
-            label='External Docs'
-            fieldKey='External'
-            hoverState={hoverState}
-            setHoverState={setHoverState}
-            activeClass='bg-green-500 dark:bg-green-900/60'
-            defaultClass=' '
-            borderClass='border-black dark:border-gray-600'
-            className='flex flex-1 items-center justify-center'
-            useMouseOver
-          />
-        </div>
-        <HoverBox<HoverState>
-          label='Components'
-          fieldKey='Components'
+        <TagsAndExternalDocsSection hoverState={hoverState} setHoverState={setHoverState} />
+        <SpecComponentsSection
           hoverState={hoverState}
           setHoverState={setHoverState}
-          activeClass='bg-gray-100 dark:bg-gray-800'
-          defaultClass=' '
-          borderClass='border-black dark:border-gray-600'
-          className='flex-1'
-          useMouseOver
-        >
-          <ComponentsGridList items={ASYNCAPI_V2_COMPONENT_NAMES} />
-        </HoverBox>
+          componentNames={ASYNCAPI_V2_COMPONENT_NAMES}
+        />
       </Column>
     </div>
   );

--- a/components/OpenAPIComparison.tsx
+++ b/components/OpenAPIComparison.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Column, HoverBox } from './ComparisonCommon';
+import { Column, ComparisonBox, ComponentsGridList, HoverBox } from './ComparisonCommon';
 
 interface HoverState {
   Info: boolean;
@@ -19,19 +19,33 @@ interface OpenAPIComparisonProps {
   className?: string;
 }
 
-const StaticBox = ({ children, className = '' }: { children: React.ReactNode; className?: string }) => (
-  <div className={`m-2 border border-black p-2 dark:border-gray-600 ${className}`}>{children}</div>
-);
+/** Component entries shown inside the OpenAPI 3.0 Components section. */
+const OPENAPI_V2_COMPONENT_NAMES = [
+  'Schemas',
+  'Responses',
+  'Parameters',
+  'Examples',
+  'Request Bodies',
+  'Headers',
+  'Security Schemes',
+  'Links',
+  'Callbacks'
+];
 
-const ComponentGrid = ({ children }: { children: React.ReactNode }) => (
-  <div className='grid-gap-2 mt-2 grid flex-1 grid-cols-2 flex-wrap'>{children}</div>
-);
-
-const ComponentItem = ({ children }: { children: React.ReactNode }) => (
-  <div className='m-2 box-border border border-black bg-gray-100 p-2 dark:border-gray-600 dark:bg-gray-800'>
-    {children}
-  </div>
-);
+/** Component entries shown inside the AsyncAPI 2.0 Components section. */
+const ASYNCAPI_V2_COMPONENT_NAMES = [
+  'Schemas',
+  'Messages',
+  'Security Schemes',
+  'Parameters',
+  'Correlation Ids',
+  'Operation Traits',
+  'Message Traits',
+  'Server Bindings',
+  'Channel Bindings',
+  'Operation Bindings',
+  'Message Bindings'
+];
 
 /**
  * @description React component for comparing OpenAPI 3.0 and AsyncAPI 2.0.
@@ -78,7 +92,7 @@ export default function OpenAPIComparison({ className = '' }: OpenAPIComparisonP
             testId='OpenAPI-sec-servers'
             useMouseOver
           />
-          <StaticBox className='flex-1 hover:bg-gray-200 dark:hover:bg-gray-800'>Security</StaticBox>
+          <ComparisonBox className='flex-1 hover:bg-gray-200 dark:hover:bg-gray-800'>Security</ComparisonBox>
         </div>
         <HoverBox<HoverState>
           label='Paths'
@@ -187,17 +201,7 @@ export default function OpenAPIComparison({ className = '' }: OpenAPIComparisonP
           testId='OpenAPI-components'
           useMouseOver
         >
-          <ComponentGrid>
-            <ComponentItem>Schemas</ComponentItem>
-            <ComponentItem>Responses</ComponentItem>
-            <ComponentItem>Parameters</ComponentItem>
-            <ComponentItem>Examples</ComponentItem>
-            <ComponentItem>Request Bodies</ComponentItem>
-            <ComponentItem>Headers</ComponentItem>
-            <ComponentItem>Security Schemes</ComponentItem>
-            <ComponentItem>Links</ComponentItem>
-            <ComponentItem>Callbacks</ComponentItem>
-          </ComponentGrid>
+          <ComponentsGridList items={OPENAPI_V2_COMPONENT_NAMES} />
         </HoverBox>
       </Column>
 
@@ -276,8 +280,8 @@ export default function OpenAPIComparison({ className = '' }: OpenAPIComparisonP
                           borderClass='border-red-600 dark:border-red-700'
                           className='flex-1'
                         >
-                          <StaticBox className='box-border flex-1'>Headers</StaticBox>
-                          <StaticBox className='box-border flex-1'>Payload</StaticBox>
+                          <ComparisonBox className='box-border flex-1'>Headers</ComparisonBox>
+                          <ComparisonBox className='box-border flex-1'>Payload</ComparisonBox>
                         </HoverBox>
                       </div>
                     </div>
@@ -288,9 +292,9 @@ export default function OpenAPIComparison({ className = '' }: OpenAPIComparisonP
           </div>
         </HoverBox>
         <div className='flex flex-1 flex-wrap'>
-          <StaticBox className='box-border flex-1 hover:bg-blue-400 dark:hover:bg-blue-900/50'>
+          <ComparisonBox className='box-border flex-1 hover:bg-blue-400 dark:hover:bg-blue-900/50'>
             Id (application identifier)
-          </StaticBox>
+          </ComparisonBox>
         </div>
         <div className='flex flex-1 flex-wrap'>
           <HoverBox<HoverState>
@@ -327,19 +331,7 @@ export default function OpenAPIComparison({ className = '' }: OpenAPIComparisonP
           className='flex-1'
           useMouseOver
         >
-          <ComponentGrid>
-            <ComponentItem>Schemas</ComponentItem>
-            <ComponentItem>Messages</ComponentItem>
-            <ComponentItem>Security Schemes</ComponentItem>
-            <ComponentItem>Parameters</ComponentItem>
-            <ComponentItem>Correlation Ids</ComponentItem>
-            <ComponentItem>Operation Traits</ComponentItem>
-            <ComponentItem>Message Traits</ComponentItem>
-            <ComponentItem>Server Bindings</ComponentItem>
-            <ComponentItem>Channel Bindings</ComponentItem>
-            <ComponentItem>Operation Bindings</ComponentItem>
-            <ComponentItem>Message Bindings</ComponentItem>
-          </ComponentGrid>
+          <ComponentsGridList items={ASYNCAPI_V2_COMPONENT_NAMES} />
         </HoverBox>
       </Column>
     </div>

--- a/components/OpenAPIComparison.tsx
+++ b/components/OpenAPIComparison.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 
+import { Column, HoverBox } from './ComparisonCommon';
+
 interface HoverState {
   Info: boolean;
   Servers: boolean;
@@ -16,6 +18,20 @@ interface HoverState {
 interface OpenAPIComparisonProps {
   className?: string;
 }
+
+const StaticBox = ({ children, className = '' }: { children: React.ReactNode; className?: string }) => (
+  <div className={`m-2 border border-black p-2 dark:border-gray-600 ${className}`}>{children}</div>
+);
+
+const ComponentGrid = ({ children }: { children: React.ReactNode }) => (
+  <div className='grid-gap-2 mt-2 grid flex-1 grid-cols-2 flex-wrap'>{children}</div>
+);
+
+const ComponentItem = ({ children }: { children: React.ReactNode }) => (
+  <div className='m-2 box-border border border-black bg-gray-100 p-2 dark:border-gray-600 dark:bg-gray-800'>
+    {children}
+  </div>
+);
 
 /**
  * @description React component for comparing OpenAPI 3.0 and AsyncAPI 2.0.
@@ -36,239 +52,296 @@ export default function OpenAPIComparison({ className = '' }: OpenAPIComparisonP
   });
 
   return (
-    <div className={`${className} flex flex-wrap text-center`}>
-      <div className='mr-1 flex-1 border border-black p-2'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>OpenAPI 3.0</h3>
-        <div>
-          <div
-            className={`${hoverState.Info ? 'bg-blue-100 ' : ' '}m-2 border border-blue-300 p-2`}
-            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Info: true }))}
-            onMouseLeave={() => setHoverState({ ...hoverState, Info: false })}
-            data-testid='OpenAPI-sec-info'
-          >
-            Info
-          </div>
-          <div className='flex flex-1 flex-wrap'>
-            <div
-              className={`${hoverState.Servers ? 'bg-green-100' : ' '} m-2 flex-1 border border-green-300 p-2`}
-              onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Servers: true }))}
-              onMouseLeave={() => setHoverState({ ...hoverState, Servers: false })}
-              data-testid='OpenAPI-sec-servers'
-            >
-              Servers
-            </div>
-            <div className='border-bg-gray-500 m-2 flex-1 border p-2 hover:bg-gray-200'>Security</div>
-          </div>
-          <div
-            className={`${hoverState.Paths ? 'bg-yellow-100' : ' '} m-2 border border-yellow-300 p-2`}
-            onMouseEnter={() => setHoverState((prevState) => ({ ...prevState, Paths: true }))}
-            onMouseLeave={() => setHoverState({ ...hoverState, Paths: false })}
-            data-testid='OpenAPI-paths'
-          >
-            Paths
-            <div className='flex flex-1 flex-wrap'>
-              <div
-                className={`${hoverState.PathItem ? 'bg-yellow-300' : 'bg-white'} m-2 border border-yellow-600 p-2`}
-                onMouseEnter={() => {
-                  return setHoverState((prevState) => ({ ...prevState, PathItem: true }));
-                }}
-                onMouseLeave={() => {
-                  return setHoverState({ ...hoverState, PathItem: false });
-                }}
-                data-testid='OpenAPI-path-item'
-              >
-                Path Item
-                <div className='flex flex-1 flex-col flex-wrap'>
-                  <div
-                    className={`${hoverState.Summary ? 'bg-blue-200' : 'bg-white'} m-2 border border-blue-500 p-2`}
-                    onMouseEnter={() => setHoverState((prevState) => ({ ...prevState, Summary: true }))}
-                    onMouseLeave={() => {
-                      return setHoverState({ ...hoverState, Summary: false });
-                    }}
-                    data-testid='OpenAPI-summary'
-                  >
-                    Summary and description
-                  </div>
-                  <div className='flex flex-1 flex-wrap'>
-                    <div
-                      className={`${hoverState.Operation ? 'bg-orange-100' : 'bg-white'} m-2 flex-1 border border-orange-300 p-2`}
-                      onMouseEnter={() => setHoverState((prevState) => ({ ...prevState, Operation: true }))}
-                      onMouseLeave={() => setHoverState({ ...hoverState, Operation: false })}
-                      data-testid='OpenAPI-operation'
-                    >
-                      Operation (GET, PUT, POST, etc.)
-                      <div className='flex flex-1 flex-wrap'>
-                        <div
-                          className={`${hoverState.Message ? 'bg-red-400' : 'bg-white'} m-2 flex-1 border border-red-600 p-2`}
-                          onMouseEnter={() => setHoverState((prevState) => ({ ...prevState, Message: true }))}
-                          onMouseLeave={() => setHoverState({ ...hoverState, Message: false })}
-                          data-testid='OpenAPI-request'
-                        >
-                          Request
-                        </div>
-                        <div
-                          className={`${hoverState.Message ? 'bg-red-400' : 'bg-white'} m-2 flex-1 border border-red-600 p-2`}
-                          onMouseEnter={() => setHoverState((prevState) => ({ ...prevState, Message: true }))}
-                          onMouseLeave={() => setHoverState({ ...hoverState, Message: false })}
-                          data-testid='OpenAPI-responses'
-                        >
-                          Responses
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className='flex flex-1 flex-wrap'>
-            <div
-              className={`${hoverState.Tags ? 'bg-pink-300' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2`}
-              onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Tags: true }))}
-              onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Tags: false }))}
-              data-testid='OpenAPI-tags'
-            >
-              <p>Tags</p>
-            </div>
-            <div
-              className={`${hoverState.External ? 'bg-green-500' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2`}
-              onMouseOver={() => setHoverState((prevState) => ({ ...prevState, External: true }))}
-              onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, External: false }))}
-              data-testid='OpenAPI-external'
-            >
-              <p>External Docs</p>
-            </div>
-          </div>
-          <div
-            className={`${hoverState.Components ? 'bg-gray-100' : ' '} m-2 flex-1 border border-black p-2`}
-            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Components: true }))}
-            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Components: false }))}
-            data-testid='OpenAPI-components'
-          >
-            Components
-            <div className='grid-gap-2 mt-1 grid flex-1 grid-cols-2'>
-              <div className='m-2 border border-black bg-gray-100 p-2'>Schemas</div>
-              <div className='m-2 border border-black bg-gray-100 p-2'>Responses</div>
-              <div className='m-2 border border-black bg-gray-100 p-2'>Parameters</div>
-              <div className='m-2 border border-black bg-gray-100 p-2'>Examples</div>
-              <div className='m-2 border border-black bg-gray-100 p-2'>Request Bodies</div>
-              <div className='m-2 border border-black bg-gray-100 p-2'>Headers</div>
-              <div className='m-2 border border-black bg-gray-100 p-2'>Security Schemes</div>
-              <div className='m-2 border border-black bg-gray-100 p-2'>Links</div>
-              <div className='m-2 border border-black bg-gray-100 p-2'>Callbacks</div>
-            </div>
-          </div>
+    <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
+      <Column title='OpenAPI 3.0'>
+        <HoverBox<HoverState>
+          label='Info'
+          fieldKey='Info'
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass='bg-blue-100 dark:bg-blue-900/40'
+          defaultClass=' '
+          borderClass='border-blue-300 dark:border-blue-700'
+          testId='OpenAPI-sec-info'
+          useMouseOver
+        />
+        <div className='flex flex-1 flex-wrap'>
+          <HoverBox<HoverState>
+            label='Servers'
+            fieldKey='Servers'
+            hoverState={hoverState}
+            setHoverState={setHoverState}
+            activeClass='bg-green-100 dark:bg-green-900/40'
+            defaultClass=' '
+            borderClass='border-green-300 dark:border-green-700'
+            className='flex-1'
+            testId='OpenAPI-sec-servers'
+            useMouseOver
+          />
+          <StaticBox className='flex-1 hover:bg-gray-200 dark:hover:bg-gray-800'>Security</StaticBox>
         </div>
-      </div>
-      <div className='ml-1 flex-1 border border-black p-2'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 2.0</h3>
-        <div>
-          <div
-            className={`${hoverState.Info ? 'bg-blue-100 ' : ' '}m-2 border border-blue-300 p-2`}
-            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Info: true }))}
-            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Info: false }))}
-          >
-            Info
-          </div>
+        <HoverBox<HoverState>
+          label='Paths'
+          fieldKey='Paths'
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass='bg-yellow-100 dark:bg-yellow-900/40'
+          defaultClass=' '
+          borderClass='border-yellow-300 dark:border-yellow-700'
+          testId='OpenAPI-paths'
+        >
           <div className='flex flex-1 flex-wrap'>
-            <div
-              className={`${hoverState.Servers ? 'bg-green-100' : ' '} m-2 flex-1 border border-green-300 p-2`}
-              onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Servers: true }))}
-              onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Servers: false }))}
+            <HoverBox<HoverState>
+              label='Path Item'
+              fieldKey='PathItem'
+              hoverState={hoverState}
+              setHoverState={setHoverState}
+              activeClass='bg-yellow-300 dark:bg-yellow-800/60'
+              borderClass='border-yellow-600 dark:border-yellow-700'
+              testId='OpenAPI-path-item'
             >
-              Servers (hosts + security)
-            </div>
-          </div>
-          <div
-            className={`${hoverState.Paths ? 'bg-yellow-100' : ' '} m-2 border border-yellow-300 p-2`}
-            onMouseEnter={() => setHoverState((prevState) => ({ ...prevState, Paths: true }))}
-            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Paths: false }))}
-          >
-            Channel
-            <div className='flex flex-1 flex-wrap'>
-              <div
-                className={`${hoverState.PathItem ? 'bg-yellow-300' : 'bg-white'} m-2 border border-yellow-600 p-2`}
-                onMouseOver={() => setHoverState((prevState) => ({ ...prevState, PathItem: true }))}
-                onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, PathItem: false }))}
-              >
-                Channel Item
+              <div className='flex flex-1 flex-col flex-wrap'>
+                <HoverBox<HoverState>
+                  label='Summary and description'
+                  fieldKey='Summary'
+                  hoverState={hoverState}
+                  setHoverState={setHoverState}
+                  activeClass='bg-blue-200 dark:bg-blue-900/50'
+                  borderClass='border-blue-500 dark:border-blue-400'
+                  testId='OpenAPI-summary'
+                />
                 <div className='flex flex-1 flex-wrap'>
-                  <div className='flex flex-1 flex-wrap'>
-                    <div
-                      className={`${hoverState.Operation ? 'bg-orange-100' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
-                      onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Operation: true }))}
-                      onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Operation: false }))}
-                    >
-                      Operation (Publish and Subscribe)
-                      <div className='flex flex-1 flex-col flex-wrap'>
-                        <div
-                          className={`${hoverState.Summary ? 'bg-blue-200' : 'bg-white'} m-2 border border-blue-500 p-2`}
-                          onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Summary: true }))}
-                          onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Summary: false }))}
-                        >
-                          Summary, description, tags, etc.
-                        </div>
-                        <div className='flex flex-1 flex-wrap'>
-                          <div
-                            className={`${hoverState.Message ? 'bg-red-400' : 'bg-white'} m-2 flex-1 border border-red-600 p-2`}
-                            onMouseEnter={() => setHoverState((prevState) => ({ ...prevState, Message: true }))}
-                            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Message: false }))}
-                          >
-                            Message
-                            <div className='m-2 mr-1 box-border flex-1 border border-black p-2'>Headers</div>
-                            <div className='m-2 mr-1 box-border flex-1 border border-black p-2'>Payload</div>
-                          </div>
-                        </div>
-                      </div>
+                  <HoverBox<HoverState>
+                    label='Operation (GET, PUT, POST, etc.)'
+                    fieldKey='Operation'
+                    hoverState={hoverState}
+                    setHoverState={setHoverState}
+                    activeClass='bg-orange-100 dark:bg-orange-900/40'
+                    borderClass='border-orange-300 dark:border-orange-700'
+                    className='flex-1'
+                    testId='OpenAPI-operation'
+                  >
+                    <div className='flex flex-1 flex-wrap'>
+                      <HoverBox<HoverState>
+                        label='Request'
+                        fieldKey='Message'
+                        hoverState={hoverState}
+                        setHoverState={setHoverState}
+                        activeClass='bg-red-400 dark:bg-red-900/60'
+                        borderClass='border-red-600 dark:border-red-700'
+                        className='flex-1'
+                        testId='OpenAPI-request'
+                      />
+                      <HoverBox<HoverState>
+                        label='Responses'
+                        fieldKey='Message'
+                        hoverState={hoverState}
+                        setHoverState={setHoverState}
+                        activeClass='bg-red-400 dark:bg-red-900/60'
+                        borderClass='border-red-600 dark:border-red-700'
+                        className='flex-1'
+                        testId='OpenAPI-responses'
+                      />
                     </div>
-                  </div>
+                  </HoverBox>
                 </div>
               </div>
-            </div>
+            </HoverBox>
           </div>
-          <div className='flex flex-1 flex-wrap'>
-            <div className='m-2 box-border flex-1 border border-black p-2 hover:bg-blue-400'>
-              Id (application identifier)
-            </div>
-          </div>
-          <div className='flex flex-1 flex-wrap'>
-            <div
-              className={`${hoverState.Tags ? 'bg-pink-300' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2`}
-              onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Tags: true }))}
-              onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Tags: false }))}
-            >
-              <p>Tags</p>
-            </div>
-            <div
-              className={`${hoverState.External ? 'bg-green-500' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2`}
-              onMouseOver={() => setHoverState((prevState) => ({ ...prevState, External: true }))}
-              onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, External: false }))}
-            >
-              <p>External Docs</p>
-            </div>
-          </div>
-          <div
-            className={`${hoverState.Components ? 'bg-gray-100' : ' '} m-2 flex-1 border border-black p-2`}
-            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Components: true }))}
-            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Components: false }))}
-          >
-            Components
-            <div className='grid-gap-2 mt-2 grid flex-1 grid-cols-2 flex-wrap'>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Schemas</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Messages</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Security Schemes</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Parameters</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Correlation Ids</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Operation Traits</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Message Traits</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Server Bindings</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Channel Bindings</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Operation Bindings</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Message Bindings</div>
-            </div>
-          </div>
+        </HoverBox>
+        <div className='flex flex-1 flex-wrap'>
+          <HoverBox<HoverState>
+            label='Tags'
+            fieldKey='Tags'
+            hoverState={hoverState}
+            setHoverState={setHoverState}
+            activeClass='bg-pink-300 dark:bg-pink-900/60'
+            defaultClass=' '
+            borderClass='border-black dark:border-gray-600'
+            className='flex flex-1 items-center justify-center'
+            testId='OpenAPI-tags'
+            useMouseOver
+          />
+          <HoverBox<HoverState>
+            label='External Docs'
+            fieldKey='External'
+            hoverState={hoverState}
+            setHoverState={setHoverState}
+            activeClass='bg-green-500 dark:bg-green-900/60'
+            defaultClass=' '
+            borderClass='border-black dark:border-gray-600'
+            className='flex flex-1 items-center justify-center'
+            testId='OpenAPI-external'
+            useMouseOver
+          />
         </div>
-      </div>
+        <HoverBox<HoverState>
+          label='Components'
+          fieldKey='Components'
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass='bg-gray-100 dark:bg-gray-800'
+          defaultClass=' '
+          borderClass='border-black dark:border-gray-600'
+          className='flex-1'
+          testId='OpenAPI-components'
+          useMouseOver
+        >
+          <ComponentGrid>
+            <ComponentItem>Schemas</ComponentItem>
+            <ComponentItem>Responses</ComponentItem>
+            <ComponentItem>Parameters</ComponentItem>
+            <ComponentItem>Examples</ComponentItem>
+            <ComponentItem>Request Bodies</ComponentItem>
+            <ComponentItem>Headers</ComponentItem>
+            <ComponentItem>Security Schemes</ComponentItem>
+            <ComponentItem>Links</ComponentItem>
+            <ComponentItem>Callbacks</ComponentItem>
+          </ComponentGrid>
+        </HoverBox>
+      </Column>
+
+      <Column title='AsyncAPI 2.0'>
+        <HoverBox<HoverState>
+          label='Info'
+          fieldKey='Info'
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass='bg-blue-100 dark:bg-blue-900/40'
+          defaultClass=' '
+          borderClass='border-blue-300 dark:border-blue-700'
+          useMouseOver
+        />
+        <div className='flex flex-1 flex-wrap'>
+          <HoverBox<HoverState>
+            label='Servers (hosts + security)'
+            fieldKey='Servers'
+            hoverState={hoverState}
+            setHoverState={setHoverState}
+            activeClass='bg-green-100 dark:bg-green-900/40'
+            defaultClass=' '
+            borderClass='border-green-300 dark:border-green-700'
+            className='flex-1'
+            useMouseOver
+          />
+        </div>
+        <HoverBox<HoverState>
+          label='Channel'
+          fieldKey='Paths'
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass='bg-yellow-100 dark:bg-yellow-900/40'
+          defaultClass=' '
+          borderClass='border-yellow-300 dark:border-yellow-700'
+        >
+          <div className='flex flex-1 flex-wrap'>
+            <HoverBox<HoverState>
+              label='Channel Item'
+              fieldKey='PathItem'
+              hoverState={hoverState}
+              setHoverState={setHoverState}
+              activeClass='bg-yellow-300 dark:bg-yellow-800/60'
+              borderClass='border-yellow-600 dark:border-yellow-700'
+              useMouseOver
+            >
+              <div className='flex flex-1 flex-wrap'>
+                <div className='flex flex-1 flex-wrap'>
+                  <HoverBox<HoverState>
+                    label='Operation (Publish and Subscribe)'
+                    fieldKey='Operation'
+                    hoverState={hoverState}
+                    setHoverState={setHoverState}
+                    activeClass='bg-orange-100 dark:bg-orange-900/40'
+                    borderClass='border-orange-300 dark:border-orange-700'
+                    className='flex-1'
+                    useMouseOver
+                  >
+                    <div className='flex flex-1 flex-col flex-wrap'>
+                      <HoverBox<HoverState>
+                        label='Summary, description, tags, etc.'
+                        fieldKey='Summary'
+                        hoverState={hoverState}
+                        setHoverState={setHoverState}
+                        activeClass='bg-blue-200 dark:bg-blue-900/50'
+                        borderClass='border-blue-500 dark:border-blue-400'
+                        useMouseOver
+                      />
+                      <div className='flex flex-1 flex-wrap'>
+                        <HoverBox<HoverState>
+                          label='Message'
+                          fieldKey='Message'
+                          hoverState={hoverState}
+                          setHoverState={setHoverState}
+                          activeClass='bg-red-400 dark:bg-red-900/60'
+                          borderClass='border-red-600 dark:border-red-700'
+                          className='flex-1'
+                        >
+                          <StaticBox className='box-border flex-1'>Headers</StaticBox>
+                          <StaticBox className='box-border flex-1'>Payload</StaticBox>
+                        </HoverBox>
+                      </div>
+                    </div>
+                  </HoverBox>
+                </div>
+              </div>
+            </HoverBox>
+          </div>
+        </HoverBox>
+        <div className='flex flex-1 flex-wrap'>
+          <StaticBox className='box-border flex-1 hover:bg-blue-400 dark:hover:bg-blue-900/50'>
+            Id (application identifier)
+          </StaticBox>
+        </div>
+        <div className='flex flex-1 flex-wrap'>
+          <HoverBox<HoverState>
+            label='Tags'
+            fieldKey='Tags'
+            hoverState={hoverState}
+            setHoverState={setHoverState}
+            activeClass='bg-pink-300 dark:bg-pink-900/60'
+            defaultClass=' '
+            borderClass='border-black dark:border-gray-600'
+            className='flex flex-1 items-center justify-center'
+            useMouseOver
+          />
+          <HoverBox<HoverState>
+            label='External Docs'
+            fieldKey='External'
+            hoverState={hoverState}
+            setHoverState={setHoverState}
+            activeClass='bg-green-500 dark:bg-green-900/60'
+            defaultClass=' '
+            borderClass='border-black dark:border-gray-600'
+            className='flex flex-1 items-center justify-center'
+            useMouseOver
+          />
+        </div>
+        <HoverBox<HoverState>
+          label='Components'
+          fieldKey='Components'
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass='bg-gray-100 dark:bg-gray-800'
+          defaultClass=' '
+          borderClass='border-black dark:border-gray-600'
+          className='flex-1'
+          useMouseOver
+        >
+          <ComponentGrid>
+            <ComponentItem>Schemas</ComponentItem>
+            <ComponentItem>Messages</ComponentItem>
+            <ComponentItem>Security Schemes</ComponentItem>
+            <ComponentItem>Parameters</ComponentItem>
+            <ComponentItem>Correlation Ids</ComponentItem>
+            <ComponentItem>Operation Traits</ComponentItem>
+            <ComponentItem>Message Traits</ComponentItem>
+            <ComponentItem>Server Bindings</ComponentItem>
+            <ComponentItem>Channel Bindings</ComponentItem>
+            <ComponentItem>Operation Bindings</ComponentItem>
+            <ComponentItem>Message Bindings</ComponentItem>
+          </ComponentGrid>
+        </HoverBox>
+      </Column>
     </div>
   );
 }

--- a/components/OpenAPIComparison.tsx
+++ b/components/OpenAPIComparison.tsx
@@ -1,7 +1,13 @@
 import React, { useState } from 'react';
 
 import { Column, ComparisonBox, HoverBox } from './ComparisonCommon';
-import { AsyncAPIServersSection, OpenAPIServersSection, SpecComponentsSection, SpecInfoSection, TagsAndExternalDocsSection } from './OpenAPIComparisonCommon';
+import {
+  AsyncAPIServersSection,
+  OpenAPIServersSection,
+  SpecComponentsSection,
+  SpecInfoSection,
+  TagsAndExternalDocsSection
+} from './OpenAPIComparisonCommon';
 
 interface HoverState {
   Info: boolean;
@@ -21,7 +27,7 @@ interface OpenAPIComparisonProps {
 }
 
 /** Component entries shown inside the OpenAPI 3.0 Components section. */
-const OPENAPI_V2_COMPONENT_NAMES = [
+const OPENAPI_COMPONENT_NAMES = [
   'Schemas',
   'Responses',
   'Parameters',
@@ -34,7 +40,7 @@ const OPENAPI_V2_COMPONENT_NAMES = [
 ];
 
 /** Component entries shown inside the AsyncAPI 2.0 Components section. */
-const ASYNCAPI_V2_COMPONENT_NAMES = [
+const ASYNCAPI_COMPONENT_NAMES = [
   'Schemas',
   'Messages',
   'Security Schemes',
@@ -70,18 +76,14 @@ export default function OpenAPIComparison({ className = '' }: OpenAPIComparisonP
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
       <Column title='OpenAPI 3.0'>
         <SpecInfoSection hoverState={hoverState} setHoverState={setHoverState} />
-        <OpenAPIServersSection
-          hoverState={hoverState}
-          setHoverState={setHoverState}
-          testId='OpenAPI-sec-servers'
-        />
+        <OpenAPIServersSection hoverState={hoverState} setHoverState={setHoverState} testId='OpenAPI-sec-servers' />
         <HoverBox<HoverState>
           label='Paths'
           fieldKey='Paths'
           hoverState={hoverState}
           setHoverState={setHoverState}
           activeClass='bg-yellow-100 dark:bg-yellow-900/40'
-          defaultClass=' '
+          defaultClass=''
           borderClass='border-yellow-300 dark:border-yellow-700'
           testId='OpenAPI-paths'
         >
@@ -148,7 +150,7 @@ export default function OpenAPIComparison({ className = '' }: OpenAPIComparisonP
         <SpecComponentsSection
           hoverState={hoverState}
           setHoverState={setHoverState}
-          componentNames={OPENAPI_V2_COMPONENT_NAMES}
+          componentNames={OPENAPI_COMPONENT_NAMES}
         />
       </Column>
 
@@ -161,7 +163,7 @@ export default function OpenAPIComparison({ className = '' }: OpenAPIComparisonP
           hoverState={hoverState}
           setHoverState={setHoverState}
           activeClass='bg-yellow-100 dark:bg-yellow-900/40'
-          defaultClass=' '
+          defaultClass=''
           borderClass='border-yellow-300 dark:border-yellow-700'
         >
           <div className='flex flex-1 flex-wrap'>
@@ -226,7 +228,7 @@ export default function OpenAPIComparison({ className = '' }: OpenAPIComparisonP
         <SpecComponentsSection
           hoverState={hoverState}
           setHoverState={setHoverState}
-          componentNames={ASYNCAPI_V2_COMPONENT_NAMES}
+          componentNames={ASYNCAPI_COMPONENT_NAMES}
         />
       </Column>
     </div>

--- a/components/OpenAPIComparison.tsx
+++ b/components/OpenAPIComparison.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
-import { Column, ComparisonBox, ComponentsGridList, HoverBox } from './ComparisonCommon';
+import { Column, ComparisonBox, HoverBox } from './ComparisonCommon';
+import { AsyncAPIServersSection, OpenAPIServersSection, SpecComponentsSection, SpecInfoSection, TagsAndExternalDocsSection } from './OpenAPIComparisonCommon';
 
 interface HoverState {
   Info: boolean;
@@ -47,84 +48,6 @@ const ASYNCAPI_V2_COMPONENT_NAMES = [
   'Message Bindings'
 ];
 
-interface SharedSectionProps {
-  hoverState: HoverState;
-  setHoverState: React.Dispatch<React.SetStateAction<HoverState>>;
-}
-
-/**
- * The "Info" hover box that appears at the top of both spec columns.
- * Hovering on one column highlights the matching box in the other column.
- */
-const SpecInfoSection = ({ hoverState, setHoverState }: SharedSectionProps) => (
-  <HoverBox<HoverState>
-    label='Info'
-    fieldKey='Info'
-    hoverState={hoverState}
-    setHoverState={setHoverState}
-    activeClass='bg-blue-100 dark:bg-blue-900/40'
-    defaultClass=' '
-    borderClass='border-blue-300 dark:border-blue-700'
-    useMouseOver
-  />
-);
-
-/**
- * The "Tags" and "External Docs" row that appears at the bottom of both spec columns.
- * Both boxes share the same hover state so hovering one highlights the other.
- */
-const TagsAndExternalDocsSection = ({ hoverState, setHoverState }: SharedSectionProps) => (
-  <div className='flex flex-1 flex-wrap'>
-    <HoverBox<HoverState>
-      label='Tags'
-      fieldKey='Tags'
-      hoverState={hoverState}
-      setHoverState={setHoverState}
-      activeClass='bg-pink-300 dark:bg-pink-900/60'
-      defaultClass=' '
-      borderClass='border-black dark:border-gray-600'
-      className='flex flex-1 items-center justify-center'
-      useMouseOver
-    />
-    <HoverBox<HoverState>
-      label='External Docs'
-      fieldKey='External'
-      hoverState={hoverState}
-      setHoverState={setHoverState}
-      activeClass='bg-green-500 dark:bg-green-900/60'
-      defaultClass=' '
-      borderClass='border-black dark:border-gray-600'
-      className='flex flex-1 items-center justify-center'
-      useMouseOver
-    />
-  </div>
-);
-
-interface SpecComponentsSectionProps extends SharedSectionProps {
-  /** List of component names to display in the two-column grid. */
-  componentNames: string[];
-}
-
-/**
- * The "Components" hover box that wraps a grid of spec component names.
- * Each column passes its own component name list; hover state is still shared.
- */
-const SpecComponentsSection = ({ hoverState, setHoverState, componentNames }: SpecComponentsSectionProps) => (
-  <HoverBox<HoverState>
-    label='Components'
-    fieldKey='Components'
-    hoverState={hoverState}
-    setHoverState={setHoverState}
-    activeClass='bg-gray-100 dark:bg-gray-800'
-    defaultClass=' '
-    borderClass='border-black dark:border-gray-600'
-    className='flex-1'
-    useMouseOver
-  >
-    <ComponentsGridList items={componentNames} />
-  </HoverBox>
-);
-
 /**
  * @description React component for comparing OpenAPI 3.0 and AsyncAPI 2.0.
  * @param {string} [props.className=''] - Additional CSS classes for styling.
@@ -147,21 +70,11 @@ export default function OpenAPIComparison({ className = '' }: OpenAPIComparisonP
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
       <Column title='OpenAPI 3.0'>
         <SpecInfoSection hoverState={hoverState} setHoverState={setHoverState} />
-        <div className='flex flex-1 flex-wrap'>
-          <HoverBox<HoverState>
-            label='Servers'
-            fieldKey='Servers'
-            hoverState={hoverState}
-            setHoverState={setHoverState}
-            activeClass='bg-green-100 dark:bg-green-900/40'
-            defaultClass=' '
-            borderClass='border-green-300 dark:border-green-700'
-            className='flex-1'
-            testId='OpenAPI-sec-servers'
-            useMouseOver
-          />
-          <ComparisonBox className='flex-1 hover:bg-gray-200 dark:hover:bg-gray-800'>Security</ComparisonBox>
-        </div>
+        <OpenAPIServersSection
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          testId='OpenAPI-sec-servers'
+        />
         <HoverBox<HoverState>
           label='Paths'
           fieldKey='Paths'
@@ -241,19 +154,7 @@ export default function OpenAPIComparison({ className = '' }: OpenAPIComparisonP
 
       <Column title='AsyncAPI 2.0'>
         <SpecInfoSection hoverState={hoverState} setHoverState={setHoverState} />
-        <div className='flex flex-1 flex-wrap'>
-          <HoverBox<HoverState>
-            label='Servers (hosts + security)'
-            fieldKey='Servers'
-            hoverState={hoverState}
-            setHoverState={setHoverState}
-            activeClass='bg-green-100 dark:bg-green-900/40'
-            defaultClass=' '
-            borderClass='border-green-300 dark:border-green-700'
-            className='flex-1'
-            useMouseOver
-          />
-        </div>
+        <AsyncAPIServersSection hoverState={hoverState} setHoverState={setHoverState} />
         <HoverBox<HoverState>
           label='Channel'
           fieldKey='Paths'

--- a/components/OpenAPIComparisonCommon.tsx
+++ b/components/OpenAPIComparisonCommon.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+
+import { ComparisonBox, ComponentsGridList, HoverBox } from './ComparisonCommon';
+
+export interface BaseHoverState {
+  Info: boolean;
+  Servers: boolean;
+  Tags: boolean;
+  External: boolean;
+  Components: boolean;
+}
+
+export interface SharedSectionProps<T extends BaseHoverState & { [K in keyof T]: boolean }> {
+  hoverState: T;
+  setHoverState: React.Dispatch<React.SetStateAction<T>>;
+}
+
+/**
+ * The "Info" hover box that appears at the top of both spec columns.
+ * Hovering on one column highlights the matching box in the other column.
+ */
+export const SpecInfoSection = <T extends BaseHoverState & { [K in keyof T]: boolean }>({
+  hoverState,
+  setHoverState
+}: SharedSectionProps<T>) => (
+  <HoverBox<T>
+    label='Info'
+    fieldKey={'Info' as keyof T}
+    hoverState={hoverState}
+    setHoverState={setHoverState}
+    activeClass='bg-blue-100 dark:bg-blue-900/40'
+    defaultClass=' '
+    borderClass='border-blue-300 dark:border-blue-700'
+    useMouseOver
+  />
+);
+
+/**
+ * The "Tags" and "External Docs" row that appears at the bottom of both spec columns.
+ * Both boxes share the same hover state so hovering one highlights the other.
+ */
+export const TagsAndExternalDocsSection = <T extends BaseHoverState & { [K in keyof T]: boolean }>({
+  hoverState,
+  setHoverState
+}: SharedSectionProps<T>) => (
+  <div className='flex flex-1 flex-wrap'>
+    <HoverBox<T>
+      label='Tags'
+      fieldKey={'Tags' as keyof T}
+      hoverState={hoverState}
+      setHoverState={setHoverState}
+      activeClass='bg-pink-300 dark:bg-pink-900/60'
+      defaultClass=' '
+      borderClass='border-black dark:border-gray-600'
+      className='flex flex-1 items-center justify-center'
+      useMouseOver
+    />
+    <HoverBox<T>
+      label='External Docs'
+      fieldKey={'External' as keyof T}
+      hoverState={hoverState}
+      setHoverState={setHoverState}
+      activeClass='bg-green-500 dark:bg-green-900/60'
+      defaultClass=' '
+      borderClass='border-black dark:border-gray-600'
+      className='flex flex-1 items-center justify-center'
+      useMouseOver
+    />
+  </div>
+);
+
+export interface SpecComponentsSectionProps<T extends BaseHoverState & { [K in keyof T]: boolean }>
+  extends SharedSectionProps<T> {
+  /** List of component names to display in the two-column grid. */
+  componentNames: string[];
+}
+
+/**
+ * The "Components" hover box that wraps a grid of spec component names.
+ * Each column passes its own component name list; hover state is still shared.
+ */
+export const SpecComponentsSection = <T extends BaseHoverState & { [K in keyof T]: boolean }>({
+  hoverState,
+  setHoverState,
+  componentNames
+}: SpecComponentsSectionProps<T>) => (
+  <HoverBox<T>
+    label='Components'
+    fieldKey={'Components' as keyof T}
+    hoverState={hoverState}
+    setHoverState={setHoverState}
+    activeClass='bg-gray-100 dark:bg-gray-800'
+    defaultClass=' '
+    borderClass='border-black dark:border-gray-600'
+    className='flex-1'
+    useMouseOver
+  >
+    <ComponentsGridList items={componentNames} />
+  </HoverBox>
+);
+
+/**
+ * The OpenAPI servers and security section for Column 1.
+ */
+export const OpenAPIServersSection = <T extends BaseHoverState & { [K in keyof T]: boolean }>({
+  hoverState,
+  setHoverState,
+  testId
+}: SharedSectionProps<T> & { testId?: string }) => (
+  <div className='flex flex-1 flex-wrap'>
+    <HoverBox<T>
+      label='Servers'
+      fieldKey={'Servers' as keyof T}
+      hoverState={hoverState}
+      setHoverState={setHoverState}
+      activeClass='bg-green-100 dark:bg-green-900/40'
+      defaultClass=' '
+      borderClass='border-green-300 dark:border-green-700'
+      className='flex-1'
+      testId={testId}
+      useMouseOver
+    />
+    <ComparisonBox className='flex-1 hover:bg-gray-200 dark:hover:bg-gray-800'>Security</ComparisonBox>
+  </div>
+);
+
+/**
+ * The AsyncAPI servers section for Column 2.
+ */
+export const AsyncAPIServersSection = <T extends BaseHoverState & { [K in keyof T]: boolean }>({
+  hoverState,
+  setHoverState
+}: SharedSectionProps<T>) => (
+  <div className='flex flex-1 flex-wrap'>
+    <HoverBox<T>
+      label='Servers (hosts + security)'
+      fieldKey={'Servers' as keyof T}
+      hoverState={hoverState}
+      setHoverState={setHoverState}
+      activeClass='bg-green-100 dark:bg-green-900/40'
+      defaultClass=' '
+      borderClass='border-green-300 dark:border-green-700'
+      className='flex-1'
+      useMouseOver
+    />
+  </div>
+);

--- a/components/OpenAPIComparisonCommon.tsx
+++ b/components/OpenAPIComparisonCommon.tsx
@@ -25,7 +25,7 @@ export const SpecInfoSection = <T extends BaseHoverState & { [K in keyof T]: boo
 }: SharedSectionProps<T>) => (
   <HoverBox<T>
     label='Info'
-    fieldKey={'Info' as keyof T}
+    fieldKey='Info'
     hoverState={hoverState}
     setHoverState={setHoverState}
     activeClass='bg-blue-100 dark:bg-blue-900/40'
@@ -46,7 +46,7 @@ export const TagsAndExternalDocsSection = <T extends BaseHoverState & { [K in ke
   <div className='flex flex-1 flex-wrap'>
     <HoverBox<T>
       label='Tags'
-      fieldKey={'Tags' as keyof T}
+      fieldKey='Tags'
       hoverState={hoverState}
       setHoverState={setHoverState}
       activeClass='bg-pink-300 dark:bg-pink-900/60'
@@ -57,7 +57,7 @@ export const TagsAndExternalDocsSection = <T extends BaseHoverState & { [K in ke
     />
     <HoverBox<T>
       label='External Docs'
-      fieldKey={'External' as keyof T}
+      fieldKey='External'
       hoverState={hoverState}
       setHoverState={setHoverState}
       activeClass='bg-green-500 dark:bg-green-900/60'
@@ -86,7 +86,7 @@ export const SpecComponentsSection = <T extends BaseHoverState & { [K in keyof T
 }: SpecComponentsSectionProps<T>) => (
   <HoverBox<T>
     label='Components'
-    fieldKey={'Components' as keyof T}
+    fieldKey='Components'
     hoverState={hoverState}
     setHoverState={setHoverState}
     activeClass='bg-gray-100 dark:bg-gray-800'
@@ -110,7 +110,7 @@ export const OpenAPIServersSection = <T extends BaseHoverState & { [K in keyof T
   <div className='flex flex-1 flex-wrap'>
     <HoverBox<T>
       label='Servers'
-      fieldKey={'Servers' as keyof T}
+      fieldKey='Servers'
       hoverState={hoverState}
       setHoverState={setHoverState}
       activeClass='bg-green-100 dark:bg-green-900/40'
@@ -134,7 +134,7 @@ export const AsyncAPIServersSection = <T extends BaseHoverState & { [K in keyof 
   <div className='flex flex-1 flex-wrap'>
     <HoverBox<T>
       label='Servers (hosts + security)'
-      fieldKey={'Servers' as keyof T}
+      fieldKey='Servers'
       hoverState={hoverState}
       setHoverState={setHoverState}
       activeClass='bg-green-100 dark:bg-green-900/40'

--- a/components/OpenAPIComparisonCommon.tsx
+++ b/components/OpenAPIComparisonCommon.tsx
@@ -29,7 +29,7 @@ export const SpecInfoSection = <T extends BaseHoverState & { [K in keyof T]: boo
     hoverState={hoverState}
     setHoverState={setHoverState}
     activeClass='bg-blue-100 dark:bg-blue-900/40'
-    defaultClass=' '
+    defaultClass=''
     borderClass='border-blue-300 dark:border-blue-700'
     useMouseOver
   />
@@ -50,7 +50,7 @@ export const TagsAndExternalDocsSection = <T extends BaseHoverState & { [K in ke
       hoverState={hoverState}
       setHoverState={setHoverState}
       activeClass='bg-pink-300 dark:bg-pink-900/60'
-      defaultClass=' '
+      defaultClass=''
       borderClass='border-black dark:border-gray-600'
       className='flex flex-1 items-center justify-center'
       useMouseOver
@@ -61,7 +61,7 @@ export const TagsAndExternalDocsSection = <T extends BaseHoverState & { [K in ke
       hoverState={hoverState}
       setHoverState={setHoverState}
       activeClass='bg-green-500 dark:bg-green-900/60'
-      defaultClass=' '
+      defaultClass=''
       borderClass='border-black dark:border-gray-600'
       className='flex flex-1 items-center justify-center'
       useMouseOver
@@ -69,9 +69,10 @@ export const TagsAndExternalDocsSection = <T extends BaseHoverState & { [K in ke
   </div>
 );
 
-export interface SpecComponentsSectionProps<T extends BaseHoverState & { [K in keyof T]: boolean }>
-  extends SharedSectionProps<T> {
-  /** List of component names to display in the two-column grid. */
+export interface SpecComponentsSectionProps<
+  T extends BaseHoverState & { [K in keyof T]: boolean }
+> extends SharedSectionProps<T> {
+  // List of component names to display in the two-column grid.
   componentNames: string[];
 }
 
@@ -90,7 +91,7 @@ export const SpecComponentsSection = <T extends BaseHoverState & { [K in keyof T
     hoverState={hoverState}
     setHoverState={setHoverState}
     activeClass='bg-gray-100 dark:bg-gray-800'
-    defaultClass=' '
+    defaultClass=''
     borderClass='border-black dark:border-gray-600'
     className='flex-1'
     useMouseOver
@@ -114,7 +115,7 @@ export const OpenAPIServersSection = <T extends BaseHoverState & { [K in keyof T
       hoverState={hoverState}
       setHoverState={setHoverState}
       activeClass='bg-green-100 dark:bg-green-900/40'
-      defaultClass=' '
+      defaultClass=''
       borderClass='border-green-300 dark:border-green-700'
       className='flex-1'
       testId={testId}
@@ -138,7 +139,7 @@ export const AsyncAPIServersSection = <T extends BaseHoverState & { [K in keyof 
       hoverState={hoverState}
       setHoverState={setHoverState}
       activeClass='bg-green-100 dark:bg-green-900/40'
-      defaultClass=' '
+      defaultClass=''
       borderClass='border-green-300 dark:border-green-700'
       className='flex-1'
       useMouseOver

--- a/components/OpenAPIComparisonV3.tsx
+++ b/components/OpenAPIComparisonV3.tsx
@@ -1,7 +1,13 @@
 import React, { useState } from 'react';
 
 import { Column, ComparisonBox, HoverBox } from './ComparisonCommon';
-import { AsyncAPIServersSection, OpenAPIServersSection, SpecComponentsSection, SpecInfoSection, TagsAndExternalDocsSection } from './OpenAPIComparisonCommon';
+import {
+  AsyncAPIServersSection,
+  OpenAPIServersSection,
+  SpecComponentsSection,
+  SpecInfoSection,
+  TagsAndExternalDocsSection
+} from './OpenAPIComparisonCommon';
 
 interface HoverState {
   Info: boolean;
@@ -79,7 +85,7 @@ export default function OpenAPIComparisonV3({ className = '' }: OpenAPICompariso
           hoverState={hoverState}
           setHoverState={setHoverState}
           activeClass='bg-yellow-100 dark:bg-yellow-900/40'
-          defaultClass=' '
+          defaultClass=''
           borderClass='border-yellow-300 dark:border-yellow-700'
         >
           <div className='flex flex-1 flex-wrap'>
@@ -160,7 +166,7 @@ export default function OpenAPIComparisonV3({ className = '' }: OpenAPICompariso
           hoverState={hoverState}
           setHoverState={setHoverState}
           activeClass='bg-yellow-100 dark:bg-yellow-900/40'
-          defaultClass=' '
+          defaultClass=''
           borderClass='border-yellow-300 dark:border-yellow-700'
         >
           <div className='flex flex-1 flex-wrap'>

--- a/components/OpenAPIComparisonV3.tsx
+++ b/components/OpenAPIComparisonV3.tsx
@@ -47,6 +47,84 @@ const ASYNCAPI_V3_COMPONENT_NAMES = [
   'Message Bindings'
 ];
 
+interface SharedSectionProps {
+  hoverState: HoverState;
+  setHoverState: React.Dispatch<React.SetStateAction<HoverState>>;
+}
+
+/**
+ * The "Info" hover box that appears at the top of both spec columns.
+ * Hovering on one column highlights the matching box in the other column.
+ */
+const SpecInfoSection = ({ hoverState, setHoverState }: SharedSectionProps) => (
+  <HoverBox<HoverState>
+    label='Info'
+    fieldKey='Info'
+    hoverState={hoverState}
+    setHoverState={setHoverState}
+    activeClass='bg-blue-100 dark:bg-blue-900/40'
+    defaultClass=' '
+    borderClass='border-blue-300 dark:border-blue-700'
+    useMouseOver
+  />
+);
+
+/**
+ * The "Tags" and "External Docs" row that appears at the bottom of both spec columns.
+ * Both boxes share the same hover state so hovering one highlights the other.
+ */
+const TagsAndExternalDocsSection = ({ hoverState, setHoverState }: SharedSectionProps) => (
+  <div className='flex flex-1 flex-wrap'>
+    <HoverBox<HoverState>
+      label='Tags'
+      fieldKey='Tags'
+      hoverState={hoverState}
+      setHoverState={setHoverState}
+      activeClass='bg-pink-300 dark:bg-pink-900/60'
+      defaultClass=' '
+      borderClass='border-black dark:border-gray-600'
+      className='flex flex-1 items-center justify-center'
+      useMouseOver
+    />
+    <HoverBox<HoverState>
+      label='External Docs'
+      fieldKey='External'
+      hoverState={hoverState}
+      setHoverState={setHoverState}
+      activeClass='bg-green-500 dark:bg-green-900/60'
+      defaultClass=' '
+      borderClass='border-black dark:border-gray-600'
+      className='flex flex-1 items-center justify-center'
+      useMouseOver
+    />
+  </div>
+);
+
+interface SpecComponentsSectionProps extends SharedSectionProps {
+  /** List of component names to display in the two-column grid. */
+  componentNames: string[];
+}
+
+/**
+ * The "Components" hover box that wraps a grid of spec component names.
+ * Each column passes its own component name list; hover state is still shared.
+ */
+const SpecComponentsSection = ({ hoverState, setHoverState, componentNames }: SpecComponentsSectionProps) => (
+  <HoverBox<HoverState>
+    label='Components'
+    fieldKey='Components'
+    hoverState={hoverState}
+    setHoverState={setHoverState}
+    activeClass='bg-gray-100 dark:bg-gray-800'
+    defaultClass=' '
+    borderClass='border-black dark:border-gray-600'
+    className='flex-1'
+    useMouseOver
+  >
+    <ComponentsGridList items={componentNames} />
+  </HoverBox>
+);
+
 /**
  * @description OpenAPIComparisonV3 component displays a comparison between OpenAPI 3.0 and AsyncAPI 3.0 specifications.
  * @param {string} [props.className=''] - Additional CSS classes for styling.
@@ -70,16 +148,7 @@ export default function OpenAPIComparisonV3({ className = '' }: OpenAPICompariso
   return (
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
       <Column title='OpenAPI 3.0'>
-        <HoverBox<HoverState>
-          label='Info'
-          fieldKey='Info'
-          hoverState={hoverState}
-          setHoverState={setHoverState}
-          activeClass='bg-blue-100 dark:bg-blue-900/40'
-          defaultClass=' '
-          borderClass='border-blue-300 dark:border-blue-700'
-          useMouseOver
-        />
+        <SpecInfoSection hoverState={hoverState} setHoverState={setHoverState} />
         <div className='flex flex-1 flex-wrap'>
           <HoverBox<HoverState>
             label='Servers'
@@ -164,56 +233,16 @@ export default function OpenAPIComparisonV3({ className = '' }: OpenAPICompariso
             </HoverBox>
           </div>
         </HoverBox>
-        <div className='flex flex-1 flex-wrap'>
-          <HoverBox<HoverState>
-            label='Tags'
-            fieldKey='Tags'
-            hoverState={hoverState}
-            setHoverState={setHoverState}
-            activeClass='bg-pink-300 dark:bg-pink-900/60'
-            defaultClass=' '
-            borderClass='border-black dark:border-gray-600'
-            className='flex flex-1 items-center justify-center'
-            useMouseOver
-          />
-          <HoverBox<HoverState>
-            label='External Docs'
-            fieldKey='External'
-            hoverState={hoverState}
-            setHoverState={setHoverState}
-            activeClass='bg-green-500 dark:bg-green-900/60'
-            defaultClass=' '
-            borderClass='border-black dark:border-gray-600'
-            className='flex flex-1 items-center justify-center'
-            useMouseOver
-          />
-        </div>
-        <HoverBox<HoverState>
-          label='Components'
-          fieldKey='Components'
+        <TagsAndExternalDocsSection hoverState={hoverState} setHoverState={setHoverState} />
+        <SpecComponentsSection
           hoverState={hoverState}
           setHoverState={setHoverState}
-          activeClass='bg-gray-100 dark:bg-gray-800'
-          defaultClass=' '
-          borderClass='border-black dark:border-gray-600'
-          className='flex-1'
-          useMouseOver
-        >
-          <ComponentsGridList items={OPENAPI_V3_COMPONENT_NAMES} />
-        </HoverBox>
+          componentNames={OPENAPI_V3_COMPONENT_NAMES}
+        />
       </Column>
 
       <Column title='AsyncAPI 3.0'>
-        <HoverBox<HoverState>
-          label='Info'
-          fieldKey='Info'
-          hoverState={hoverState}
-          setHoverState={setHoverState}
-          activeClass='bg-blue-100 dark:bg-blue-900/40'
-          defaultClass=' '
-          borderClass='border-blue-300 dark:border-blue-700'
-          useMouseOver
-        />
+        <SpecInfoSection hoverState={hoverState} setHoverState={setHoverState} />
         <div className='flex flex-1 flex-wrap'>
           <HoverBox<HoverState>
             label='Servers (hosts + security)'
@@ -334,43 +363,12 @@ export default function OpenAPIComparisonV3({ className = '' }: OpenAPICompariso
             Id (application identifier)
           </ComparisonBox>
         </div>
-        <div className='flex flex-1 flex-wrap'>
-          <HoverBox<HoverState>
-            label='Tags'
-            fieldKey='Tags'
-            hoverState={hoverState}
-            setHoverState={setHoverState}
-            activeClass='bg-pink-300 dark:bg-pink-900/60'
-            defaultClass=' '
-            borderClass='border-black dark:border-gray-600'
-            className='flex flex-1 items-center justify-center'
-            useMouseOver
-          />
-          <HoverBox<HoverState>
-            label='External Docs'
-            fieldKey='External'
-            hoverState={hoverState}
-            setHoverState={setHoverState}
-            activeClass='bg-green-500 dark:bg-green-900/60'
-            defaultClass=' '
-            borderClass='border-black dark:border-gray-600'
-            className='flex flex-1 items-center justify-center'
-            useMouseOver
-          />
-        </div>
-        <HoverBox<HoverState>
-          label='Components'
-          fieldKey='Components'
+        <TagsAndExternalDocsSection hoverState={hoverState} setHoverState={setHoverState} />
+        <SpecComponentsSection
           hoverState={hoverState}
           setHoverState={setHoverState}
-          activeClass='bg-gray-100 dark:bg-gray-800'
-          defaultClass=' '
-          borderClass='border-black dark:border-gray-600'
-          className='flex-1'
-          useMouseOver
-        >
-          <ComponentsGridList items={ASYNCAPI_V3_COMPONENT_NAMES} />
-        </HoverBox>
+          componentNames={ASYNCAPI_V3_COMPONENT_NAMES}
+        />
       </Column>
     </div>
   );

--- a/components/OpenAPIComparisonV3.tsx
+++ b/components/OpenAPIComparisonV3.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Column, HoverBox } from './ComparisonCommon';
+import { Column, ComparisonBox, ComponentsGridList, HoverBox } from './ComparisonCommon';
 
 interface HoverState {
   Info: boolean;
@@ -21,23 +21,35 @@ interface OpenAPIComparisonV3Props {
   className?: string;
 }
 
-const StaticBox = ({ children, className = '' }: { children: React.ReactNode; className?: string }) => (
-  <div className={`m-2 border border-black p-2 dark:border-gray-600 ${className}`}>{children}</div>
-);
+/** Component entries shown inside the OpenAPI 3.0 Components section (V3 comparison). */
+const OPENAPI_V3_COMPONENT_NAMES = [
+  'Definitions',
+  'Responses',
+  'Parameters',
+  'Response Headers',
+  'Security Definitions',
+  'Callbacks',
+  'Links'
+];
 
-const ComponentGrid = ({ children }: { children: React.ReactNode }) => (
-  <div className='grid-gap-2 mt-2 grid flex-1 grid-cols-2 flex-wrap'>{children}</div>
-);
-
-const ComponentItem = ({ children }: { children: React.ReactNode }) => (
-  <div className='m-2 box-border border border-black bg-gray-100 p-2 dark:border-gray-600 dark:bg-gray-800'>
-    {children}
-  </div>
-);
+/** Component entries shown inside the AsyncAPI 3.0 Components section. */
+const ASYNCAPI_V3_COMPONENT_NAMES = [
+  'Schemas',
+  'Messages',
+  'Security Schemes',
+  'Parameters',
+  'Correlation Ids',
+  'Operation Traits',
+  'Message Traits',
+  'Server Bindings',
+  'Channel Bindings',
+  'Operation Bindings',
+  'Message Bindings'
+];
 
 /**
  * @description OpenAPIComparisonV3 component displays a comparison between OpenAPI 3.0 and AsyncAPI 3.0 specifications.
- * @param {string} [props.className=''] - Additional CSS classes for styling
+ * @param {string} [props.className=''] - Additional CSS classes for styling.
  */
 export default function OpenAPIComparisonV3({ className = '' }: OpenAPIComparisonV3Props) {
   const [hoverState, setHoverState] = useState<HoverState>({
@@ -80,7 +92,7 @@ export default function OpenAPIComparisonV3({ className = '' }: OpenAPICompariso
             className='flex-1'
             useMouseOver
           />
-          <StaticBox className='flex-1 hover:bg-gray-200 dark:hover:bg-gray-800'>Security</StaticBox>
+          <ComparisonBox className='flex-1 hover:bg-gray-200 dark:hover:bg-gray-800'>Security</ComparisonBox>
         </div>
         <HoverBox<HoverState>
           label='Paths'
@@ -187,15 +199,7 @@ export default function OpenAPIComparisonV3({ className = '' }: OpenAPICompariso
           className='flex-1'
           useMouseOver
         >
-          <ComponentGrid>
-            <ComponentItem>Definitions</ComponentItem>
-            <ComponentItem>Responses</ComponentItem>
-            <ComponentItem>Parameters</ComponentItem>
-            <ComponentItem>Response Headers</ComponentItem>
-            <ComponentItem>Security Definitions</ComponentItem>
-            <ComponentItem>Callbacks</ComponentItem>
-            <ComponentItem>Links</ComponentItem>
-          </ComponentGrid>
+          <ComponentsGridList items={OPENAPI_V3_COMPONENT_NAMES} />
         </HoverBox>
       </Column>
 
@@ -263,8 +267,8 @@ export default function OpenAPIComparisonV3({ className = '' }: OpenAPICompariso
                       borderClass='border-red-600 dark:border-red-700'
                       className='flex-1'
                     >
-                      <StaticBox className='box-border flex-1'>Headers</StaticBox>
-                      <StaticBox className='box-border flex-1'>Payload</StaticBox>
+                      <ComparisonBox className='box-border flex-1'>Headers</ComparisonBox>
+                      <ComparisonBox className='box-border flex-1'>Payload</ComparisonBox>
                     </HoverBox>
                   </div>
                 </div>
@@ -326,9 +330,9 @@ export default function OpenAPIComparisonV3({ className = '' }: OpenAPICompariso
           </div>
         </HoverBox>
         <div className='flex flex-1 flex-wrap'>
-          <StaticBox className='box-border flex-1 hover:bg-blue-400 dark:hover:bg-blue-900/50'>
+          <ComparisonBox className='box-border flex-1 hover:bg-blue-400 dark:hover:bg-blue-900/50'>
             Id (application identifier)
-          </StaticBox>
+          </ComparisonBox>
         </div>
         <div className='flex flex-1 flex-wrap'>
           <HoverBox<HoverState>
@@ -365,19 +369,7 @@ export default function OpenAPIComparisonV3({ className = '' }: OpenAPICompariso
           className='flex-1'
           useMouseOver
         >
-          <ComponentGrid>
-            <ComponentItem>Schemas</ComponentItem>
-            <ComponentItem>Messages</ComponentItem>
-            <ComponentItem>Security Schemes</ComponentItem>
-            <ComponentItem>Parameters</ComponentItem>
-            <ComponentItem>Correlation Ids</ComponentItem>
-            <ComponentItem>Operation Traits</ComponentItem>
-            <ComponentItem>Message Traits</ComponentItem>
-            <ComponentItem>Server Bindings</ComponentItem>
-            <ComponentItem>Channel Bindings</ComponentItem>
-            <ComponentItem>Operation Bindings</ComponentItem>
-            <ComponentItem>Message Bindings</ComponentItem>
-          </ComponentGrid>
+          <ComponentsGridList items={ASYNCAPI_V3_COMPONENT_NAMES} />
         </HoverBox>
       </Column>
     </div>

--- a/components/OpenAPIComparisonV3.tsx
+++ b/components/OpenAPIComparisonV3.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
-import { Column, ComparisonBox, ComponentsGridList, HoverBox } from './ComparisonCommon';
+import { Column, ComparisonBox, HoverBox } from './ComparisonCommon';
+import { AsyncAPIServersSection, OpenAPIServersSection, SpecComponentsSection, SpecInfoSection, TagsAndExternalDocsSection } from './OpenAPIComparisonCommon';
 
 interface HoverState {
   Info: boolean;
@@ -47,84 +48,6 @@ const ASYNCAPI_V3_COMPONENT_NAMES = [
   'Message Bindings'
 ];
 
-interface SharedSectionProps {
-  hoverState: HoverState;
-  setHoverState: React.Dispatch<React.SetStateAction<HoverState>>;
-}
-
-/**
- * The "Info" hover box that appears at the top of both spec columns.
- * Hovering on one column highlights the matching box in the other column.
- */
-const SpecInfoSection = ({ hoverState, setHoverState }: SharedSectionProps) => (
-  <HoverBox<HoverState>
-    label='Info'
-    fieldKey='Info'
-    hoverState={hoverState}
-    setHoverState={setHoverState}
-    activeClass='bg-blue-100 dark:bg-blue-900/40'
-    defaultClass=' '
-    borderClass='border-blue-300 dark:border-blue-700'
-    useMouseOver
-  />
-);
-
-/**
- * The "Tags" and "External Docs" row that appears at the bottom of both spec columns.
- * Both boxes share the same hover state so hovering one highlights the other.
- */
-const TagsAndExternalDocsSection = ({ hoverState, setHoverState }: SharedSectionProps) => (
-  <div className='flex flex-1 flex-wrap'>
-    <HoverBox<HoverState>
-      label='Tags'
-      fieldKey='Tags'
-      hoverState={hoverState}
-      setHoverState={setHoverState}
-      activeClass='bg-pink-300 dark:bg-pink-900/60'
-      defaultClass=' '
-      borderClass='border-black dark:border-gray-600'
-      className='flex flex-1 items-center justify-center'
-      useMouseOver
-    />
-    <HoverBox<HoverState>
-      label='External Docs'
-      fieldKey='External'
-      hoverState={hoverState}
-      setHoverState={setHoverState}
-      activeClass='bg-green-500 dark:bg-green-900/60'
-      defaultClass=' '
-      borderClass='border-black dark:border-gray-600'
-      className='flex flex-1 items-center justify-center'
-      useMouseOver
-    />
-  </div>
-);
-
-interface SpecComponentsSectionProps extends SharedSectionProps {
-  /** List of component names to display in the two-column grid. */
-  componentNames: string[];
-}
-
-/**
- * The "Components" hover box that wraps a grid of spec component names.
- * Each column passes its own component name list; hover state is still shared.
- */
-const SpecComponentsSection = ({ hoverState, setHoverState, componentNames }: SpecComponentsSectionProps) => (
-  <HoverBox<HoverState>
-    label='Components'
-    fieldKey='Components'
-    hoverState={hoverState}
-    setHoverState={setHoverState}
-    activeClass='bg-gray-100 dark:bg-gray-800'
-    defaultClass=' '
-    borderClass='border-black dark:border-gray-600'
-    className='flex-1'
-    useMouseOver
-  >
-    <ComponentsGridList items={componentNames} />
-  </HoverBox>
-);
-
 /**
  * @description OpenAPIComparisonV3 component displays a comparison between OpenAPI 3.0 and AsyncAPI 3.0 specifications.
  * @param {string} [props.className=''] - Additional CSS classes for styling.
@@ -149,20 +72,7 @@ export default function OpenAPIComparisonV3({ className = '' }: OpenAPICompariso
     <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
       <Column title='OpenAPI 3.0'>
         <SpecInfoSection hoverState={hoverState} setHoverState={setHoverState} />
-        <div className='flex flex-1 flex-wrap'>
-          <HoverBox<HoverState>
-            label='Servers'
-            fieldKey='Servers'
-            hoverState={hoverState}
-            setHoverState={setHoverState}
-            activeClass='bg-green-100 dark:bg-green-900/40'
-            defaultClass=' '
-            borderClass='border-green-300 dark:border-green-700'
-            className='flex-1'
-            useMouseOver
-          />
-          <ComparisonBox className='flex-1 hover:bg-gray-200 dark:hover:bg-gray-800'>Security</ComparisonBox>
-        </div>
+        <OpenAPIServersSection hoverState={hoverState} setHoverState={setHoverState} />
         <HoverBox<HoverState>
           label='Paths'
           fieldKey='Paths'
@@ -243,19 +153,7 @@ export default function OpenAPIComparisonV3({ className = '' }: OpenAPICompariso
 
       <Column title='AsyncAPI 3.0'>
         <SpecInfoSection hoverState={hoverState} setHoverState={setHoverState} />
-        <div className='flex flex-1 flex-wrap'>
-          <HoverBox<HoverState>
-            label='Servers (hosts + security)'
-            fieldKey='Servers'
-            hoverState={hoverState}
-            setHoverState={setHoverState}
-            activeClass='bg-green-100 dark:bg-green-900/40'
-            defaultClass=' '
-            borderClass='border-green-300 dark:border-green-700'
-            className='flex-1'
-            useMouseOver
-          />
-        </div>
+        <AsyncAPIServersSection hoverState={hoverState} setHoverState={setHoverState} />
         <HoverBox<HoverState>
           label='Channels'
           fieldKey='Paths'

--- a/components/OpenAPIComparisonV3.tsx
+++ b/components/OpenAPIComparisonV3.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 
+import { Column, HoverBox } from './ComparisonCommon';
+
 interface HoverState {
   Info: boolean;
   Servers: boolean;
@@ -18,6 +20,20 @@ interface HoverState {
 interface OpenAPIComparisonV3Props {
   className?: string;
 }
+
+const StaticBox = ({ children, className = '' }: { children: React.ReactNode; className?: string }) => (
+  <div className={`m-2 border border-black p-2 dark:border-gray-600 ${className}`}>{children}</div>
+);
+
+const ComponentGrid = ({ children }: { children: React.ReactNode }) => (
+  <div className='grid-gap-2 mt-2 grid flex-1 grid-cols-2 flex-wrap'>{children}</div>
+);
+
+const ComponentItem = ({ children }: { children: React.ReactNode }) => (
+  <div className='m-2 box-border border border-black bg-gray-100 p-2 dark:border-gray-600 dark:bg-gray-800'>
+    {children}
+  </div>
+);
 
 /**
  * @description OpenAPIComparisonV3 component displays a comparison between OpenAPI 3.0 and AsyncAPI 3.0 specifications.
@@ -40,265 +56,330 @@ export default function OpenAPIComparisonV3({ className = '' }: OpenAPICompariso
   });
 
   return (
-    <div className={`${className} flex flex-wrap text-center`}>
-      <div className='mr-1 flex-1 border border-black p-2'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>OpenAPI 3.0</h3>
-        <div>
-          <div
-            className={`${hoverState.Info ? 'bg-blue-100 ' : ' '}m-2 border border-blue-300 p-2`}
-            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Info: true }))}
-            onMouseLeave={() => setHoverState({ ...hoverState, Info: false })}
-          >
-            Info
-          </div>
-          <div className='flex flex-1 flex-wrap'>
-            <div
-              className={`${hoverState.Servers ? 'bg-green-100' : ' '} m-2 flex-1 border border-green-300 p-2`}
-              onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Servers: true }))}
-              onMouseLeave={() => setHoverState({ ...hoverState, Servers: false })}
-            >
-              Servers
-            </div>
-            <div className='border-bg-gray-500 m-2 flex-1 border p-2 hover:bg-gray-200'>Security</div>
-          </div>
-          <div
-            className={`${hoverState.Paths ? 'bg-yellow-100' : ' '} m-2 border border-yellow-300 p-2`}
-            onMouseEnter={() => setHoverState((prevState) => ({ ...prevState, Paths: true }))}
-            onMouseLeave={() => setHoverState({ ...hoverState, Paths: false })}
-          >
-            Paths
-            <div className='flex flex-1 flex-wrap'>
-              <div
-                className={`${hoverState.PathItem ? 'bg-yellow-300' : 'bg-white'} m-2 border border-yellow-600 p-2`}
-                onMouseEnter={() => {
-                  return setHoverState((prevState) => ({ ...prevState, PathItem: true }));
-                }}
-                onMouseLeave={() => {
-                  return setHoverState({ ...hoverState, PathItem: false });
-                }}
-              >
-                Path Item
-                <div className='flex flex-1 flex-col flex-wrap'>
-                  <div
-                    className={`${hoverState.Summary ? 'bg-blue-200' : 'bg-white'} m-2 border border-blue-500 p-2`}
-                    onMouseEnter={() => setHoverState((prevState) => ({ ...prevState, Summary: true }))}
-                    onMouseLeave={() => {
-                      return setHoverState({ ...hoverState, Summary: false });
-                    }}
-                  >
-                    Summary and description
-                  </div>
-                  <div className='flex flex-1 flex-wrap'>
-                    <div
-                      className={`${hoverState.OperationItem ? 'bg-orange-300' : 'bg-white'} m-2 flex-1 border border-orange-300 p-2`}
-                      onMouseEnter={() => setHoverState((prevState) => ({ ...prevState, OperationItem: true }))}
-                      onMouseLeave={() => setHoverState({ ...hoverState, OperationItem: false })}
-                    >
-                      Operation
-                      <div
-                        className={`${hoverState.OperationType ? 'bg-orange-400' : 'bg-white'} m-2 flex-1 border border-orange-300 p-2`}
-                        onMouseEnter={() => setHoverState((prevState) => ({ ...prevState, OperationType: true }))}
-                        onMouseLeave={() => setHoverState({ ...hoverState, OperationType: false })}
-                      >
-                        GET, PUT, POST, etc.
-                      </div>
-                      <div
-                        className={`${hoverState.Message ? 'bg-red-400' : 'bg-white'} m-2 flex-1 border border-red-600 p-2`}
-                        onMouseEnter={() => setHoverState((prevState) => ({ ...prevState, Message: true }))}
-                        onMouseLeave={() => setHoverState({ ...hoverState, Message: false })}
-                      >
-                        Request
-                      </div>
-                      <div
-                        className={`${hoverState.Message ? 'bg-red-400' : 'bg-white'} m-2 flex-1 border border-red-600 p-2`}
-                        onMouseEnter={() => setHoverState((prevState) => ({ ...prevState, Message: true }))}
-                        onMouseLeave={() => setHoverState({ ...hoverState, Message: false })}
-                      >
-                        Responses
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className='flex flex-1 flex-wrap'>
-            <div
-              className={`${hoverState.Tags ? 'bg-pink-300' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2`}
-              onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Tags: true }))}
-              onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Tags: false }))}
-            >
-              <p>Tags</p>
-            </div>
-            <div
-              className={`${hoverState.External ? 'bg-green-500' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2`}
-              onMouseOver={() => setHoverState((prevState) => ({ ...prevState, External: true }))}
-              onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, External: false }))}
-            >
-              <p>External Docs</p>
-            </div>
-          </div>
-          <div
-            className={`${hoverState.Components ? 'bg-gray-100' : ' '} m-2 flex-1 border border-black p-2`}
-            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Components: true }))}
-            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Components: false }))}
-          >
-            Components
-            <div className='grid-gap-2 mt-1 grid flex-1 grid-cols-2'>
-              <div className='m-2 border border-black bg-gray-100 p-2'>Definitions</div>
-              <div className='m-2 border border-black bg-gray-100 p-2'>Responses</div>
-              <div className='m-2 border border-black bg-gray-100 p-2'>Parameters</div>
-              <div className='m-2 border border-black bg-gray-100 p-2'>Response Headers</div>
-              <div className='m-2 border border-black bg-gray-100 p-2'>Security Definitions</div>
-              <div className='m-2 border border-black bg-gray-100 p-2'>Callbacks</div>
-              <div className='m-2 border border-black bg-gray-100 p-2'>Links</div>
-            </div>
-          </div>
+    <div className={`${className} flex flex-col flex-wrap gap-1 text-center md:flex-row`}>
+      <Column title='OpenAPI 3.0'>
+        <HoverBox<HoverState>
+          label='Info'
+          fieldKey='Info'
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass='bg-blue-100 dark:bg-blue-900/40'
+          defaultClass=' '
+          borderClass='border-blue-300 dark:border-blue-700'
+          useMouseOver
+        />
+        <div className='flex flex-1 flex-wrap'>
+          <HoverBox<HoverState>
+            label='Servers'
+            fieldKey='Servers'
+            hoverState={hoverState}
+            setHoverState={setHoverState}
+            activeClass='bg-green-100 dark:bg-green-900/40'
+            defaultClass=' '
+            borderClass='border-green-300 dark:border-green-700'
+            className='flex-1'
+            useMouseOver
+          />
+          <StaticBox className='flex-1 hover:bg-gray-200 dark:hover:bg-gray-800'>Security</StaticBox>
         </div>
-      </div>
-      <div className='ml-1 flex-1 border border-black p-2'>
-        <h3 className='mb-4 ml-2 font-sans text-lg font-medium'>AsyncAPI 3.0</h3>
-        <div>
-          <div
-            className={`${hoverState.Info ? 'bg-blue-100 ' : ' '}m-2 border border-blue-300 p-2`}
-            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Info: true }))}
-            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Info: false }))}
-          >
-            Info
-          </div>
+        <HoverBox<HoverState>
+          label='Paths'
+          fieldKey='Paths'
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass='bg-yellow-100 dark:bg-yellow-900/40'
+          defaultClass=' '
+          borderClass='border-yellow-300 dark:border-yellow-700'
+        >
           <div className='flex flex-1 flex-wrap'>
-            <div
-              className={`${hoverState.Servers ? 'bg-green-100' : ' '} m-2 flex-1 border border-green-300 p-2`}
-              onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Servers: true }))}
-              onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Servers: false }))}
+            <HoverBox<HoverState>
+              label='Path Item'
+              fieldKey='PathItem'
+              hoverState={hoverState}
+              setHoverState={setHoverState}
+              activeClass='bg-yellow-300 dark:bg-yellow-800/60'
+              borderClass='border-yellow-600 dark:border-yellow-700'
             >
-              Servers (hosts + security)
-            </div>
-          </div>
-          <div
-            className={`${hoverState.Paths ? 'bg-yellow-100' : ' '} m-2 border border-yellow-300 p-2`}
-            onMouseEnter={() => setHoverState((prevState) => ({ ...prevState, Paths: true }))}
-            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Paths: false }))}
-          >
-            Channels
-            <div className='flex flex-1 flex-wrap'>
-              <div
-                className={`${hoverState.PathItem ? 'bg-yellow-300' : 'bg-white'} m-2 border border-yellow-600 p-2`}
-                onMouseOver={() => setHoverState((prevState) => ({ ...prevState, PathItem: true }))}
-                onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, PathItem: false }))}
-              >
-                Channel
+              <div className='flex flex-1 flex-col flex-wrap'>
+                <HoverBox<HoverState>
+                  label='Summary and description'
+                  fieldKey='Summary'
+                  hoverState={hoverState}
+                  setHoverState={setHoverState}
+                  activeClass='bg-blue-200 dark:bg-blue-900/50'
+                  borderClass='border-blue-500 dark:border-blue-400'
+                />
                 <div className='flex flex-1 flex-wrap'>
-                  <div className='flex flex-1 flex-wrap'>
-                    <div
-                      className={`${hoverState.Summary ? 'bg-blue-200' : 'bg-white'} m-2 border border-blue-500 p-2`}
-                      onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Summary: true }))}
-                      onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Summary: false }))}
-                    >
-                      Summary, description
-                    </div>
-                    <div className='flex flex-1 flex-wrap'>
-                      <div
-                        className={`${hoverState.Message ? 'bg-red-400' : 'bg-white'} m-2 flex-1 border border-red-600 p-2`}
-                        onMouseEnter={() => setHoverState((prevState) => ({ ...prevState, Message: true }))}
-                        onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Message: false }))}
-                      >
-                        Messages
-                        <div className='m-2 mr-1 box-border flex-1 border border-black p-2'>Headers</div>
-                        <div className='m-2 mr-1 box-border flex-1 border border-black p-2'>Payload</div>
-                      </div>
-                    </div>
-                  </div>
+                  <HoverBox<HoverState>
+                    label='Operation'
+                    fieldKey='OperationItem'
+                    hoverState={hoverState}
+                    setHoverState={setHoverState}
+                    activeClass='bg-orange-300 dark:bg-orange-800/60'
+                    borderClass='border-orange-300 dark:border-orange-700'
+                    className='flex-1'
+                  >
+                    <HoverBox<HoverState>
+                      label='GET, PUT, POST, etc.'
+                      fieldKey='OperationType'
+                      hoverState={hoverState}
+                      setHoverState={setHoverState}
+                      activeClass='bg-orange-400 dark:bg-orange-900/70'
+                      borderClass='border-orange-300 dark:border-orange-700'
+                      className='flex-1'
+                    />
+                    <HoverBox<HoverState>
+                      label='Request'
+                      fieldKey='Message'
+                      hoverState={hoverState}
+                      setHoverState={setHoverState}
+                      activeClass='bg-red-400 dark:bg-red-900/60'
+                      borderClass='border-red-600 dark:border-red-700'
+                      className='flex-1'
+                    />
+                    <HoverBox<HoverState>
+                      label='Responses'
+                      fieldKey='Message'
+                      hoverState={hoverState}
+                      setHoverState={setHoverState}
+                      activeClass='bg-red-400 dark:bg-red-900/60'
+                      borderClass='border-red-600 dark:border-red-700'
+                      className='flex-1'
+                    />
+                  </HoverBox>
                 </div>
               </div>
-            </div>
+            </HoverBox>
           </div>
-          <div
-            className={`${hoverState.Operations ? 'bg-orange-200' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
-            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Operations: true }))}
-            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Operations: false }))}
-          >
-            Operations
-            <div className='flex flex-1 flex-wrap'>
-              <div
-                className={`${hoverState.OperationItem ? 'bg-orange-300' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
-                onMouseOver={() => setHoverState((prevState) => ({ ...prevState, OperationItem: true }))}
-                onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, OperationItem: false }))}
-              >
-                Operation
-                <div className='flex flex-1 flex-col flex-wrap'>
-                  <div
-                    className={`${hoverState.OperationType ? 'bg-orange-400' : 'bg-white '} m-2 flex-1 border border-orange-300 p-2`}
-                    onMouseOver={() => setHoverState((prevState) => ({ ...prevState, OperationType: true }))}
-                    onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, OperationType: false }))}
-                  >
-                    action (send or receive)
-                  </div>
-                  <div
-                    className={`${hoverState.PathItem ? 'bg-yellow-300' : 'bg-white'} m-2 border border-yellow-600 p-2`}
-                    onMouseEnter={() => {
-                      return setHoverState((prevState) => ({ ...prevState, PathItem: true }));
-                    }}
-                    onMouseLeave={() => {
-                      return setHoverState({ ...hoverState, PathItem: false });
-                    }}
-                  >
-                    Channel reference
-                  </div>
-                  <div
-                    className={`${hoverState.Message ? 'bg-red-400' : 'bg-white'} m-2 flex-1 border border-red-600 p-2`}
-                    onMouseEnter={() => setHoverState((prevState) => ({ ...prevState, Message: true }))}
-                    onMouseLeave={() => setHoverState({ ...hoverState, Message: false })}
-                  >
-                    Messages reference
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className='flex flex-1 flex-wrap'>
-            <div className='m-2 box-border flex-1 border border-black p-2 hover:bg-blue-400'>
-              Id (application identifier)
-            </div>
-          </div>
-          <div className='flex flex-1 flex-wrap'>
-            <div
-              className={`${hoverState.Tags ? 'bg-pink-300' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2`}
-              onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Tags: true }))}
-              onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Tags: false }))}
-            >
-              <p>Tags</p>
-            </div>
-            <div
-              className={`${hoverState.External ? 'bg-green-500' : ' '} m-2 flex flex-1 items-center justify-center border border-black p-2`}
-              onMouseOver={() => setHoverState((prevState) => ({ ...prevState, External: true }))}
-              onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, External: false }))}
-            >
-              <p>External Docs</p>
-            </div>
-          </div>
-          <div
-            className={`${hoverState.Components ? 'bg-gray-100' : ' '} m-2 flex-1 border border-black p-2`}
-            onMouseOver={() => setHoverState((prevState) => ({ ...prevState, Components: true }))}
-            onMouseLeave={() => setHoverState((prevState) => ({ ...prevState, Components: false }))}
-          >
-            Components
-            <div className='grid-gap-2 mt-2 grid flex-1 grid-cols-2 flex-wrap'>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Schemas</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Messages</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Security Schemes</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Parameters</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Correlation Ids</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Operation Traits</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Message Traits</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Server Bindings</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Channel Bindings</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Operation Bindings</div>
-              <div className='m-2 box-border border border-black bg-gray-100 p-2'>Message Bindings</div>
-            </div>
-          </div>
+        </HoverBox>
+        <div className='flex flex-1 flex-wrap'>
+          <HoverBox<HoverState>
+            label='Tags'
+            fieldKey='Tags'
+            hoverState={hoverState}
+            setHoverState={setHoverState}
+            activeClass='bg-pink-300 dark:bg-pink-900/60'
+            defaultClass=' '
+            borderClass='border-black dark:border-gray-600'
+            className='flex flex-1 items-center justify-center'
+            useMouseOver
+          />
+          <HoverBox<HoverState>
+            label='External Docs'
+            fieldKey='External'
+            hoverState={hoverState}
+            setHoverState={setHoverState}
+            activeClass='bg-green-500 dark:bg-green-900/60'
+            defaultClass=' '
+            borderClass='border-black dark:border-gray-600'
+            className='flex flex-1 items-center justify-center'
+            useMouseOver
+          />
         </div>
-      </div>
+        <HoverBox<HoverState>
+          label='Components'
+          fieldKey='Components'
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass='bg-gray-100 dark:bg-gray-800'
+          defaultClass=' '
+          borderClass='border-black dark:border-gray-600'
+          className='flex-1'
+          useMouseOver
+        >
+          <ComponentGrid>
+            <ComponentItem>Definitions</ComponentItem>
+            <ComponentItem>Responses</ComponentItem>
+            <ComponentItem>Parameters</ComponentItem>
+            <ComponentItem>Response Headers</ComponentItem>
+            <ComponentItem>Security Definitions</ComponentItem>
+            <ComponentItem>Callbacks</ComponentItem>
+            <ComponentItem>Links</ComponentItem>
+          </ComponentGrid>
+        </HoverBox>
+      </Column>
+
+      <Column title='AsyncAPI 3.0'>
+        <HoverBox<HoverState>
+          label='Info'
+          fieldKey='Info'
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass='bg-blue-100 dark:bg-blue-900/40'
+          defaultClass=' '
+          borderClass='border-blue-300 dark:border-blue-700'
+          useMouseOver
+        />
+        <div className='flex flex-1 flex-wrap'>
+          <HoverBox<HoverState>
+            label='Servers (hosts + security)'
+            fieldKey='Servers'
+            hoverState={hoverState}
+            setHoverState={setHoverState}
+            activeClass='bg-green-100 dark:bg-green-900/40'
+            defaultClass=' '
+            borderClass='border-green-300 dark:border-green-700'
+            className='flex-1'
+            useMouseOver
+          />
+        </div>
+        <HoverBox<HoverState>
+          label='Channels'
+          fieldKey='Paths'
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass='bg-yellow-100 dark:bg-yellow-900/40'
+          defaultClass=' '
+          borderClass='border-yellow-300 dark:border-yellow-700'
+        >
+          <div className='flex flex-1 flex-wrap'>
+            <HoverBox<HoverState>
+              label='Channel'
+              fieldKey='PathItem'
+              hoverState={hoverState}
+              setHoverState={setHoverState}
+              activeClass='bg-yellow-300 dark:bg-yellow-800/60'
+              borderClass='border-yellow-600 dark:border-yellow-700'
+              useMouseOver
+            >
+              <div className='flex flex-1 flex-wrap'>
+                <div className='flex flex-1 flex-wrap'>
+                  <HoverBox<HoverState>
+                    label='Summary, description'
+                    fieldKey='Summary'
+                    hoverState={hoverState}
+                    setHoverState={setHoverState}
+                    activeClass='bg-blue-200 dark:bg-blue-900/50'
+                    borderClass='border-blue-500 dark:border-blue-400'
+                    useMouseOver
+                  />
+                  <div className='flex flex-1 flex-wrap'>
+                    <HoverBox<HoverState>
+                      label='Messages'
+                      fieldKey='Message'
+                      hoverState={hoverState}
+                      setHoverState={setHoverState}
+                      activeClass='bg-red-400 dark:bg-red-900/60'
+                      borderClass='border-red-600 dark:border-red-700'
+                      className='flex-1'
+                    >
+                      <StaticBox className='box-border flex-1'>Headers</StaticBox>
+                      <StaticBox className='box-border flex-1'>Payload</StaticBox>
+                    </HoverBox>
+                  </div>
+                </div>
+              </div>
+            </HoverBox>
+          </div>
+        </HoverBox>
+        <HoverBox<HoverState>
+          label='Operations'
+          fieldKey='Operations'
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass='bg-orange-200 dark:bg-orange-900/50'
+          borderClass='border-orange-300 dark:border-orange-700'
+          className='flex-1'
+          useMouseOver
+        >
+          <div className='flex flex-1 flex-wrap'>
+            <HoverBox<HoverState>
+              label='Operation'
+              fieldKey='OperationItem'
+              hoverState={hoverState}
+              setHoverState={setHoverState}
+              activeClass='bg-orange-300 dark:bg-orange-800/60'
+              borderClass='border-orange-300 dark:border-orange-700'
+              className='flex-1'
+              useMouseOver
+            >
+              <div className='flex flex-1 flex-col flex-wrap'>
+                <HoverBox<HoverState>
+                  label='action (send or receive)'
+                  fieldKey='OperationType'
+                  hoverState={hoverState}
+                  setHoverState={setHoverState}
+                  activeClass='bg-orange-400 dark:bg-orange-900/70'
+                  borderClass='border-orange-300 dark:border-orange-700'
+                  className='flex-1'
+                  useMouseOver
+                />
+                <HoverBox<HoverState>
+                  label='Channel reference'
+                  fieldKey='PathItem'
+                  hoverState={hoverState}
+                  setHoverState={setHoverState}
+                  activeClass='bg-yellow-300 dark:bg-yellow-800/60'
+                  borderClass='border-yellow-600 dark:border-yellow-700'
+                />
+                <HoverBox<HoverState>
+                  label='Messages reference'
+                  fieldKey='Message'
+                  hoverState={hoverState}
+                  setHoverState={setHoverState}
+                  activeClass='bg-red-400 dark:bg-red-900/60'
+                  borderClass='border-red-600 dark:border-red-700'
+                  className='flex-1'
+                />
+              </div>
+            </HoverBox>
+          </div>
+        </HoverBox>
+        <div className='flex flex-1 flex-wrap'>
+          <StaticBox className='box-border flex-1 hover:bg-blue-400 dark:hover:bg-blue-900/50'>
+            Id (application identifier)
+          </StaticBox>
+        </div>
+        <div className='flex flex-1 flex-wrap'>
+          <HoverBox<HoverState>
+            label='Tags'
+            fieldKey='Tags'
+            hoverState={hoverState}
+            setHoverState={setHoverState}
+            activeClass='bg-pink-300 dark:bg-pink-900/60'
+            defaultClass=' '
+            borderClass='border-black dark:border-gray-600'
+            className='flex flex-1 items-center justify-center'
+            useMouseOver
+          />
+          <HoverBox<HoverState>
+            label='External Docs'
+            fieldKey='External'
+            hoverState={hoverState}
+            setHoverState={setHoverState}
+            activeClass='bg-green-500 dark:bg-green-900/60'
+            defaultClass=' '
+            borderClass='border-black dark:border-gray-600'
+            className='flex flex-1 items-center justify-center'
+            useMouseOver
+          />
+        </div>
+        <HoverBox<HoverState>
+          label='Components'
+          fieldKey='Components'
+          hoverState={hoverState}
+          setHoverState={setHoverState}
+          activeClass='bg-gray-100 dark:bg-gray-800'
+          defaultClass=' '
+          borderClass='border-black dark:border-gray-600'
+          className='flex-1'
+          useMouseOver
+        >
+          <ComponentGrid>
+            <ComponentItem>Schemas</ComponentItem>
+            <ComponentItem>Messages</ComponentItem>
+            <ComponentItem>Security Schemes</ComponentItem>
+            <ComponentItem>Parameters</ComponentItem>
+            <ComponentItem>Correlation Ids</ComponentItem>
+            <ComponentItem>Operation Traits</ComponentItem>
+            <ComponentItem>Message Traits</ComponentItem>
+            <ComponentItem>Server Bindings</ComponentItem>
+            <ComponentItem>Channel Bindings</ComponentItem>
+            <ComponentItem>Operation Bindings</ComponentItem>
+            <ComponentItem>Message Bindings</ComponentItem>
+          </ComponentGrid>
+        </HoverBox>
+      </Column>
     </div>
   );
 }


### PR DESCRIPTION
**Description**

- Refactored OpenAPI comparison diagrams to follow the shared comparison component pattern.
- Replaced repeated inline hover handling with the reusable `HoverBox` component.
- Moved shared comparison helpers into `components/ComparisonCommon.tsx`.
- Updated OpenAPI comparison layouts to use shared `Column`, `HoverBox`, `StaticBox`, `ComponentGrid`, and `ComponentItem` patterns.
- Improved dark mode styling for borders, backgrounds, and hover states.
- Preserved existing OpenAPI comparison test IDs to avoid changing test behavior.

**Screenshots**

| Theme | Before | After |
| --- | --- | --- |
| Light | <img width="1010" height="733" alt="Screenshot Light Before" src="https://github.com/user-attachments/assets/8e312ff2-d5e5-4902-ac74-3d60515eeb03" /> | <img width="1002" height="742" alt="Screenshot Light After" src="https://github.com/user-attachments/assets/71eecc0b-feec-4a1c-bd76-3bf40cb2a5f9" /> |
| Dark | <img width="1048" height="743" alt="Screenshot Dark Before" src="https://github.com/user-attachments/assets/0989a618-7ce0-4b49-a5b7-ae5ab738e006" /> | <img width="1022" height="734" alt="Screenshot Dark After" src="https://github.com/user-attachments/assets/b42b84e9-fb16-494c-828b-ad8649389e4d" /> |

**Related issue(s)**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced hover-driven comparison UI across AsyncAPI and OpenAPI views with improved visual interaction patterns.
  * Restructured comparison layout using shared UI components for consistent styling and behavior across comparison panels.
  * Updated AsyncAPI 3.0 operations section with nested hover interactions for better information navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->