### PR TITLE
fix: broken-url-in-tools

### DIFF
--- a/pages/tools/index.tsx
+++ b/pages/tools/index.tsx
@@ -71,7 +71,7 @@ export default function ToolsIndex() {
                 community. Have an AsyncAPI tool you want to be featured on this list? Then follow the procedure given
                 in the{' '}
                 <TextLink
-                  href='https://github.com/asyncapi/community/blob/master/new-tool-documentation.md'
+                  href='https://github.com/asyncapi/community/blob/master/docs/040-guides/add-new-asyncapi-tool-to-website.md'
                   target='_blank'
                   className='text-gray-900 dark:text-white font-semibold hover:text-gray-600 dark:hover:text-gray-300 underline-offset-4 underline decoration-2 decoration-primary-500 dark:decoration-primary-400 transition-colors duration-200'
                 >


### PR DESCRIPTION
Updates the tool documentation link on the tools page to point to the correct documentation path in the community repository.

### Changes:
- Updated tool documentation URL from https://github.com/asyncapi/community/blob/master/new-tool-documentation.md to  https://github.com/asyncapi/community/blob/master/docs/040-guides/add-new-asyncapi-tool-to-website.md
- The previous link was pointing to an outdated or incorrect path. The new link directs users to the proper guide for adding new AsyncAPI tools to the website.

ref  : https://github.com/asyncapi/website/issues/5465#issuecomment-4582981458 - Issue - 10




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Tool Documentation link to reference the current guides location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->