### PR TITLE
fix: dark theme text issues in generator-api-section

### DIFF
--- a/components/MDX/MDX.tsx
+++ b/components/MDX/MDX.tsx
@@ -434,19 +434,19 @@ const getMDXComponents = (reactId: string) => ({
   Tbody: TableBody,
   Thead,
   Table,
-  Dl: (props: React.HTMLProps<HTMLDListElement>) => (
-    <dl {...props} className={`${props.className || ''} my-4 font-body antialiased`} />
+  Dl: ({ className, ...props }: React.HTMLProps<HTMLDListElement>) => (
+    <dl {...props} className={`${className || ''} my-4 font-body antialiased`} />
   ),
-  Dt: (props: React.HTMLProps<HTMLElement>) => (
+  Dt: ({ className, ...props }: React.HTMLProps<HTMLElement>) => (
     <dt
       {...props}
-      className={`${props.className || ''} mt-6 font-heading text-lg font-semibold dark:text-white text-gray-900 antialiased [&_a]:border-b [&_a]:border-secondary-400 [&_a]:dark:text-white [&_a]:font-semibold [&_a]:text-gray-900 [&_a]:transition [&_a]:duration-300 [&_a]:ease-in-out [&_a]:hover:border-secondary-500 [&_a]:font-body [&_a]:antialiased [&_code]:rounded [&_code]:bg-gray-200 [&_code]:dark:bg-gray-800 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_code]:text-gray-800 [&_code]:dark:text-gray-300`}
+      className={`${className || ''} mt-6 font-heading text-lg font-semibold dark:text-white text-gray-900 antialiased [&_a]:border-b [&_a]:border-secondary-400 [&_a]:dark:text-white [&_a]:font-semibold [&_a]:text-gray-900 [&_a]:transition [&_a]:duration-300 [&_a]:ease-in-out [&_a]:hover:border-secondary-500 [&_a]:font-body [&_a]:antialiased [&_code]:rounded [&_code]:bg-gray-200 [&_code]:dark:bg-gray-800 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_code]:text-gray-800 [&_code]:dark:text-gray-300`}
     />
   ),
-  Dd: (props: React.HTMLProps<HTMLElement>) => (
+  Dd: ({ className, ...props }: React.HTMLProps<HTMLElement>) => (
     <dd
       {...props}
-      className={`${props.className || ''} ml-4 font-body dark:text-dark-text text-gray-700 antialiased [&_a]:border-b [&_a]:border-secondary-400 [&_a]:dark:text-white [&_a]:font-semibold [&_a]:text-gray-900 [&_a]:transition [&_a]:duration-300 [&_a]:ease-in-out [&_a]:hover:border-secondary-500 [&_a]:font-body [&_a]:antialiased [&_code]:rounded [&_code]:bg-gray-200 [&_code]:dark:bg-gray-800 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_code]:text-gray-800 [&_code]:dark:text-gray-300`}
+      className={`${className || ''} ml-4 font-body dark:text-dark-text text-gray-700 antialiased [&_a]:border-b [&_a]:border-secondary-400 [&_a]:dark:text-white [&_a]:font-semibold [&_a]:text-gray-900 [&_a]:transition [&_a]:duration-300 [&_a]:ease-in-out [&_a]:hover:border-secondary-500 [&_a]:font-body [&_a]:antialiased [&_code]:rounded [&_code]:bg-gray-200 [&_code]:dark:bg-gray-800 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_code]:text-gray-800 [&_code]:dark:text-gray-300`}
     />
   ),
   Asyncapi3ChannelComparison,

--- a/components/MDX/MDX.tsx
+++ b/components/MDX/MDX.tsx
@@ -440,7 +440,7 @@ const getMDXComponents = (reactId: string) => ({
   Dt: ({ className, ...props }: React.HTMLProps<HTMLElement>) => (
     <dt
       {...props}
-      className={`${className || ''} mt-6 font-heading text-lg font-semibold dark:text-white text-gray-900 antialiased [&_a]:border-b [&_a]:border-secondary-400 [&_a]:dark:text-white [&_a]:font-semibold [&_a]:text-gray-900 [&_a]:transition [&_a]:duration-300 [&_a]:ease-in-out [&_a]:hover:border-secondary-500 [&_a]:font-body [&_a]:antialiased [&_code]:rounded [&_code]:bg-gray-200 [&_code]:dark:bg-gray-800 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_code]:text-gray-800 [&_code]:dark:text-gray-300`}
+      className={`${className || ''} mt-6 font-heading text-lg font-semibold dark:text-dark-heading text-gray-900 antialiased [&_a]:border-b [&_a]:border-secondary-400 [&_a]:dark:text-white [&_a]:font-semibold [&_a]:text-gray-900 [&_a]:transition [&_a]:duration-300 [&_a]:ease-in-out [&_a]:hover:border-secondary-500 [&_a]:font-body [&_a]:antialiased [&_code]:rounded [&_code]:bg-gray-200 [&_code]:dark:bg-gray-800 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_code]:text-gray-800 [&_code]:dark:text-gray-300`}
     />
   ),
   Dd: ({ className, ...props }: React.HTMLProps<HTMLElement>) => (

--- a/components/MDX/MDX.tsx
+++ b/components/MDX/MDX.tsx
@@ -434,6 +434,21 @@ const getMDXComponents = (reactId: string) => ({
   Tbody: TableBody,
   Thead,
   Table,
+  Dl: (props: React.HTMLProps<HTMLDListElement>) => (
+    <dl {...props} className={`${props.className || ''} my-4 font-body antialiased`} />
+  ),
+  Dt: (props: React.HTMLProps<HTMLElement>) => (
+    <dt
+      {...props}
+      className={`${props.className || ''} mt-6 font-heading text-lg font-semibold dark:text-white text-gray-900 antialiased [&_a]:border-b [&_a]:border-secondary-400 [&_a]:dark:text-white [&_a]:font-semibold [&_a]:text-gray-900 [&_a]:transition [&_a]:duration-300 [&_a]:ease-in-out [&_a]:hover:border-secondary-500 [&_a]:font-body [&_a]:antialiased [&_code]:rounded [&_code]:bg-gray-200 [&_code]:dark:bg-gray-800 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_code]:text-gray-800 [&_code]:dark:text-gray-300`}
+    />
+  ),
+  Dd: (props: React.HTMLProps<HTMLElement>) => (
+    <dd
+      {...props}
+      className={`${props.className || ''} ml-4 font-body dark:text-dark-text text-gray-700 antialiased [&_a]:border-b [&_a]:border-secondary-400 [&_a]:dark:text-white [&_a]:font-semibold [&_a]:text-gray-900 [&_a]:transition [&_a]:duration-300 [&_a]:ease-in-out [&_a]:hover:border-secondary-500 [&_a]:font-body [&_a]:antialiased [&_code]:rounded [&_code]:bg-gray-200 [&_code]:dark:bg-gray-800 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_code]:text-gray-800 [&_code]:dark:text-gray-300`}
+    />
+  ),
   Asyncapi3ChannelComparison,
   Asyncapi3IdAndAddressComparison,
   Asyncapi3MetaComparison,

--- a/scripts/build-pages.ts
+++ b/scripts/build-pages.ts
@@ -5,7 +5,7 @@ import path from 'path';
 const SRC_DIR = 'markdown';
 const TARGET_DIR = 'pages';
 
-const capitalizeTags = ['table', 'tr', 'td', 'th', 'thead', 'tbody'];
+const capitalizeTags = ['table', 'tr', 'td', 'th', 'thead', 'tbody', 'dl', 'dt', 'dd'];
 
 /**
  * Ensures that the specified directory exists. If it doesn't, creates it.


### PR DESCRIPTION
**Description**

- Fixed UI issues regarding text visibility in the dark theme for the `generator-api-section`.

**Screenshots**

| Theme | Before | After |
| --- | --- | --- |
| **Light** | <img width="936" height="259" alt="Light Theme Before" src="https://github.com/user-attachments/assets/c3bdd71b-d607-456c-8d80-a589964dd54b" /> | <img width="982" height="374" alt="Light Theme After" src="https://github.com/user-attachments/assets/d25bb098-c725-4ccb-a4eb-172090968698" /> |
| **Dark** | <img width="949" height="264" alt="Dark Theme Before" src="https://github.com/user-attachments/assets/3aa02334-ddc5-49af-81cf-6eb9e9779383" /> | <img width="973" height="395" alt="Dark Theme After" src="https://github.com/user-attachments/assets/c740805c-0764-4eae-92c8-03b5303dc16b" /> |

**Reproduce**

1. Navigate to https://deploy-preview-5525--asyncapi-website.netlify.app/docs/tools/generator/api
2. Toggle between the light and dark themes to verify the text visibility is fixed.

**Related issue(s)**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rendering definition lists in MDX content with proper formatting and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->