### PR TITLE
fix: update broken allcontributors and TSC_MEMBERSHIP links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ When you submit changes, your submissions are understood to be under the same [A
 
 ## Contribution recognition
 
-We use the [All Contributors](https://allcontributors.org/docs/en/specification) specification to handle recognitions. Read the [`recognize contributors` document](https://www.asyncapi.com/docs/community/010-contribution-guidelines/recognize-contributors).
+We use the [All Contributors](https://allcontributors.org/en/reference/specification/) specification to handle recognitions. Read the [`recognize contributors` document](https://www.asyncapi.com/docs/community/010-contribution-guidelines/recognize-contributors).
 
 ## Maintainers setup
 

--- a/components/footer/FooterList.ts
+++ b/components/footer/FooterList.ts
@@ -81,7 +81,8 @@ export const COMMUNITY_URLS = {
       'https://github.com/asyncapi/community/blob/master/docs/020-governance-and-policies/AMBASSADOR_PROGRAM.md',
     AMBASSADOR_ORGANIZATION:
       'https://github.com/asyncapi/community/blob/master/AMBASSADOR_ORGANIZATION.md#are-you-interested-in-becoming-an-official-asyncapi-ambassador',
-    TSC_MEMBERSHIP: 'https://github.com/asyncapi/community/blob/master/TSC_MEMBERSHIP.md',
+    TSC_MEMBERSHIP:
+      'https://github.com/asyncapi/community/blob/master/docs/020-governance-and-policies/TSC_MEMBERSHIP.md',
     CONTRIBUTING: 'https://github.com/asyncapi/community/blob/master/CONTRIBUTING.md'
   },
   YOUTUBE: {

--- a/markdown/about/index.md
+++ b/markdown/about/index.md
@@ -38,9 +38,9 @@ You can see the list of maintainers who also form part of the [AsyncAPI TSC here
 
 ## Contributors
 
-We do our best to recognize every contribution to the project. We do it individually in every repository from [AsyncAPI GitHub organization](https://github.com/asyncapi/). There should always be a **Contributors** section in the readme, like [this one](https://github.com/asyncapi/asyncapi/blob/master/README.md#contributors). We use [All Contributors](https://allcontributors.org/docs/en/specification) specification to handle recognitions. 
+We do our best to recognize every contribution to the project. We do it individually in every repository from [AsyncAPI GitHub organization](https://github.com/asyncapi/). There should always be a **Contributors** section in the readme, like [this one](https://github.com/asyncapi/asyncapi/blob/master/README.md#contributors). We use [All Contributors](https://allcontributors.org/en/reference/specification/) specification to handle recognitions. 
 
-We apologize in advance if we failed to recognize your work. Feel free to contact us on [Slack](https://www.asyncapi.com/slack-invite/), and we will fix it immediately, or just talk to our [All Contributors bot](https://allcontributors.org).
+We apologize in advance if we failed to recognize your work. Feel free to contact us on [Slack](https://www.asyncapi.com/slack-invite/), and we will fix it immediately, or just talk to our [All Contributors bot](https://allcontributors.org/en/bot/).
 
 ## AsyncAPI, in numbers
 Interested to know more about our growth? Feel free to check our annual summary report: 

--- a/markdown/docs/community/010-contribution-guidelines/recognize-contributors.md
+++ b/markdown/docs/community/010-contribution-guidelines/recognize-contributors.md
@@ -7,7 +7,7 @@ weight: 130
 
 We do our best to recognize every contribution to the project. We do it individually in every repository from the AsyncAPI GitHub organization.
 
-There should always be a **Contributors** section in the readme, like [this one](https://github.com/asyncapi/asyncapi/blob/master/README.md#contributors). We use [All Contributors](https://allcontributors.org/docs/en/specification) specification to handle recognitions.
+There should always be a **Contributors** section in the readme, like [this one](https://github.com/asyncapi/asyncapi/blob/master/README.md#contributors). We use [All Contributors](https://allcontributors.org/en/reference/specification/) specification to handle recognitions.
 
 Remember, not only code matters! You can contribute to AsyncAPI in different ways. You can:
 - Report a well-written issue that explains a bug or a feature that later is fixed/implemented.
@@ -17,7 +17,7 @@ Remember, not only code matters! You can contribute to AsyncAPI in different way
 - Write a blog post on the AsyncAPI blog.
 - Answer to questions under issues or in Slack
 
-You can help us out in many different ways. Just check out [this](https://allcontributors.org/docs/en/emoji-key) list of possible contributions. All of this is a contribution!
+You can help us out in many different ways. Just check out [this](https://allcontributors.org/en/reference/emoji-key/) list of possible contributions. All of this is a contribution!
 
 > We apologize in advance if we failed in recognizing your work. Feel free to contact us on [slack](https://asyncapi.com/slack-invite), and we will fix it immediately, or talk to All Contributors bot directly.
 
@@ -27,7 +27,7 @@ To recognize work, after it is done, in closed issue or pull request, add a prop
 
 `@all-contributors please add @{GITHUB_USERNAME} for {EMOJI_KEY}`.
 
-Check out a full list of [emoji keys](https://allcontributors.org/docs/en/emoji-key) although here you can find a shortlist of the most popular one:
+Check out a full list of [emoji keys](https://allcontributors.org/en/reference/emoji-key/) although here you can find a shortlist of the most popular one:
 
 Emoji/Type | Represents |
 :---: | :---:


### PR DESCRIPTION
**Description**

This PR fixes several broken external links found across the website's documentation and configuration files. The `allcontributors.org` site restructured its URL paths from `/docs/en/` to `/en/reference/`, and the `TSC_MEMBERSHIP.md` file was moved from the root of the `asyncapi/community` repo to a subdirectory, making the old hardcoded path return a 404.

**Changes made:**

- Updated the `TSC_MEMBERSHIP` constant in `FooterList.ts` to point to the correct subdirectory path
- Updated All Contributors specification links across documentation files
- Updated All Contributors emoji-key links across documentation files
- Updated the All Contributors bot link from the bare domain to the proper `/en/bot/` path

**Link changes (old → new):**

| File | Old URL | New URL |
|------|----------|----------|
| `components/footer/FooterList.ts` | [https://github.com/asyncapi/community/blob/master/TSC_MEMBERSHIP.md](https://github.com/asyncapi/community/blob/master/TSC_MEMBERSHIP.md) | [https://github.com/asyncapi/community/blob/master/docs/020-governance-and-policies/TSC_MEMBERSHIP.md](https://github.com/asyncapi/community/blob/master/docs/020-governance-and-policies/TSC_MEMBERSHIP.md) |
| `CONTRIBUTING.md` | [https://allcontributors.org/docs/en/specification](https://allcontributors.org/docs/en/specification) | [https://allcontributors.org/en/reference/specification/](https://allcontributors.org/en/reference/specification/) |
| `markdown/about/index.md` | [https://allcontributors.org/docs/en/specification](https://allcontributors.org/docs/en/specification) | [https://allcontributors.org/en/reference/specification/](https://allcontributors.org/en/reference/specification/) |
| `markdown/about/index.md` | [https://allcontributors.org](https://allcontributors.org) | [https://allcontributors.org/en/bot/](https://allcontributors.org/en/bot/) |
| `markdown/docs/.../recognize-contributors.md` | [https://allcontributors.org/docs/en/specification](https://allcontributors.org/docs/en/specification) | [https://allcontributors.org/en/reference/specification/](https://allcontributors.org/en/reference/specification/) |
| `markdown/docs/.../recognize-contributors.md` | [https://allcontributors.org/docs/en/emoji-key](https://allcontributors.org/docs/en/emoji-key) | [https://allcontributors.org/en/reference/emoji-key/](https://allcontributors.org/en/reference/emoji-key/) |

**Related issue(s)**
#5546 

<!-- If there is an existing issue tracking these broken links, add: Fixes #5546 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized and updated documentation links and reference paths across the site.
  * Refreshed contributor recognition links (All Contributors spec and bot) and updated governance/membership document links to their current locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->