### PR TITLE
fix: enhance dark mode support and improve UI elements across tools

### DIFF
--- a/components/tools/CardData.tsx
+++ b/components/tools/CardData.tsx
@@ -86,15 +86,16 @@ export const CardData = ({
   }, [type, setVisible, setRead]);
 
   return (
-    <div className={twMerge('text-left text-sm text-gray-500', className)}>
+    <div className={twMerge('text-left text-sm text-gray-500 dark:text-gray-300', className)}>
       {heading}
-      <span className='group relative'>
+      <span className='group relative inline-flex'>
         {outsideClick && visible[type] && (
           <span
             ref={domNode}
             data-testid='Carddata-description'
-            className='absolute -left-2/3 -top-4 z-10 w-48 translate-x-1/3 rounded border border-gray-200
-              bg-white px-2 py-1 text-xs shadow-md'
+            className='absolute left-0 top-7 z-50 max-h-60 w-64 max-w-[calc(100vw-2rem)] overflow-y-auto
+              rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs text-gray-700 shadow-xl
+              dark:border-gray-600 dark:bg-dark-card dark:text-gray-300 dark:shadow-2xl'
           >
             {read ? (
               data
@@ -105,7 +106,7 @@ export const CardData = ({
             )}
             {description && (
               <button
-                className='cursor-pointer text-cyan-600'
+                className='cursor-pointer text-cyan-600 hover:text-cyan-700 dark:text-cyan-400 dark:hover:text-cyan-300'
                 onClick={() => {
                   setOutsideClick(true);
                   setRead(!read);
@@ -121,7 +122,7 @@ export const CardData = ({
             setRead(false);
             setVisible({ ...initial, [type]: !visible[type] });
           }}
-          className='mx-1'
+          className='mx-1 text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-300 dark:hover:text-white'
           data-testid='Carddata-button'
         >
           <InfoIcon />

--- a/components/tools/Filters.tsx
+++ b/components/tools/Filters.tsx
@@ -155,7 +155,10 @@ export default function Filters({ setOpenFilter }: FiltersProps) {
             <button
               type='button'
               className={twMerge(
-                `bg-gray-200 dark:bg-gray-700 px-4 py-2 flex gap-1 rounded-md hover:bg-secondary-100 dark:hover:bg-secondary-900/50 border hover:border-secondary-500 dark:hover:border-secondary-400 cursor-pointer transition-all dark:text-gray-300 ${checkPaid === 'free' ? 'bg-secondary-100 dark:bg-secondary-900/50 border-secondary-500 dark:border-secondary-400' : ''}`
+                `bg-white dark:bg-dark-background px-4 py-2 flex gap-1 rounded-md border border-gray-300
+                dark:border-gray-600 hover:bg-secondary-100 dark:hover:bg-secondary-600/20 hover:border-secondary-500
+                dark:hover:border-secondary-400 cursor-pointer transition-all text-gray-700 dark:text-gray-300
+                ${checkPaid === 'free' ? 'bg-secondary-100 dark:bg-secondary-600/25 border-secondary-500 dark:border-secondary-400 text-gray-900 dark:text-white' : ''}`
               )}
               onClick={() => (checkPaid === 'free' ? setCheckPaid('all') : setCheckPaid('free'))}
             >
@@ -164,7 +167,10 @@ export default function Filters({ setOpenFilter }: FiltersProps) {
             </button>
             <button
               type='button'
-              className={`flex cursor-pointer gap-1 rounded-md border bg-gray-200 dark:bg-gray-700 px-4 py-2 hover:border-secondary-500 dark:hover:border-secondary-400 hover:bg-secondary-100 dark:hover:bg-secondary-900/50 transition-all dark:text-gray-300 ${checkPaid === 'paid' ? 'border-secondary-500 dark:border-secondary-400 bg-secondary-100 dark:bg-secondary-900/50' : ''}`}
+              className={`flex cursor-pointer gap-1 rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-700
+                transition-all hover:border-secondary-500 hover:bg-secondary-100 dark:border-gray-600
+                dark:bg-dark-background dark:text-gray-300 dark:hover:border-secondary-400
+                dark:hover:bg-secondary-600/20 ${checkPaid === 'paid' ? 'border-secondary-500 bg-secondary-100 text-gray-900 dark:border-secondary-400 dark:bg-secondary-600/25 dark:text-white' : ''}`}
               onClick={() => (checkPaid === 'paid' ? setCheckPaid('all') : setCheckPaid('paid'))}
             >
               <span className='text-sm'>Commercial</span>
@@ -204,7 +210,9 @@ export default function Filters({ setOpenFilter }: FiltersProps) {
             <button
               type='button'
               className={twMerge(
-                `px-4 py-2 flex justify-between rounded-lg border border-gray-400 dark:border-gray-600 w-full bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 shadow text-sm cursor-pointer transition-all ${openedFiltersDropown === OpenedFiltersDropdownType.LANGUAGE ? 'rounded-b-none' : ''}`
+                `px-4 py-2 flex justify-between rounded-lg border border-gray-400 dark:border-gray-600 w-full bg-white
+                dark:bg-dark-background text-gray-700 dark:text-gray-300 shadow text-sm cursor-pointer transition-all
+                hover:border-gray-500 dark:hover:border-gray-500 ${openedFiltersDropown === OpenedFiltersDropdownType.LANGUAGE ? 'rounded-b-none border-secondary-500 dark:border-secondary-400' : ''}`
               )}
               onClick={() => toggleDropdown(OpenedFiltersDropdownType.LANGUAGE)}
             >
@@ -221,7 +229,7 @@ export default function Filters({ setOpenFilter }: FiltersProps) {
               />
             </button>
             {openedFiltersDropown === OpenedFiltersDropdownType.LANGUAGE && (
-              <div className='w-auto overflow-x-auto rounded-b-lg border border-gray-400 dark:border-gray-600 bg-gray-200 dark:bg-gray-700 duration-150'>
+              <div className='w-auto overflow-x-auto rounded-b-lg border border-gray-400 bg-white duration-150 dark:border-gray-600 dark:bg-dark-card'>
                 <FiltersDropdown
                   dataList={languageList}
                   checkedOptions={checkedLanguage}
@@ -247,7 +255,9 @@ export default function Filters({ setOpenFilter }: FiltersProps) {
             <button
               type='button'
               className={twMerge(
-                `px-4 py-2 flex justify-between rounded-lg border border-gray-400 dark:border-gray-600 w-full bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 shadow text-sm cursor-pointer transition-all ${openedFiltersDropown === OpenedFiltersDropdownType.TECHNOLOGY ? 'rounded-b-none' : ''}`
+                `px-4 py-2 flex justify-between rounded-lg border border-gray-400 dark:border-gray-600 w-full bg-white
+                dark:bg-dark-background text-gray-700 dark:text-gray-300 shadow text-sm cursor-pointer transition-all
+                hover:border-gray-500 dark:hover:border-gray-500 ${openedFiltersDropown === OpenedFiltersDropdownType.TECHNOLOGY ? 'rounded-b-none border-secondary-500 dark:border-secondary-400' : ''}`
               )}
               onClick={() => toggleDropdown(OpenedFiltersDropdownType.TECHNOLOGY)}
             >
@@ -264,7 +274,7 @@ export default function Filters({ setOpenFilter }: FiltersProps) {
               />
             </button>
             {openedFiltersDropown === OpenedFiltersDropdownType.TECHNOLOGY && (
-              <div className='w-auto overflow-x-auto rounded-b-lg border border-gray-400 dark:border-gray-600 bg-gray-200 dark:bg-gray-700 duration-150'>
+              <div className='w-auto overflow-x-auto rounded-b-lg border border-gray-400 bg-white duration-150 dark:border-gray-600 dark:bg-dark-card'>
                 <FiltersDropdown
                   dataList={technologyList}
                   checkedOptions={checkedTechnology}
@@ -290,7 +300,9 @@ export default function Filters({ setOpenFilter }: FiltersProps) {
             <button
               type='button'
               className={twMerge(
-                `px-4 py-2 flex justify-between rounded-lg border border-gray-400 dark:border-gray-600 w-full bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 shadow text-sm cursor-pointer transition-all ${openedFiltersDropown === OpenedFiltersDropdownType.CATEGORY ? 'rounded-b-none' : ''}`
+                `px-4 py-2 flex justify-between rounded-lg border border-gray-400 dark:border-gray-600 w-full bg-white
+                dark:bg-dark-background text-gray-700 dark:text-gray-300 shadow text-sm cursor-pointer transition-all
+                hover:border-gray-500 dark:hover:border-gray-500 ${openedFiltersDropown === OpenedFiltersDropdownType.CATEGORY ? 'rounded-b-none border-secondary-500 dark:border-secondary-400' : ''}`
               )}
               onClick={() => toggleDropdown(OpenedFiltersDropdownType.CATEGORY)}
             >
@@ -307,7 +319,7 @@ export default function Filters({ setOpenFilter }: FiltersProps) {
               />
             </button>
             {openedFiltersDropown === OpenedFiltersDropdownType.CATEGORY && (
-              <div className='w-auto overflow-x-auto rounded-b-lg border border-gray-400 dark:border-gray-600 bg-gray-200 dark:bg-gray-700 duration-150'>
+              <div className='w-auto overflow-x-auto rounded-b-lg border border-gray-400 bg-white duration-150 dark:border-gray-600 dark:bg-dark-card'>
                 <FiltersDropdown
                   dataList={categoryList}
                   checkedOptions={checkedCategory}

--- a/components/tools/FiltersDisplay.tsx
+++ b/components/tools/FiltersDisplay.tsx
@@ -38,12 +38,12 @@ export default function FiltersDisplay({ checkedOptions = [], setCheckedOptions 
               <div
                 key={index}
                 className={twMerge(
-                  'hover:border-gray-800 dark:hover:border-gray-400 border border-gray-600 dark:border-gray-500 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white p-1 pb-0 rounded-2xl flex gap-1 items-start transition-colors duration-200'
+                  'flex items-start gap-1 rounded-2xl border border-gray-400 bg-white px-2 py-1 text-gray-700 transition-colors duration-200 hover:border-gray-700 hover:text-gray-900 dark:border-gray-600 dark:bg-dark-background dark:text-gray-300 dark:hover:border-secondary-400 dark:hover:text-white'
                 )}
               >
                 <div className='m-auto h-fit text-xs'>{items}</div>
                 <button
-                  className='mt-[-2px] rounded-full p-1 hover:bg-gray-100 dark:hover:bg-dark-background transition-colors duration-200'
+                  className='rounded-full p-1 transition-colors duration-200 hover:bg-gray-100 dark:hover:bg-gray-700'
                   onClick={(event) => handleClickOption(event, items, checkedOptions, setCheckedOptions)}
                   data-testid='Filters-Display-Button'
                 >

--- a/components/tools/FiltersDropdown.tsx
+++ b/components/tools/FiltersDropdown.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import { twMerge } from 'tailwind-merge';
 
-import type {
-  Category,
-  Language,
-  Technology,
-} from '@/types/components/tools/ToolDataType';
+import type { Category, Language, Technology } from '@/types/components/tools/ToolDataType';
 
 type DataList = Language[] | Technology[] | Category[];
 
@@ -28,16 +24,11 @@ export default function FiltersDropdown({
   dataList = [],
   checkedOptions = [],
   setCheckedOptions,
-  className = '',
+  className = ''
 }: FiltersDropdownProps) {
-  const handleClickOption = (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-    option: string,
-  ) => {
+  const handleClickOption = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>, option: string) => {
     const isChecked = checkedOptions.includes(option);
-    const updatedOptions = isChecked
-      ? checkedOptions.filter((item) => item !== option)
-      : [...checkedOptions, option];
+    const updatedOptions = isChecked ? checkedOptions.filter((item) => item !== option) : [...checkedOptions, option];
 
     setCheckedOptions(updatedOptions);
   };
@@ -45,9 +36,9 @@ export default function FiltersDropdown({
   return (
     <div
       className={twMerge(
-        `max-w-lg flex flex-col max-h-[20vh] gap-1 overflow-y-auto p-2 px-0 duration-200 delay-150 bg-white text-gray-700 dark:bg-dark-card dark:text-gray-200 ${className}`,
+        `max-w-lg flex flex-col max-h-[20vh] gap-1 overflow-y-auto p-2 px-0 duration-200 delay-150 bg-white text-gray-700 dark:bg-dark-card dark:text-gray-200 ${className}`
       )}
-      data-testid="FiltersDropdown-div"
+      data-testid='FiltersDropdown-div'
     >
       {dataList.map((data, index) => {
         const checked = checkedOptions.includes(data.name);
@@ -55,29 +46,25 @@ export default function FiltersDropdown({
         return (
           <button
             key={index}
-            type="button"
+            type='button'
             className={twMerge(
               `group flex w-full cursor-pointer items-start gap-2 p-2 text-left text-gray-700
               transition-colors hover:bg-gray-100
               dark:text-gray-200 dark:hover:bg-gray-100 dark:hover:text-gray-900
-              ${checked ? 'bg-secondary-100 text-gray-900 dark:!bg-gray-100 dark:!text-gray-900' : ''}`,
+              ${checked ? 'bg-secondary-100 text-gray-900 dark:!bg-gray-100 dark:!text-gray-900' : ''}`
             )}
             onClick={(event) => handleClickOption(event, data.name)}
           >
             {checked ? (
-              <img
-                src="/img/illustrations/icons/CheckedIcon.svg"
-                alt="checked"
-                className="mt-0.5 size-3"
-              />
+              <img src='/img/illustrations/icons/CheckedIcon.svg' alt='checked' className='mt-0.5 size-3' />
             ) : (
               <img
-                src="/img/illustrations/icons/UncheckedIcon.svg"
-                alt="unchecked"
-                className="mt-0.5 size-3 dark:invert group-hover:dark:invert-0"
+                src='/img/illustrations/icons/UncheckedIcon.svg'
+                alt='unchecked'
+                className='mt-0.5 size-3 dark:invert group-hover:dark:invert-0'
               />
             )}
-            <div className="mb-px text-xs">{data.name}</div>
+            <div className='mb-px text-xs'>{data.name}</div>
           </button>
         );
       })}

--- a/components/tools/FiltersDropdown.tsx
+++ b/components/tools/FiltersDropdown.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { twMerge } from 'tailwind-merge';
 
-import type { Category, Language, Technology } from '@/types/components/tools/ToolDataType';
+import type {
+  Category,
+  Language,
+  Technology,
+} from '@/types/components/tools/ToolDataType';
 
 type DataList = Language[] | Technology[] | Category[];
 
@@ -24,11 +28,16 @@ export default function FiltersDropdown({
   dataList = [],
   checkedOptions = [],
   setCheckedOptions,
-  className = ''
+  className = '',
 }: FiltersDropdownProps) {
-  const handleClickOption = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>, option: string) => {
+  const handleClickOption = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    option: string,
+  ) => {
     const isChecked = checkedOptions.includes(option);
-    const updatedOptions = isChecked ? checkedOptions.filter((item) => item !== option) : [...checkedOptions, option];
+    const updatedOptions = isChecked
+      ? checkedOptions.filter((item) => item !== option)
+      : [...checkedOptions, option];
 
     setCheckedOptions(updatedOptions);
   };
@@ -36,9 +45,9 @@ export default function FiltersDropdown({
   return (
     <div
       className={twMerge(
-        `max-w-lg flex flex-col max-h-[20vh] gap-1 overflow-y-auto p-2 px-0 duration-200 delay-150 bg-white text-gray-700 dark:bg-dark-card dark:text-gray-200 ${className}`
+        `max-w-lg flex flex-col max-h-[20vh] gap-1 overflow-y-auto p-2 px-0 duration-200 delay-150 bg-white text-gray-700 dark:bg-dark-card dark:text-gray-200 ${className}`,
       )}
-      data-testid='FiltersDropdown-div'
+      data-testid="FiltersDropdown-div"
     >
       {dataList.map((data, index) => {
         const checked = checkedOptions.includes(data.name);
@@ -46,25 +55,29 @@ export default function FiltersDropdown({
         return (
           <button
             key={index}
-            type='button'
+            type="button"
             className={twMerge(
               `group flex w-full cursor-pointer items-start gap-2 p-2 text-left text-gray-700
               transition-colors hover:bg-gray-100
               dark:text-gray-200 dark:hover:bg-gray-100 dark:hover:text-gray-900
-              ${checked ? 'bg-secondary-100 text-gray-900 dark:!bg-gray-100 dark:!text-gray-900' : ''}`
+              ${checked ? 'bg-secondary-100 text-gray-900 dark:!bg-gray-100 dark:!text-gray-900' : ''}`,
             )}
             onClick={(event) => handleClickOption(event, data.name)}
           >
             {checked ? (
-              <img src='/img/illustrations/icons/CheckedIcon.svg' alt='checked' className='mt-0.5 size-3' />
+              <img
+                src="/img/illustrations/icons/CheckedIcon.svg"
+                alt="checked"
+                className="mt-0.5 size-3"
+              />
             ) : (
               <img
-                src='/img/illustrations/icons/UncheckedIcon.svg'
-                alt='unchecked'
-                className='mt-0.5 size-3 dark:invert group-hover:dark:invert-0'
+                src="/img/illustrations/icons/UncheckedIcon.svg"
+                alt="unchecked"
+                className="mt-0.5 size-3 dark:invert group-hover:dark:invert-0"
               />
             )}
-            <div className='mb-px text-xs'>{data.name}</div>
+            <div className="mb-px text-xs">{data.name}</div>
           </button>
         );
       })}

--- a/components/tools/FiltersDropdown.tsx
+++ b/components/tools/FiltersDropdown.tsx
@@ -26,7 +26,7 @@ export default function FiltersDropdown({
   setCheckedOptions,
   className = ''
 }: FiltersDropdownProps) {
-  const handleClickOption = (event: React.MouseEvent<HTMLDivElement, MouseEvent>, option: string) => {
+  const handleClickOption = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>, option: string) => {
     const isChecked = checkedOptions.includes(option);
     const updatedOptions = isChecked ? checkedOptions.filter((item) => item !== option) : [...checkedOptions, option];
 
@@ -44,10 +44,12 @@ export default function FiltersDropdown({
         const checked = checkedOptions.includes(data.name);
 
         return (
-          <div
+          <button
             key={index}
+            type='button'
             className={twMerge(
-              `group flex cursor-pointer items-start gap-2 p-2 text-gray-700 transition-colors hover:bg-gray-100
+              `group flex w-full cursor-pointer items-start gap-2 p-2 text-left text-gray-700
+              transition-colors hover:bg-gray-100
               dark:text-gray-200 dark:hover:bg-gray-100 dark:hover:text-gray-900
               ${checked ? 'bg-secondary-100 text-gray-900 dark:!bg-gray-100 dark:!text-gray-900' : ''}`
             )}
@@ -63,7 +65,7 @@ export default function FiltersDropdown({
               />
             )}
             <div className='mb-px text-xs'>{data.name}</div>
-          </div>
+          </button>
         );
       })}
     </div>

--- a/components/tools/FiltersDropdown.tsx
+++ b/components/tools/FiltersDropdown.tsx
@@ -36,7 +36,7 @@ export default function FiltersDropdown({
   return (
     <div
       className={twMerge(
-        `max-w-lg flex flex-col max-h-[20vh] gap-1 overflow-y-auto p-2 px-0 duration-200 delay-150 bg-gray-200 ${className}`
+        `max-w-lg flex flex-col max-h-[20vh] gap-1 overflow-y-auto p-2 px-0 duration-200 delay-150 bg-white text-gray-700 dark:bg-dark-card dark:text-gray-200 ${className}`
       )}
       data-testid='FiltersDropdown-div'
     >
@@ -47,16 +47,22 @@ export default function FiltersDropdown({
           <div
             key={index}
             className={twMerge(
-              `hover:bg-gray-300 text-black p-1 py-2 gap-1 flex cursor-pointer items-start ${checked ? 'bg-gray-400' : ''}`
+              `group flex cursor-pointer items-start gap-2 p-2 text-gray-700 transition-colors hover:bg-gray-100
+              dark:text-gray-200 dark:hover:bg-gray-100 dark:hover:text-gray-900
+              ${checked ? 'bg-secondary-100 text-gray-900 dark:!bg-gray-100 dark:!text-gray-900' : ''}`
             )}
             onClick={(event) => handleClickOption(event, data.name)}
           >
             {checked ? (
-              <img src='/img/illustrations/icons/CheckedIcon.svg' alt='checked' />
+              <img src='/img/illustrations/icons/CheckedIcon.svg' alt='checked' className='mt-0.5 size-3' />
             ) : (
-              <img src='/img/illustrations/icons/UncheckedIcon.svg' alt='unchecked' />
+              <img
+                src='/img/illustrations/icons/UncheckedIcon.svg'
+                alt='unchecked'
+                className='mt-0.5 size-3 dark:invert group-hover:dark:invert-0'
+              />
             )}
-            <div className='-mt-px mb-px text-xs'>{data.name}</div>
+            <div className='mb-px text-xs'>{data.name}</div>
           </div>
         );
       })}

--- a/components/tools/Toggle.tsx
+++ b/components/tools/Toggle.tsx
@@ -11,14 +11,14 @@ const Toggle = ({
   setChecked,
   label,
   bgColor = 'bg-gray-200',
-  checkedStateBgColor = 'bg-secondary-500',
+  checkedStateBgColor = 'bg-secondary-500'
 }: ToggleProps) => {
   return (
-    <label className="relative inline-flex cursor-pointer items-center">
+    <label className='relative inline-flex cursor-pointer items-center'>
       <input
-        type="checkbox"
+        type='checkbox'
         value={checked ? 'true' : 'false'}
-        className="peer sr-only"
+        className='peer sr-only'
         onChange={() => setChecked(!checked)}
       />
       <div
@@ -30,14 +30,10 @@ const Toggle = ({
           dark:after:bg-gray-200`,
           bgColor,
           checked &&
-            `after:translate-x-full after:border-white ${checkedStateBgColor} dark:bg-secondary-600 dark:ring-secondary-400/60`,
+            `after:translate-x-full after:border-white ${checkedStateBgColor} dark:bg-secondary-600 dark:ring-secondary-400/60`
         )}
       ></div>
-      {label && (
-        <div className="ml-2 text-sm font-medium text-gray-700 dark:text-gray-300">
-          {label}
-        </div>
-      )}
+      {label && <div className='ml-2 text-sm font-medium text-gray-700 dark:text-gray-300'>{label}</div>}
     </label>
   );
 };

--- a/components/tools/Toggle.tsx
+++ b/components/tools/Toggle.tsx
@@ -23,10 +23,14 @@ const Toggle = ({
       />
       <div
         className={twMerge(
-          `w-11 h-6 ${bgColor} dark:bg-gray-700 peer-focus:outline-none rounded-full peer after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 dark:after:border-gray-600 after:border after:rounded-full after:h-5 after:w-5 after:transition-all ${checked ? `after:translate-x-full after:border-white ${checkedStateBgColor} dark:bg-secondary-600` : ''}`
+          `h-6 w-11 rounded-full ${bgColor} transition-colors peer peer-focus:outline-none peer-focus:ring-2
+          peer-focus:ring-secondary-500/40 dark:bg-dark-background dark:ring-1 dark:ring-gray-600
+          after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border
+          after:border-gray-300 after:bg-white after:transition-all after:content-[''] dark:after:border-gray-500
+          dark:after:bg-gray-200 ${checked ? `after:translate-x-full after:border-white ${checkedStateBgColor} dark:bg-secondary-600 dark:ring-secondary-400/60` : ''}`
         )}
       ></div>
-      {label && <div className='ml-2 text-sm font-medium dark:text-gray-300'>{label}</div>}
+      {label && <div className='ml-2 text-sm font-medium text-gray-700 dark:text-gray-300'>{label}</div>}
     </label>
   );
 };

--- a/components/tools/Toggle.tsx
+++ b/components/tools/Toggle.tsx
@@ -23,11 +23,13 @@ const Toggle = ({
       />
       <div
         className={twMerge(
-          `h-6 w-11 rounded-full ${bgColor} transition-colors peer peer-focus:outline-none peer-focus:ring-2
+          `h-6 w-11 rounded-full transition-colors peer peer-focus:outline-none peer-focus:ring-2
           peer-focus:ring-secondary-500/40 dark:bg-dark-background dark:ring-1 dark:ring-gray-600
           after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border
           after:border-gray-300 after:bg-white after:transition-all after:content-[''] dark:after:border-gray-500
-          dark:after:bg-gray-200 ${checked ? `after:translate-x-full after:border-white ${checkedStateBgColor} dark:bg-secondary-600 dark:ring-secondary-400/60` : ''}`
+          dark:after:bg-gray-200`,
+          bgColor,
+          checked && `after:translate-x-full after:border-white ${checkedStateBgColor} dark:bg-secondary-600 dark:ring-secondary-400/60`
         )}
       ></div>
       {label && <div className='ml-2 text-sm font-medium text-gray-700 dark:text-gray-300'>{label}</div>}

--- a/components/tools/Toggle.tsx
+++ b/components/tools/Toggle.tsx
@@ -11,14 +11,14 @@ const Toggle = ({
   setChecked,
   label,
   bgColor = 'bg-gray-200',
-  checkedStateBgColor = 'bg-secondary-500'
+  checkedStateBgColor = 'bg-secondary-500',
 }: ToggleProps) => {
   return (
-    <label className='relative inline-flex cursor-pointer items-center'>
+    <label className="relative inline-flex cursor-pointer items-center">
       <input
-        type='checkbox'
+        type="checkbox"
         value={checked ? 'true' : 'false'}
-        className='peer sr-only'
+        className="peer sr-only"
         onChange={() => setChecked(!checked)}
       />
       <div
@@ -29,10 +29,15 @@ const Toggle = ({
           after:border-gray-300 after:bg-white after:transition-all after:content-[''] dark:after:border-gray-500
           dark:after:bg-gray-200`,
           bgColor,
-          checked && `after:translate-x-full after:border-white ${checkedStateBgColor} dark:bg-secondary-600 dark:ring-secondary-400/60`
+          checked &&
+            `after:translate-x-full after:border-white ${checkedStateBgColor} dark:bg-secondary-600 dark:ring-secondary-400/60`,
         )}
       ></div>
-      {label && <div className='ml-2 text-sm font-medium text-gray-700 dark:text-gray-300'>{label}</div>}
+      {label && (
+        <div className="ml-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+          {label}
+        </div>
+      )}
     </label>
   );
 };

--- a/components/tools/ToolsCard.tsx
+++ b/components/tools/ToolsCard.tsx
@@ -49,15 +49,17 @@ export default function ToolsCard({ toolData }: ToolsCardProp) {
   });
 
   return (
-    <div className='flex h-auto flex-col rounded-xl border border-gray-200 dark:border-gray-700 shadow-md dark:shadow-xl bg-white dark:bg-dark-card hover:shadow-xl dark:hover:shadow-2xl transition-all duration-300 hover:scale-[1.02] hover:border-gray-300 dark:hover:border-gray-600 overflow-hidden'>
+    <div className='relative z-0 flex h-auto flex-col overflow-visible rounded-xl border border-gray-200 bg-white shadow-md transition-all duration-300 hover:z-30 hover:scale-[1.02] hover:border-gray-300 hover:shadow-xl dark:border-gray-700 dark:bg-dark-card dark:shadow-xl dark:hover:border-gray-600 dark:hover:shadow-2xl'>
       <div className='mb-6 px-6 pt-8'>
         <div className='flex flex-col gap-2'>
-          <div className='flex w-full justify-between gap-4'>
-            <Heading typeStyle={HeadingTypeStyle.smSemibold} className='dark:text-white'>
+          <div className='grid w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3'>
+            <Heading typeStyle={HeadingTypeStyle.smSemibold} className='min-w-0 break-words dark:text-white'>
               {toolData.title}
             </Heading>
             <div
-              className='size-fit min-w-[5.3rem] rounded-lg border border-green-600 dark:border-green-500 bg-green-100 dark:bg-green-900/30 p-1 text-center text-xs text-green-700 dark:text-green-400 font-semibold shadow-sm'
+              className='size-fit max-w-full whitespace-nowrap rounded-lg border border-green-600
+                bg-green-100 px-2 py-1 text-center text-xs font-semibold text-green-700 shadow-sm
+                dark:border-green-500 dark:bg-green-900/30 dark:text-green-400'
               onMouseEnter={() =>
                 setTimeout(() => {
                   if (!visible.desc) setVisible({ ...visible, desc: true });
@@ -74,7 +76,11 @@ export default function ToolsCard({ toolData }: ToolsCardProp) {
               >
                 {toolData.filters?.hasCommercial === false ? 'Open Source' : 'Commercial'}
                 {visible.desc && (
-                  <span className='absolute -left-2/3 top-8 z-10 w-48 -translate-x-12 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-dark-card px-3 py-2 text-left text-gray-700 dark:text-gray-300 shadow-lg text-xs'>
+                  <span
+                    className='absolute right-0 top-8 z-50 w-56 whitespace-normal break-words rounded-lg border
+                    border-gray-200 bg-white px-3 py-2 text-left text-xs leading-5 text-gray-700 shadow-xl
+                    dark:border-gray-600 dark:bg-dark-card dark:text-gray-300 dark:shadow-2xl'
+                  >
                     {Data.properties.filters.properties.hasCommercial.description}
                   </span>
                 )}


### PR DESCRIPTION
**Description**

- Improved dark theme styles for the tools filter panel, including dropdown inputs, selected dropdown rows, applied filter chips, and ownership toggle.
- Updated info popovers and badge tooltip styling so content is readable in dark mode and no longer clips or overflows awkwardly.
- Fixed tools card header layout so the Open Source/Commercial badge stays aligned with the title without overlapping long titles.

**Screenshots**

| Theme | Feature | Before | After |
| --- | --- | --- | --- |
| **Light** | Filter View | <img width="359" height="722" alt="Light Filter Before" src="https://github.com/user-attachments/assets/1e0e6fe7-8626-4a8f-b734-0436a22cd431" /> | <img width="349" height="732" alt="Light Filter After" src="https://github.com/user-attachments/assets/49b66165-04bf-4362-bdb2-0b60090634ab" /> |
| **Light** | Tooltip | <img width="407" height="458" alt="Light Tooltip Before" src="https://github.com/user-attachments/assets/8ce68765-30f9-47cd-b445-74d6f0e4fefd" /> | <img width="399" height="451" alt="Light Tooltip After" src="https://github.com/user-attachments/assets/2fd2d949-7f1e-4f0f-bc7c-1041a03f33ed" /> |
| **Light** | Explanation Mark Hover | <img width="394" height="456" alt="Light Hover Before" src="https://github.com/user-attachments/assets/63d4b7d9-f4c2-4b9c-9c44-b64cae7265fb" /> | <img width="394" height="460" alt="Light Hover After" src="https://github.com/user-attachments/assets/ff9bf41e-e021-4955-821c-1f5186a6885f" /> |
| **Light** | Open Source Badge | <img width="440" height="472" alt="Light Badge Before" src="https://github.com/user-attachments/assets/e429c652-a488-48ef-8120-9745d784e4d2" /> | <img width="435" height="468" alt="Light Badge After" src="https://github.com/user-attachments/assets/0f29a33e-6b8e-462b-8877-5715aa278e39" /> |
| **Dark** | Filter View | <img width="370" height="740" alt="Dark Filter Before" src="https://github.com/user-attachments/assets/e06230ec-0237-4c00-bbd7-eca209e85eb2" /> | <img width="359" height="730" alt="Dark Filter After" src="https://github.com/user-attachments/assets/ec0f1ac2-b010-4bae-a968-b5370808b637" /> |
| **Dark** | Tooltip | <img width="400" height="486" alt="Dark Tooltip Before" src="https://github.com/user-attachments/assets/7b51e63b-d2d7-451a-a8bd-e163507521ab" /> | <img width="401" height="481" alt="Dark Tooltip After" src="https://github.com/user-attachments/assets/a484c11f-7885-4513-b7e5-b0a553b40500" /> |
| **Dark** | Explanation Mark Hover | <img width="401" height="455" alt="Dark Hover Before" src="https://github.com/user-attachments/assets/53cd29f2-a867-4c62-8639-9c85969185e9" /> | <img width="400" height="455" alt="Dark Hover After" src="https://github.com/user-attachments/assets/9643074b-34a5-4642-b5db-e2bec79029f8" /> |
| **Dark** | Open Source Badge | <img width="398" height="463" alt="Dark Badge Before" src="https://github.com/user-attachments/assets/c2f5ca62-9819-4c84-a0d0-30d2a1913db5" /> | <img width="425" height="448" alt="Dark Badge After" src="https://github.com/user-attachments/assets/b68874d6-ff04-435a-98cb-b93235e98c90" /> |

**Reproduce**

1. Navigate to https://deploy-preview-5522--asyncapi-website.netlify.app/tools
2. Click on filters and apply them in both the dark and light themes.
3. Check the tool cards and hover behaviors to verify styling changes.

**Related issue(s)**

- Ref: https://github.com/asyncapi/website/pull/5253#issuecomment-4578167312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved dark-mode colors, contrast and visual consistency across filters, cards, chips, toggles and buttons
  * Refined hover, focus and active states for interactive elements and badges
  * Adjusted card and chip spacing and visual hierarchy for cleaner layouts
* **Refactor**
  * Filter options made keyboard-focusable and standardized for more reliable interaction
  * Tooltips/popovers and description panels restyled with improved positioning, sizing and scroll behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5522?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->