### PR TITLE
fix: redesigned-reminder-card-dark-mode

### DIFF
--- a/components/Remember.tsx
+++ b/components/Remember.tsx
@@ -21,7 +21,10 @@ export default function Remember({ title = 'Remember', className = '', children 
       className={`${className} mb-8 mt-4 rounded bg-secondary-100 dark:bg-dark-card p-4 text-gray-900 dark:text-gray-200`}
       data-testid='Remember-main'
     >
-      <h5 className='mb-4 border-b dark:text-white border-gray-900 dark:border-gray-600 pb-2 text-lg' data-testid='Remember-heading'>
+      <h5
+        className='mb-4 border-b dark:text-white border-gray-900 dark:border-gray-600 pb-2 text-lg'
+        data-testid='Remember-heading'
+      >
         <LightBulb className='-mt-0.5 mr-2 inline-block h-8' />
         <span className='ml-2 inline-block font-sans font-medium antialiased' data-testid='Remember-title'>
           {title}

--- a/components/Remember.tsx
+++ b/components/Remember.tsx
@@ -18,10 +18,10 @@ interface RememberProps {
 export default function Remember({ title = 'Remember', className = '', children }: RememberProps) {
   return (
     <div
-      className={`${className} mb-8 mt-4 rounded bg-secondary-100 dark:bg-dark-background p-4 text-gray-900 dark:text-gray-200`}
+      className={`${className} mb-8 mt-4 rounded bg-secondary-100 dark:bg-dark-card p-4 text-gray-900 dark:text-gray-200`}
       data-testid='Remember-main'
     >
-      <h5 className='mb-4 border-b dark:text-white border-gray-900 pb-2 text-lg' data-testid='Remember-heading'>
+      <h5 className='mb-4 border-b dark:text-white border-gray-900 dark:border-gray-600 pb-2 text-lg' data-testid='Remember-heading'>
         <LightBulb className='-mt-0.5 mr-2 inline-block h-8' />
         <span className='ml-2 inline-block font-sans font-medium antialiased' data-testid='Remember-title'>
           {title}


### PR DESCRIPTION
**Description**

- Redesigned the reminder card to improve styling and support for dark mode.

**Screenshots**

| Theme | Before | After |
| --- | --- | --- |
| **Light** | <img width="995" height="656" alt="Light Theme Before" src="https://github.com/user-attachments/assets/9309f399-fce0-4b21-b3c0-6297ac99ad8e" /> | <img width="995" height="656" alt="Light Theme After" src="https://github.com/user-attachments/assets/62cc3bb4-0a04-45d7-ac9b-3d14ec771234" /> |
| **Dark** | <img width="997" height="660" alt="Dark Theme Before" src="https://github.com/user-attachments/assets/8139d6f3-995c-46b6-bf4a-ede1a7f6c2ce" /> | <img width="990" height="662" alt="Dark Theme After" src="https://github.com/user-attachments/assets/0a7b8c06-2d36-4f75-b461-2749dc18fddb" /> |

**Reproduce**

1. Navigate to https://deploy-preview-5531--asyncapi-website.netlify.app/docs/reference
2. Locate the reminder card.
3. Toggle between the light and dark themes to verify the styling updates.

**Related issue(s)**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the Remember component’s dark-mode visuals: adjusted the main container background and refined the heading border to improve visual consistency and legibility in dark theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->