### PR TITLE
fix(e2e): add inactive link skip logic to slack footer test

### DIFF
--- a/cypress/pages/slack.js
+++ b/cypress/pages/slack.js
@@ -3,7 +3,7 @@ import BasePage from './BasePage';
 class SlackPage extends BasePage {
   visitSlack() {
     cy.visit(
-      'https://asyncapi.slack.com/join/shared_invite/zt-3clk6rmc0-Cujl2fChHYnHDUwFKRlQCw#/shared-invite/email',
+      'https://join.slack.com/t/asyncapi/shared_invite/zt-3qi8p8s2u-HxfLFE0Fx~RkpxK5yRBEmA',
     );
   }
 

--- a/cypress/slackworkspace.cy.js
+++ b/cypress/slackworkspace.cy.js
@@ -28,10 +28,21 @@ describe('Slack workspace tests', () => {
     });
   });
 
-  it('Should show links for Privacy, Contact Us, and Region Change', () => {
-    slackPage.verifyPrivacyAndTerms();
-    slackPage.verifyContactUs();
-    slackPage.verifyChangeRegion();
+  it('Should show links for Privacy, Contact Us, and Region Change', function () {
+    cy.get('body', { timeout: 10000 }).then(($body) => {
+      const isInactive =
+        $body.find('.p-refreshed_page__heading').length > 0 &&
+        $body.text().includes('This link is no longer active');
+
+      if (isInactive) {
+        cy.log('Slack invite link is inactive - skipping test');
+        this.skip();
+      } else {
+        slackPage.verifyPrivacyAndTerms();
+        slackPage.verifyContactUs();
+        slackPage.verifyChangeRegion();
+      }
+    });
   });
 
 });


### PR DESCRIPTION
Updated the slack invite link from `_redirects` and added skip logic for the 2nd test similar to what was present for the test 1

Fixes #5597 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Slack workspace coverage to handle inactive invite links gracefully, skipping the related checks when the invite is no longer active.
  * Preserved verification of Privacy, Contact Us, and Region Change links when the Slack invite is available.

* **Chores**
  * Switched to a newer Slack invite link for workspace access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->