### PR TITLE
fix: prevent header wrapping on medium screens

### DIFF
--- a/components/navigation/MobileNavMenu.tsx
+++ b/components/navigation/MobileNavMenu.tsx
@@ -65,7 +65,7 @@ export default function MobileNavMenu({
   const languageButtonHoverClass = 'ease-in-out hover:bg-gray-100/60 dark:hover:bg-gray-700/40 hover:translate-x-1';
 
   return (
-    <div className='fixed inset-x-0 top-0 z-60 max-h-full origin-top-right overflow-y-auto py-2 transition lg:hidden animate-in fade-in slide-in-from-top-5 duration-300'>
+    <div className='fixed inset-x-0 top-0 z-60 max-h-full origin-top-right overflow-y-auto py-2 transition min-[1100px]:hidden animate-in fade-in slide-in-from-top-5 duration-300'>
       <div className='mx-2 rounded-2xl'>
         <div className='shadow-xs divide-y divide-gray-100/50 dark:divide-gray-700/50 rounded-2xl bg-white/90 dark:bg-dark-card/90 backdrop-blur-xl border border-gray-200/50 dark:border-gray-700/50'>
           <div className='space-y-6 px-5 pb-6 pt-5'>

--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -4,6 +4,7 @@ import type { NextRouter } from 'next/router';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import { defaultLanguage, i18nPaths, languages } from '@/utils/i18n';
 
@@ -40,8 +41,13 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
   const { pathname, query, asPath } = router;
   const [open, setOpen] = useState<'learning' | 'tooling' | 'community' | null>(null);
   const [mobileMenuOpen, setMobileMenuOpen] = useState<boolean>(false);
+  const [isMounted, setIsMounted] = useState<boolean>(false);
   const [isScrolled, setIsScrolled] = useState<boolean>(false);
   const { i18n } = useTranslation();
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
 
   // Adding Scroll listener
   useEffect(() => {
@@ -194,7 +200,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
           )}
 
           <div
-            className='-my-2 -mr-2 flex flex-row items-center justify-center gap-1 lg:hidden'
+            className='-my-2 -mr-2 flex flex-row items-center justify-center gap-1 min-[1100px]:hidden'
             data-testid='Navbar-search'
           >
             <SearchButton
@@ -218,7 +224,7 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
           </div>
 
           <nav
-            className='hidden w-full space-x-4 lg:flex lg:items-center lg:justify-end xl:space-x-8'
+            className='hidden w-full space-x-4 min-[1100px]:flex min-[1100px]:items-center min-[1100px]:justify-end xl:space-x-8'
             data-testid='Navbar-main'
           >
             <div className='relative' onMouseLeave={() => showMenu(null)} ref={learningRef}>
@@ -293,14 +299,17 @@ export default function NavBar({ className = '', hideLogo = false }: NavBarProps
 
       {/* </div> */}
       {/* Mobile menu, show/hide based on mobile menu state. */}
-      {mobileMenuOpen && (
-        <MobileNavMenu
-          onClickClose={() => setMobileMenuOpen(false)}
-          uniqueLangs={uniqueLangs}
-          currentLanguage={i18n.language ? i18n.language : 'en'}
-          changeLanguage={changeLanguage}
-        />
-      )}
+      {isMounted &&
+        mobileMenuOpen &&
+        createPortal(
+          <MobileNavMenu
+            onClickClose={() => setMobileMenuOpen(false)}
+            uniqueLangs={uniqueLangs}
+            currentLanguage={i18n.language ? i18n.language : 'en'}
+            changeLanguage={changeLanguage}
+          />,
+          document.body
+        )}
     </>
   );
 }


### PR DESCRIPTION
## Description

This PR fixes the header layout issue on medium screen widths where navigation items and the GitHub button wrap between `1024px` and `1100px`.

The desktop navigation requires more horizontal space than `1024px` provides, so this PR keeps the compact header visible until `1100px` and only shows the full desktop navigation from `1100px` upward.

It also renders the mobile navigation menu through a React portal into `document.body`. This prevents the fixed mobile menu from being constrained by the sticky/transformed navbar container at medium widths.

## Related Issue

Closes #4898

## Changes

- Shows compact header controls until `1100px`.
- Shows full desktop navigation from `1100px+`.
- Updates `MobileNavMenu` visibility to match the new `1100px` breakpoint.
- Uses `createPortal` for `MobileNavMenu` so the overlay can use the full viewport height.

## Screenshots / Testing

Video demo of issue:

[header-issue.webm](https://github.com/user-attachments/assets/971d99a9-5ad5-4980-9c97-ca25063f920a)


Video demo of fix:

[header-fix.webm](https://github.com/user-attachments/assets/ec9f809f-df71-4e03-9f76-c3c5024f7639)

Expected behavior:

- No nav links or GitHub button text wrap between `1024px` and `1100px`.
- Hamburger menu opens correctly and uses the full available overlay height.
- Full desktop navigation appears normally at `1100px+`.

## Checklist

- [x] The header no longer wraps in the reported medium-width range.
- [x] The compact menu remains usable between `1024px` and `1099px`.
- [x] The full desktop nav is preserved for larger screens.
- [x] No logo size changes were made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed mobile menu rendering behavior and improved hydration stability.
  * Adjusted responsive breakpoints for mobile menu visibility across screen sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/website/pull/5536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->