### PR TITLE
fix: add filter to invert documentation diagrams in dark mode

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -544,3 +544,10 @@ select {
 .dark .case-studies-swiper .swiper-pagination-bullet {
   background: #A87EFC;
 }
+
+/* Invert documentation diagrams in dark mode */
+.dark img[src*="SNS-SQS-Pub-Sub.png"],
+.dark img[src*="SNS-HTTP.png"],
+.dark img[src*="SQS-Point-To-Point.png"] {
+  filter: invert(100%) hue-rotate(180deg);
+}


### PR DESCRIPTION
refs - https://github.com/asyncapi/website/issues/5465#issuecomment-4586415133

**Description:**

- Added CSS rules in `styles/globals.css` to invert the colors of diagram images (SNS-SQS-Pub-Sub.png, SNS-HTTP.png, SQS-Point-To-Point.png) when the website is in dark mode in `/docs/reference/bindings/3.0.0` and `/docs/reference/bindings/2.x.x`.

**Steps to Reproduce:**

1. Navigate to the SNS bindings reference page at `/docs/reference/bindings/3.0.0` or `/docs/reference/bindings/2.x.x`.
2. Toggle the website theme to dark mode.
3. Scroll down to the "SNS to SQS Pub-Sub" or "SNS to HTTP Pub Sub" or "" example sections.
4. Notice that the architecture diagram images now display with white text labels that are clearly readable against the dark background.

**Screenshots:**

| Before | After |
|--------|--------|
| <img width="600" alt="SNS diagram before 1" src="https://github.com/user-attachments/assets/ef73bdf1-4465-4fc9-b6aa-101064def1ec" /> | <img width="600" alt="SNS diagram after 1" src="https://github.com/user-attachments/assets/367c2845-fc0c-494c-a7f3-03d9c5e9dcaa" /> |
| <img width="600" alt="SNS diagram before 2" src="https://github.com/user-attachments/assets/7dcb56e3-eece-44a0-b447-487ac56c70c7" /> | <img width="600" alt="SNS diagram after 2" src="https://github.com/user-attachments/assets/8563e064-c817-4614-a3ac-6a70fa85d47b" /> |
| <img width="600" alt="SNS diagram before 3" src="https://github.com/user-attachments/assets/ca8aaca8-edbb-4430-892e-84e62bf56876" /> | <img width="600" alt="SNS diagram after 3" src="https://github.com/user-attachments/assets/08382ca9-6c21-4f15-a276-75e06b953cce" /> |
| <img width="600" alt="SNS diagram before 4" src="https://github.com/user-attachments/assets/b458f50a-7834-4a9f-91f2-ef15f7112610" /> | <img width="600" alt="SNS diagram after 4" src="https://github.com/user-attachments/assets/53aa568f-ab4e-4c57-ab2e-859fd3c49279" /> |