### PR TITLE
fix: the left sidebar highlight for the docs for dark theme 

### DIFF
--- a/components/navigation/DocsNavItem.tsx
+++ b/components/navigation/DocsNavItem.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import React from 'react';
+import { twMerge } from 'tailwind-merge';
 
 export type DocsNavItemProps = Readonly<{
   title: string;
@@ -63,7 +64,7 @@ export default function DocsNavItem({
   bucket
 }: DocsNavItemProps) {
   const isActive = isActiveSlug(slug, activeSlug, sectionSlug);
-  const classes = `${isActive ? activeClassName : inactiveClassName} ${defaultClassName} inline-block w-full`;
+  const classes = twMerge('inline-block w-full', defaultClassName, isActive ? activeClassName : inactiveClassName);
 
   return (
     <div>

--- a/components/navigation/SubCategoryDocsNav.tsx
+++ b/components/navigation/SubCategoryDocsNav.tsx
@@ -50,13 +50,13 @@ export default function SubCategoryDocsNav({ subCategory, activeItem, onClick }:
         <DocsNavItem
           {...subCategory.item}
           activeSlug={activeItem}
-          defaultClassName={`font-body text-sm text-black dark:text-white leading-8 ${
+          defaultClassName={`font-body text-sm text-black dark:text-dark-text leading-8 ${
             subCategory.children
-              ? 'hover:font-semibold  dark:text-dark-text'
-              : 'dark:hover:text-secondary-600 hover:text-secondary-600'
+              ? 'hover:font-semibold'
+              : 'hover:text-secondary-600 dark:hover:text-secondary-500'
           }`}
           inactiveClassName='font-regular'
-          activeClassName={subCategory.children ? 'font-semibold' : 'text-secondary-600'}
+          activeClassName={subCategory.children ? 'font-semibold dark:text-white' : 'text-secondary-600 dark:text-secondary-500'}
           onClick={onClickHandler}
         />
       </div>
@@ -68,9 +68,9 @@ export default function SubCategoryDocsNav({ subCategory, activeItem, onClick }:
                 <DocsNavItem
                   {...subItem}
                   activeSlug={activeItem}
-                  defaultClassName='font-body text-sm text-gray-700 dark:text-dark-text leading-7 dark:hover:text-secondary-600 hover:text-secondary-600'
+                  defaultClassName='font-body text-sm text-gray-700 dark:text-dark-text leading-7 hover:text-secondary-600 dark:hover:text-secondary-500'
                   inactiveClassName='font-regular'
-                  activeClassName='text-secondary-600'
+                  activeClassName='text-secondary-600 dark:text-secondary-500'
                   onClick={onClick}
                 />
               </li>

--- a/components/navigation/SubCategoryDocsNav.tsx
+++ b/components/navigation/SubCategoryDocsNav.tsx
@@ -51,12 +51,12 @@ export default function SubCategoryDocsNav({ subCategory, activeItem, onClick }:
           {...subCategory.item}
           activeSlug={activeItem}
           defaultClassName={`font-body text-sm text-black dark:text-dark-text leading-8 ${
-            subCategory.children
-              ? 'hover:font-semibold'
-              : 'hover:text-secondary-600 dark:hover:text-secondary-500'
+            subCategory.children ? 'hover:font-semibold' : 'hover:text-secondary-600 dark:hover:text-secondary-500'
           }`}
           inactiveClassName='font-regular'
-          activeClassName={subCategory.children ? 'font-semibold dark:text-white' : 'text-secondary-600 dark:text-secondary-500'}
+          activeClassName={
+            subCategory.children ? 'font-semibold dark:text-white' : 'text-secondary-600 dark:text-secondary-500'
+          }
           onClick={onClickHandler}
         />
       </div>


### PR DESCRIPTION
**Description**
the left sidebar is not highlighting the topic on which you are in the docs search for dark theme

before -> 
<img width="1401" height="846" alt="image" src="https://github.com/user-attachments/assets/04bf1f80-cca8-4fdf-837a-78fbca99237c" />
https://deploy-preview-5509--asyncapi-website.netlify.app/docs/concepts/producer

after ->
<img width="1258" height="740" alt="image" src="https://github.com/user-attachments/assets/359a73a4-09a3-4a31-a245-92011c664fc8" />
https://deploy-preview-5520--asyncapi-website.netlify.app/docs/tutorials/studio-document-validation

issue->https://github.com/asyncapi/website/pull/5253#issuecomment-4575044459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved consistency in navigation hover and active states across parent and child items.
  * Standardized dark-mode text and secondary color behavior for clearer visual coherence.

* **Refactor**
  * Reworked how navigation classes are composed to reduce styling conflicts and ensure consistent appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->