### PR TITLE
fix: mermaidDiagram props as read-only  

### DIFF
--- a/components/MDX/MDX.tsx
+++ b/components/MDX/MDX.tsx
@@ -133,7 +133,7 @@ interface MermaidDiagramProps {
  * @param {MermaidDiagramProps} props - The props for the MermaidDiagram component.
  * @param {string} props.graph - The Mermaid graph to render.
  */
-function MermaidDiagram({ graph }: MermaidDiagramProps) {
+function MermaidDiagram({ graph }: Readonly<MermaidDiagramProps>) {
   const [svg, setSvg] = useState<string | null>(null);
   const [theme, setTheme] = useState<MermaidTheme>('light');
 


### PR DESCRIPTION
Sonar issue https://github.com/asyncapi/website/pull/5253#issuecomment-4583411521

Expected Behavior 
<img width="1042" height="453" alt="Screenshot 2026-05-30 at 11 20 23 PM" src="https://github.com/user-attachments/assets/9490fd88-b278-4780-8ab5-7ac7a3943942" />
<img width="529" height="590" alt="Screenshot 2026-05-30 at 11 21 05 PM" src="https://github.com/user-attachments/assets/130872df-98e1-4190-be79-7bf06452eee9" />
<img width="705" height="630" alt="Screenshot 2026-05-30 at 11 20 55 PM" src="https://github.com/user-attachments/assets/854103a8-5785-49ff-9535-4c44510e3563" />
<img width="1077" height="456" alt="Screenshot 2026-05-30 at 11 20 31 PM" src="https://github.com/user-attachments/assets/c4c7730c-4295-43a7-a1fb-a75942f8649e" />

