### PR TITLE
fix: add deno.json for netlify edge functions IDE support

### DIFF
--- a/netlify/edge-functions/deno.json
+++ b/netlify/edge-functions/deno.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "lib": ["deno.window"],
+    "types": ["https://edge-bootstrap.netlify.app/v1/index.ts"]
+  }
+}


### PR DESCRIPTION
### Summary
Adds netlify/edge-functions/deno.json so editors with the [Deno VS Code extension](https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno) can resolve Deno globals and Netlify edge-bootstrap types in serve-definitions.ts.

The root tsconfig.json excludes the netlify/ directory, so the default TypeScript language service reports false positives for Deno.env, https:// imports, and the Context type — even though the edge functions run correctly on Netlify.

### Changes
Add netlify/edge-functions/deno.json with:
lib: ["deno.window"] for Deno globals
types pointing at https://edge-bootstrap.netlify.app/v1/index.ts (matches the import already used in serve-definitions.ts)
Notes
This is separate from #5538, which adds types: ["node"] to the root tsconfig.json and does not cover the excluded netlify/ path.
Local IDE setup still requires the Deno extension with deno.enablePaths for netlify/edge-functions (.vscode/ is gitignored in this repo).
Closes #5087

### Test plan

 Install the Deno VS Code extension and enable paths for netlify/edge-functions

 Open netlify/edge-functions/serve-definitions.ts — no red squiggles on Deno or the edge-bootstrap import

 deno check --config netlify/edge-functions/deno.json --allow-import netlify/edge-functions/serve-definitions.ts passes

 CI test:netlify passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Edge runtime configuration to ensure the project builds and runs with the correct Deno type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->