### PR TITLE
fix: align netlify badge for mobile layout and remove stray margins

### DIFF
--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -109,12 +109,12 @@ export default function Footer() {
               </a>
             </p>
           </div>
-          <div className='mt-8 block sm:mt-0'>
+          <div className='mt-8 flex sm:mt-0 sm:justify-end'>
             <p className='block text-sm leading-6'>
               <a href='https://netlify.com' target='_blank' rel='noopener noreferrer'>
                 <img
                   src='https://www.netlify.com/img/global/badges/netlify-color-bg.svg'
-                  className='inline-block align-middle ml-3 text-sm font-medium text-cool-gray'
+                  className='inline-block align-middle text-sm font-medium text-cool-gray'
                   alt='Deploys by Netlify'
                 />
               </a>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- align netlify badge for mobile layout and remove stray margins


 **Please check the alignments in footer**
- Before 
<img width="376" height="296" alt="Screenshot 2026-05-29 at 14 35 15" src="https://github.com/user-attachments/assets/fb0d0df8-d4e6-47a7-8767-d04c02cabcb3" />

- After 
<img width="379" height="298" alt="Screenshot 2026-05-29 at 14 34 52" src="https://github.com/user-attachments/assets/b8ad609f-551e-4289-ba0e-bdcdaf4ffe7c" />


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->