### PR TITLE
fix: correct displayName type in Sneak Peek AsyncAPI example

### DIFF
--- a/components/SneakPeek.tsx
+++ b/components/SneakPeek.tsx
@@ -105,7 +105,7 @@ export default function SneakPeek() {
       </div>
       <div>
         <span className={TEAL}>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type:</span>
-        <span className={WHITE}> object</span>
+        <span className={WHITE}> string</span>
       </div>
       <div>
         <span className={TEAL}>


### PR DESCRIPTION
## Description

This PR updates the `displayName` field type in the AsyncAPI document shown in the Sneak Peek example.

**Before:**
```yaml
displayName:
  type: object
  description: Name of the User
```

**After:**
```yaml
displayName:
  type: string
  description: Name of the User
```

The AsyncAPI document example represents `displayName` as an `object`, while the generated TypeScript and documentation preview both represent it as a `string`. This change makes the three previews consistent.

## Type of change

- [x] Bug fix

## Testing

- Verified the Sneak Peek example renders correctly locally.


## Related issue(s)

Fixes #5754



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the AsyncAPI example so the `displayName` payload property is displayed as a string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->