### PR TITLE
feat: add dark mode support to newsroom article cards and dates

### DIFF
--- a/components/newsroom/NewsroomArticle.tsx
+++ b/components/newsroom/NewsroomArticle.tsx
@@ -22,14 +22,14 @@ export default function NewsroomArticl() {
       {articlesData.map((article: Article, index: number) => (
         <li key={index}>
           <a
-            className='mb-2 block rounded-md border border-gray-200 bg-white p-6 text-left shadow-md transition-all duration-300 ease-in-out hover:shadow-lg lg:w-full'
+            className='mb-2 block rounded-md border border-gray-200 dark:border-gray-800 bg-white dark:bg-dark-card p-6 text-left shadow-md transition-all duration-300 ease-in-out hover:shadow-lg lg:w-full'
             href={article.url}
             target='_blank'
             rel='noopener noreferrer'
             data-testid={`NewsroomArticle-${index}`}
           >
             <div>
-              <Paragraph typeStyle={ParagraphTypeStyle.sm} textColor='text-gray-600'>
+              <Paragraph typeStyle={ParagraphTypeStyle.sm} textColor='text-gray-600 dark:text-gray-400'>
                 {article.publishDate}
               </Paragraph>
               <Heading level={HeadingLevel.h4} typeStyle={HeadingTypeStyle.xsSemibold} className='mt-3'>


### PR DESCRIPTION
**Description**

- Added dark mode support to newsroom article cards and dates.

**Screenshots**

| Theme | Before | After |
| --- | --- | --- |
| **Dark** | <img width="1234" height="479" alt="Dark Theme Before" src="https://github.com/user-attachments/assets/c1c8ff83-4af3-482f-85f0-85d27d6a40e2" /> | <img width="1233" height="497" alt="Dark Theme After" src="https://github.com/user-attachments/assets/e470d5bf-cf03-4403-a0f3-a421c35be8da" /> |
| **Light** | <img width="1235" height="413" alt="Light Theme Before" src="https://github.com/user-attachments/assets/ea901263-61ed-47f7-932c-a33b710da1f3" /> | <img width="1222" height="459" alt="Light Theme After" src="https://github.com/user-attachments/assets/705e9aa7-2044-407a-a4f6-9945de312f55" /> |

**Reproduce**

1. Navigate to https://deploy-preview-5253--asyncapi-website.netlify.app/community/newsroom
2. Toggle between the light and dark themes to verify the styling updates for the article cards and dates.

**Related issue(s)**