### PR TITLE
feat(ui): add React error boundary to Layout to recover from render errors

### DIFF
--- a/.changeset/feat-error-boundaries-5047.md
+++ b/.changeset/feat-error-boundaries-5047.md
@@ -1,0 +1,5 @@
+---
+'asyncapi-website': patch
+---
+
+feat(ui): add a top-level React `ErrorBoundary` and wrap every `Layout` return tree in it, so a render error in any descendant component (broken MDX page, future page, etc.) no longer tears down the whole site — it shows a recoverable fallback instead.

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,54 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+    children: ReactNode;
+    fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+    hasError: boolean;
+    error: Error | null;
+}
+
+/**
+ * Top-level ErrorBoundary for the AsyncAPI website.
+ *
+ * Wrapping the whole app in <ErrorBoundary> at the layout level means a render
+ * error in any descendant component (e.g. a future page, a broken MDX block)
+ * no longer tears down the whole site — it just shows a small recoverable
+ * fallback so navigation still works.
+ *
+ * See: https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
+ */
+export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+    constructor(props: ErrorBoundaryProps) {
+        super(props);
+        this.state = { hasError: false, error: null };
+    }
+
+    static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+        return { hasError: true, error };
+    }
+
+    componentDidCatch(error: Error, info: ErrorInfo): void {
+        // Surface the error to the browser console; in production a real Sentry
+        // hook would go here.
+        // eslint-disable-next-line no-console
+        console.error('[ErrorBoundary] Caught a render error:', error, info);
+    }
+
+    render(): ReactNode {
+        if (this.state.hasError) {
+            if (this.props.fallback) {
+                return this.props.fallback;
+            }
+            return (
+                <div role="alert" style={{ padding: '2rem', fontFamily: 'system-ui, sans-serif' }}>
+                    <h1>Something went wrong.</h1>
+                    <p>Please refresh the page, or use the navigation to continue.</p>
+                </div>
+            );
+        }
+        return this.props.children;
+    }
+}

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -6,6 +6,7 @@ import type { IPost, IPosts } from '@/types/post';
 
 import BlogContext from '../../context/BlogContext';
 import { getAllPosts, getDocBySlug, getPostBySlug } from '../../utils/api';
+import ErrorBoundary from '../ErrorBoundary';
 import BlogLayout from './BlogLayout';
 import DocsLayout from './DocsLayout';
 import GenericPostLayout from './GenericPostLayout';
@@ -28,9 +29,11 @@ export default function Layout({ children }: ILayoutProps): React.JSX.Element {
 
     return (
       <div data-testid='Docs-main-container'>
-        <DocsLayout post={post} navItems={allDocPosts}>
-          {children}
-        </DocsLayout>
+        <ErrorBoundary>
+          <DocsLayout post={post} navItems={allDocPosts}>
+            {children}
+          </DocsLayout>
+        </ErrorBoundary>
       </div>
     );
   }
@@ -39,24 +42,36 @@ export default function Layout({ children }: ILayoutProps): React.JSX.Element {
 
     return (
       <div data-testid='Blogs-main-container'>
-        <BlogLayout post={post as unknown as IPosts['blog'][number]} navItems={posts.blog}>
-          {children}
-        </BlogLayout>
+        <ErrorBoundary>
+          <BlogLayout post={post as unknown as IPosts['blog'][number]} navItems={posts.blog}>
+            {children}
+          </BlogLayout>
+        </ErrorBoundary>
       </div>
     );
   }
   if (pathname === '/blog') {
     return (
       <div data-testid='Blogs-sub-container'>
-        <BlogContext.Provider value={{ navItems: posts.blog }}>{children}</BlogContext.Provider>
+        <ErrorBoundary>
+          <BlogContext.Provider value={{ navItems: posts.blog }}>{children}</BlogContext.Provider>
+        </ErrorBoundary>
       </div>
     );
   }
   const post = getPostBySlug(pathname);
 
   if (post) {
-    return <GenericPostLayout post={post as unknown as IPosts['blog'][number]}>{children}</GenericPostLayout>;
+    return (
+      <ErrorBoundary>
+        <GenericPostLayout post={post as unknown as IPosts['blog'][number]}>{children}</GenericPostLayout>
+      </ErrorBoundary>
+    );
   }
 
-  return <div className='min-h-screen bg-white dark:bg-dark-background transition-colors duration-300'>{children}</div>;
+  return (
+    <div className='min-h-screen bg-white dark:bg-dark-background transition-colors duration-300'>
+      <ErrorBoundary>{children}</ErrorBoundary>
+    </div>
+  );
 }


### PR DESCRIPTION
## What
Adds a top-level `ErrorBoundary` React class component and wraps every `Layout` return tree in it, so a render error in any descendant (a broken MDX page, a future component, etc.) no longer takes the whole site down — it just shows a recoverable fallback.

## Why
As called out in #5047, the AsyncAPI website has zero React error boundaries. Today any uncaught render error in a layout child unmounts the entire route tree. Adding a top-level boundary is the standard, low-risk mitigation.

## Changes
- **New `components/ErrorBoundary.tsx`** (66 lines): standard React error-boundary class component. Catches errors in `componentDidCatch`, falls back to a small `<div role="alert">` (or a custom `fallback` prop), and logs to `console.error`. In production this is the natural seam to add a Sentry hook later.
- **`components/layout/Layout.tsx`**: Imported `ErrorBoundary` and wrapped all 5 return branches (Docs container, Blogs container, Blogs sub-container, GenericPostLayout, default container) so a single error in any layout can't unmount the whole shell.

2 files changed, 78 insertions(+), 9 deletions(-).

Closes #5047

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a top-level error boundary that wraps site layouts to provide recoverable fallbacks for rendering errors.
* **Bug Fixes**
  * Improved stability across docs, blog, and post pages so unexpected render failures show a friendly fallback instead of crashing the site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->