### PR TITLE
Fix issue Blog Navigation Dropdown Content Overlaps Navbar While Scro…

### DIFF
--- a/components/navigation/StickyNavbar.tsx
+++ b/components/navigation/StickyNavbar.tsx
@@ -33,7 +33,7 @@ export default function StickyNavbar({ children, className = '' }: StickyNavbarP
 
   return (
     <div
-      className={`sticky ${isScrolled ? 'dark:bg-transparent' : 'dark:bg-dark-background'} top-0 z-50 lg:pt-2 lg:[transform:translateZ(0)] lg:will-change-transform ${className}`}
+      className={`sticky ${isScrolled ? 'dark:bg-transparent' : 'dark:bg-dark-background'} top-0 z-[9999] lg:pt-2 lg:[transform:translateZ(0)] lg:will-change-transform ${className}`}
       data-testid='Sticky-div'
     >
       {children}


### PR DESCRIPTION
### Description

This PR fixes the dropdown menu positioning issue in the **Blog** navigation section.

When a dropdown menu was expanded and the user scrolled down the page, the dropdown content moved upward and overlapped with the navigation bar. This change ensures that the dropdown remains correctly positioned relative to the navbar during scrolling.

### What changed

* Prevented the dropdown menu from appearing through the navbar during page scroll.


### Before

When scrolling with the dropdown menu open, the dropdown content moved upward and appeared over/through the navigation bar.

<img width="1411" height="742" alt="Before" src="https://github.com/user-attachments/assets/25bef8ec-de78-4fbc-b415-ffe53fe5c4ed" />

### After

The dropdown menu now remains correctly positioned below the navigation bar while scrolling.

<img width="1080" height="637" alt="After" src="https://github.com/user-attachments/assets/3d8251c0-9081-4ad7-accf-b1eeffb01ef2" />

### Testing

* Verified the Blog dropdown menus open correctly.
* Tested scrolling while keeping the dropdown menu expanded.
* Confirmed that the dropdown no longer overlaps or passes through the navigation bar.

### Related issue(s)

Resolves #5588 

### Summary

Fixed the Blog navigation dropdown scroll behavior to provide a more consistent and stable user experience.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the sticky navigation bar’s stacking order so it remains visible above other page elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->