### PR TITLE
fix: improve dashboard tooltip and filter responsiveness

### DIFF
--- a/components/dashboard/GoodFirstIssuesTip.tsx
+++ b/components/dashboard/GoodFirstIssuesTip.tsx
@@ -1,4 +1,4 @@
-import { useFloating, shift, flip, offset } from '@floating-ui/react';
+import { flip, offset, shift, useFloating } from '@floating-ui/react';
 import React, { useState } from 'react';
 
 /**

--- a/components/dashboard/GoodFirstIssuesTip.tsx
+++ b/components/dashboard/GoodFirstIssuesTip.tsx
@@ -1,4 +1,4 @@
-import { useFloating } from '@floating-ui/react';
+import { useFloating, shift, flip, offset } from '@floating-ui/react';
 import React, { useState } from 'react';
 
 /**
@@ -8,7 +8,8 @@ export default function GoodFirstIssuesTip() {
   const [open, setOpen] = useState(false);
   const { x, y, refs, strategy } = useFloating({
     placement: 'right-start',
-    open
+    open,
+    middleware: [offset(10), flip({ fallbackPlacements: ['bottom-start', 'left-start'] }), shift({ padding: 10 })]
   });
 
   return (
@@ -26,13 +27,14 @@ export default function GoodFirstIssuesTip() {
       {open && (
         <div
           ref={refs.setFloating}
+          className='z-50'
           style={{
             position: strategy,
             top: y ?? '',
             left: x ?? ''
           }}
         >
-          <div className='max-w-xs rounded-xl bg-white dark:bg-dark-card p-5 shadow-2xl dark:shadow-2xl border border-gray-200 dark:border-gray-700'>
+          <div className='max-w-xs rounded-xl bg-white dark:bg-dark-card p-5 shadow-2xl dark:shadow-2xl border border-gray-200 dark:border-gray-700 w-[calc(100vw-2rem)]'>
             <div className='flex items-start gap-3'>
               <div className='flex-shrink-0 w-10 h-10 rounded-lg bg-green-100 dark:bg-green-900/30 flex items-center justify-center'>
                 <svg

--- a/components/dashboard/table/Filters.tsx
+++ b/components/dashboard/table/Filters.tsx
@@ -1,4 +1,4 @@
-import { useFloating } from '@floating-ui/react';
+import { useFloating, shift, flip, offset } from '@floating-ui/react';
 import type { RefObject } from 'react';
 import React, { useEffect, useRef, useState } from 'react';
 
@@ -82,7 +82,8 @@ export default function Filters({
 
   const { x, y, refs, strategy } = useFloating({
     placement,
-    open
+    open,
+    middleware: [offset(10), flip(), shift({ padding: 10 })]
   });
 
   const wrapperRef = useRef(null);
@@ -112,7 +113,7 @@ export default function Filters({
         <img
           alt='filter menu'
           src='/img/illustrations/icons/filters-icon.svg'
-          className='w-4 h-4 dark:invert dark:opacity-80'
+          className='w-4 h-4 dark:opacity-80'
         />
       </button>
 

--- a/components/dashboard/table/Filters.tsx
+++ b/components/dashboard/table/Filters.tsx
@@ -1,4 +1,4 @@
-import { useFloating, shift, flip, offset } from '@floating-ui/react';
+import { flip, offset, shift, useFloating } from '@floating-ui/react';
 import type { RefObject } from 'react';
 import React, { useEffect, useRef, useState } from 'react';
 
@@ -110,11 +110,7 @@ export default function Filters({
         aria-label='Filter issues'
         data-testid='Filters-img-container'
       >
-        <img
-          alt='filter menu'
-          src='/img/illustrations/icons/filters-icon.svg'
-          className='w-4 h-4 dark:opacity-80'
-        />
+        <img alt='filter menu' src='/img/illustrations/icons/filters-icon.svg' className='w-4 h-4 dark:opacity-80' />
       </button>
 
       <div ref={wrapperRef}>


### PR DESCRIPTION
ref - https://github.com/asyncapi/website/pull/5253#issuecomment-4567873219

### **Description:**

- Fixed the "Is this your first contribution?" tooltip in `GoodFirstIssuesTip` displaying issue and fixed overflowing and clipping off-screen on mobile viewports.
- Added `w-[calc(100vw-2rem)]` to the tooltip card to ensure it never exceeds the available screen width, providing a safe margin on each side for narrow devices.
- Fixed the "Filter Issues" section in `Filters` overflowing on smaller screen sizes.
- Improved the filter icon's dark mode appearance.

### **Steps to Reproduce:**

1. Navigate to the `/community/dashboard` page.
2. Hover over the **"?"** question mark icon next to the "Good First Issues" heading.
3. Observe that the "Is this your first contribution?" card now displays properly.
4. Resize the browser to a mobile viewport or use DevTools device emulation.
5. Hover over the **"?"** question mark icon again.
6. Observe that the "Is this your first contribution?" card now stays fully within the viewport instead of clipping off the left edge.
7. Click the **filter icon** on the right side of the "Good First Issues" heading.
8. Observe that the "Filter Issues" section now appears correctly within the viewport on mobile without overflowing.
9. Toggle to **dark mode** and repeat steps 2-8 to verify both cards render correctly in both themes.

### **Screenshots:**

**Good First Issues Tooltip (Desktop)**

| Before | After |
|--------|--------|
| <img width="420" alt="Tooltip Before Desktop Light" src="https://github.com/user-attachments/assets/567b0445-ba12-413a-89bf-b7da46eb39de" /> | <img width="420" alt="Tooltip After Desktop Light" src="https://github.com/user-attachments/assets/f5dd9f52-4bd8-496a-82d9-cfa37cd0aa28" /> |
| <img width="420" alt="Tooltip Before Desktop Dark" src="https://github.com/user-attachments/assets/5abacfa7-d3db-4d6b-8f0d-c8d511d01478" /> | <img width="420" alt="Tooltip After Desktop Dark" src="https://github.com/user-attachments/assets/b7b1410b-df85-40f5-8ed8-35c70de1bd68" /> |

**Good First Issues Tooltip (Mobile)**

| Before | After |
|--------|--------|
| <img width="260" alt="Tooltip Before Mobile Light" src="https://github.com/user-attachments/assets/532c3873-33a9-4240-ae60-c35749b43860" /> | <img width="260" alt="Tooltip After Mobile Light" src="https://github.com/user-attachments/assets/8a5ec092-1794-4f80-838d-087f5a5f696b" /> |
| <img width="260" alt="Tooltip Before Mobile Dark" src="https://github.com/user-attachments/assets/7efd6c11-3e98-4848-b925-afb980c089a0" /> | <img width="260" alt="Tooltip After Mobile Dark" src="https://github.com/user-attachments/assets/0bf4359f-daf6-49df-b149-55f8abdb2dd4" /> |

**Filter Issues Section (Mobile)**

| Before | After |
|--------|--------|
| <img width="260" alt="Filter Before Mobile Light" src="https://github.com/user-attachments/assets/10000951-4380-48d4-ab71-e441a200f5f8" /> | <img width="260" alt="Filter After Mobile Light" src="https://github.com/user-attachments/assets/a7c2f8e1-8768-43f7-bf3e-d930a295f315" /> |
| <img width="260" alt="Filter Before Mobile Dark" src="https://github.com/user-attachments/assets/4298dad7-8275-4119-a04a-e31d9f3ea818" /> | <img width="260" alt="Filter After Mobile Dark" src="https://github.com/user-attachments/assets/8294255b-9f23-49e3-921d-c07ca75fe280" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip positioning to better handle viewport boundaries and responsive layouts
  * Enhanced filter menu positioning behavior for improved screen adaptation

* **Style**
  * Refined filter button icon styling and visibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->