### PR TITLE
fix: add dark theme support for Warning component

### DIFF
--- a/components/Warning.tsx
+++ b/components/Warning.tsx
@@ -17,16 +17,16 @@ interface WarningProps {
  */
 export default function Warning({ className = '', title, description }: WarningProps) {
   return (
-    <div className={`${className} rounded-md bg-yellow-50 p-4`} data-testid='Warning-main'>
+    <div className={`${className} rounded-md bg-yellow-50 dark:bg-yellow-900/30 p-4`} data-testid='Warning-main'>
       <div className='flex'>
         <div className='shrink-0'>
           <IconExclamation className='size-5' />
         </div>
         <div className='ml-3'>
-          <h3 className='text-sm font-medium uppercase leading-5 text-yellow-800' data-testid='Warning-title'>
+          <h3 className='text-sm font-medium uppercase leading-5 text-yellow-800 dark:text-yellow-400' data-testid='Warning-title'>
             {title}
           </h3>
-          <div className='mt-2 text-sm leading-5 text-yellow-700' data-testid='Warning-description'>
+          <div className='mt-2 text-sm leading-5 text-yellow-700 dark:text-yellow-200' data-testid='Warning-description'>
             <p>{description}</p>
           </div>
         </div>

--- a/components/Warning.tsx
+++ b/components/Warning.tsx
@@ -20,7 +20,7 @@ export default function Warning({ className = '', title, description }: WarningP
     <div className={`${className} rounded-md bg-yellow-50 dark:bg-yellow-900/30 p-4`} data-testid='Warning-main'>
       <div className='flex'>
         <div className='shrink-0'>
-          <IconExclamation className='size-5 text-yellow-500 dark:text-yellow-400' />
+          <IconExclamation className='size-5 text-gray-900 dark:text-yellow-400' />
         </div>
         <div className='ml-3'>
           <h3

--- a/components/Warning.tsx
+++ b/components/Warning.tsx
@@ -20,13 +20,19 @@ export default function Warning({ className = '', title, description }: WarningP
     <div className={`${className} rounded-md bg-yellow-50 dark:bg-yellow-900/30 p-4`} data-testid='Warning-main'>
       <div className='flex'>
         <div className='shrink-0'>
-          <IconExclamation className='size-5' />
+          <IconExclamation className='size-5 text-yellow-500 dark:text-yellow-400' />
         </div>
         <div className='ml-3'>
-          <h3 className='text-sm font-medium uppercase leading-5 text-yellow-800 dark:text-yellow-400' data-testid='Warning-title'>
+          <h3
+            className='text-sm font-medium uppercase leading-5 text-yellow-800 dark:text-yellow-400'
+            data-testid='Warning-title'
+          >
             {title}
           </h3>
-          <div className='mt-2 text-sm leading-5 text-yellow-700 dark:text-yellow-200' data-testid='Warning-description'>
+          <div
+            className='mt-2 text-sm leading-5 text-yellow-700 dark:text-yellow-200'
+            data-testid='Warning-description'
+          >
             <p>{description}</p>
           </div>
         </div>


### PR DESCRIPTION
**Description**

- Enhanced the design of the warning components in the Roadmap section.

**Screenshots**

| Theme | Before | After |
| --- | --- | --- |
| Light | <img width="646" height="204" alt="Screenshot Light Before" src="https://github.com/user-attachments/assets/d95539fc-4dd9-494e-b23d-82ce5d9bf6fd" /> | <img width="714" height="206" alt="Screenshot Light After" src="https://github.com/user-attachments/assets/e30575dc-fdb9-4fd8-a443-be7c3f7abc4b" /> |
| Dark | <img width="635" height="174" alt="Screenshot Dark Before" src="https://github.com/user-attachments/assets/e3206a41-ab7a-491c-9b93-a3ad43c9e8e8" /> | <img width="723" height="215" alt="Screenshot Dark After" src="https://github.com/user-attachments/assets/22f5f3ae-2005-41e1-9758-f29903fb558f" /> |

**Reproduce**

1. Navigate to https://deploy-preview-5517--asyncapi-website.netlify.app/roadmap
2. Scroll down to see the warning component.
3. Test the UI by toggling between the light and dark themes.

**Related issue(s)**
- N/A