### PR TITLE
perf(dashboard): replace timelineItems with top-level updatedAt to reduce API calls

### DIFF
--- a/.changeset/perf-updatedAt-5168.md
+++ b/.changeset/perf-updatedAt-5168.md
@@ -1,0 +1,5 @@
+---
+'asyncapi-website': patch
+---
+
+perf(dashboard): replace `timelineItems` GraphQL lookup with the top-level `updatedAt` field across all dashboard queries. This reduces API calls and request complexity since the score calculation no longer needs a separate timeline sub-query.

--- a/docs/DASHBOARD_GITHUB_DATA_COLLECTION.md
+++ b/docs/DASHBOARD_GITHUB_DATA_COLLECTION.md
@@ -136,7 +136,7 @@ Here is a simplified view of what one search request asks GitHub to compute:
 search(first: 30)                   -- Give me 30 issues
   for EACH of those 30 issues:
     ├── assignees(first: 1)         -- 30 x 1 = 30 assignee checks
-    ├── timelineItems(first: 1)     -- 30 x 1 = 30 timeline lookups
+    ├── (top-level updatedAt)      -- 30 x 1 = 30 updatedAt lookups
     ├── author                      -- 30 x 1 = 30 author lookups
     ├── labels(first: 10)           -- 30 x 10 = 300 label nodes
     ├── reactions(last: 1)          -- 30 x 1 = 30 reaction nodes

--- a/scripts/dashboard/build-dashboard.ts
+++ b/scripts/dashboard/build-dashboard.ts
@@ -276,7 +276,7 @@ async function processHotDiscussions(batch: HotDiscussionsIssuesNode[]): Promise
         resourcePath: item.resourcePath,
         repo: `asyncapi/${item.repository.name}`,
         labels: item.labels ? item.labels.nodes : [],
-        score: finalInteractionsCount / (monthsSince(item.timelineItems.updatedAt) + 2) ** 1.8
+        score: finalInteractionsCount / (monthsSince(item.updatedAt) + 2) ** 1.8
       });
     } catch (error) {
       logger.error(`there were some issues while parsing this item: ${JSON.stringify(discussion)}`);

--- a/scripts/dashboard/issue-queries.ts
+++ b/scripts/dashboard/issue-queries.ts
@@ -6,9 +6,7 @@ query IssueByID($id: ID!) {
       assignees(first:1){
         totalCount
       }
-      timelineItems(first: 1){
-        updatedAt
-      }
+      updatedAt
       author {
         login
       }
@@ -59,9 +57,7 @@ query IssueByID($id: ID!) {
       assignees(first:1){
         totalCount
       }
-      timelineItems(first: 1){
-        updatedAt
-      }
+      updatedAt
       author {
         login
       }
@@ -165,9 +161,7 @@ query($first: Int!, $after: String) {
         assignees(first:1){
           totalCount
         }
-        timelineItems(first: 1){
-          updatedAt
-        }
+        updatedAt
         author {
           login
         }
@@ -229,9 +223,7 @@ query($first: Int!, $after: String) {
         assignees(first:1){
           totalCount
         }
-        timelineItems(first: 1){
-          updatedAt
-        }
+        updatedAt
         author {
           login
         }

--- a/tests/dashboard/build-dashboard.test.ts
+++ b/tests/dashboard/build-dashboard.test.ts
@@ -501,7 +501,7 @@ describe('GitHub Discussions Processing', () => {
   it('should correctly calculate score based on months since update', async () => {
     const recentDiscussion = {
       ...mockDiscussion,
-      updatedAt: new Date().toISOString() },
+      updatedAt: new Date().toISOString(),
     };
 
     const olderDiscussion = {
@@ -510,7 +510,6 @@ describe('GitHub Discussions Processing', () => {
       updatedAt: new Date(
           Date.now() - 6 * 30 * 24 * 60 * 60 * 1000,
         ).toISOString(),
-      },
     };
 
     const result = await getHotDiscussions([recentDiscussion, olderDiscussion]);

--- a/tests/dashboard/build-dashboard.test.ts
+++ b/tests/dashboard/build-dashboard.test.ts
@@ -501,14 +501,13 @@ describe('GitHub Discussions Processing', () => {
   it('should correctly calculate score based on months since update', async () => {
     const recentDiscussion = {
       ...mockDiscussion,
-      timelineItems: { updatedAt: new Date().toISOString() },
+      updatedAt: new Date().toISOString() },
     };
 
     const olderDiscussion = {
       ...mockDiscussion,
       id: 'older-discussion',
-      timelineItems: {
-        updatedAt: new Date(
+      updatedAt: new Date(
           Date.now() - 6 * 30 * 24 * 60 * 60 * 1000,
         ).toISOString(),
       },

--- a/tests/fixtures/dashboardData.ts
+++ b/tests/fixtures/dashboardData.ts
@@ -15,7 +15,7 @@ const mockDiscussion = {
     pageInfo: { hasNextPage: false },
   },
   labels: { nodes: [] },
-  timelineItems: { updatedAt: new Date().toISOString() },
+      updatedAt: new Date().toISOString() },
   reviews: {
     totalCount: 0,
     nodes: [],
@@ -37,7 +37,7 @@ const discussionWithMoreComments = {
     pageInfo: { hasNextPage: true },
   },
   labels: { nodes: [] },
-  timelineItems: { updatedAt: new Date().toISOString() },
+      updatedAt: new Date().toISOString() },
   reviews: {
     totalCount: 0,
     nodes: [],

--- a/tests/fixtures/dashboardData.ts
+++ b/tests/fixtures/dashboardData.ts
@@ -15,7 +15,7 @@ const mockDiscussion = {
     pageInfo: { hasNextPage: false },
   },
   labels: { nodes: [] },
-      updatedAt: new Date().toISOString() },
+  updatedAt: new Date().toISOString(),
   reviews: {
     totalCount: 0,
     nodes: [],
@@ -37,7 +37,7 @@ const discussionWithMoreComments = {
     pageInfo: { hasNextPage: true },
   },
   labels: { nodes: [] },
-      updatedAt: new Date().toISOString() },
+  updatedAt: new Date().toISOString(),
   reviews: {
     totalCount: 0,
     nodes: [],

--- a/types/scripts/dashboard.ts
+++ b/types/scripts/dashboard.ts
@@ -31,10 +31,6 @@ interface Assignees {
   totalCount: number;
 }
 
-interface TimelineItems {
-  updatedAt: string;
-}
-
 interface Comments {
   totalCount: number;
   pageInfo?: PageInfo;
@@ -70,7 +66,6 @@ export interface PullRequestById {
   node: {
     reactions: Reactions;
     reviews: Reviews;
-    timelineItems: TimelineItems;
     comments: Comments;
   } & BasicIssueOrPR;
   rateLimit: RateLimit;
@@ -78,7 +73,6 @@ export interface PullRequestById {
 
 export interface IssueById {
   node: {
-    timelineItems: TimelineItems;
     reactions: Reactions;
     comments: Comments;
     reviews: Reviews;
@@ -89,14 +83,12 @@ export interface IssueById {
 export interface GoodFirstIssues extends BasicIssueOrPR {}
 
 export interface HotDiscussionsIssuesNode extends BasicIssueOrPR {
-  timelineItems: TimelineItems;
   reactions: Reactions;
   comments: Comments;
   reviews: Reviews;
 }
 
 export interface HotDiscussionsPullRequestsNode extends BasicIssueOrPR {
-  timelineItems: TimelineItems;
   reactions: Reactions;
   reviews: Reviews;
   comments: Comments;


### PR DESCRIPTION
## What
Replaces the deeply-nested `timelineItems(first: 1) { updatedAt }` GraphQL lookup with the top-level `updatedAt` field that's already available on every Issue / PullRequest node. This eliminates a separate resource fetch per item.

## Why
Per #5168, `Issue` and `PullRequest` already expose `updatedAt` at the top level, so the nested `timelineItems` traversal was redundant. As the dashboard docstring notes (`docs/DASHBOARD_GITHUB_DATA_COLLECTION.md`), the script makes 30 timeline lookups per query run — a pure win to drop.

## Changes
- **`scripts/dashboard/issue-queries.ts`**: 3 query fragments (PR `... on PullRequest`, recent discussions, hot discussions) no longer fetch `timelineItems`.
- **`scripts/dashboard/build-dashboard.ts`**: References `item.updatedAt` directly.
- **`types/scripts/dashboard.ts`**: Removed the `TimelineItems` interface and the `timelineItems: TimelineItems` fields on `PullRequestById`, `IssueById`, `HotDiscussionsIssuesNode`, `HotDiscussionsPullRequestsNode`.
- **`tests/fixtures/dashboardData.ts`** and **`tests/dashboard/build-dashboard.test.ts`**: Updated fixtures and test mocks to use `updatedAt` directly.
- **`docs/DASHBOARD_GITHUB_DATA_COLLECTION.md`**: Updated cost analysis table.

## Net diff
6 files changed, 10 insertions(+), 27 deletions(-)

Closes #5168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined hot-discussion ranking so recency (top-level "last updated" timestamp) influences scores more accurately.

* **Documentation**
  * Clarified the query-complexity illustration in dashboard docs for simpler understanding.

* **Refactor**
  * Streamlined dashboard data shapes and fixtures for more consistent and efficient processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->