### PR TITLE
test: add unit tests for scripts/compose.ts

### DIFF
--- a/tests/compose.test.ts
+++ b/tests/compose.test.ts
@@ -1,0 +1,104 @@
+import { logger } from '../scripts/helpers/logger';
+
+jest.mock('inquirer', () => ({
+  prompt: jest.fn()
+}));
+
+jest.mock('fs', () => ({
+  writeFile: jest.fn()
+}));
+
+jest.mock('dayjs', () => {
+  const dayjsMock = jest.fn(() => ({
+    format: jest.fn(() => '2021-05-01T10:00:00+02:00')
+  }));
+  return dayjsMock;
+});
+
+jest.mock('../scripts/helpers/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
+const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('compose script', () => {
+  const defaultAnswers = {
+    title: 'My First Blog Post!',
+    excerpt: 'A test excerpt for the blog post.',
+    tags: 'asyncapi, tutorial',
+    type: 'Engineering',
+    canonical: 'https://example.com'
+  };
+
+  let promptMock: jest.Mock;
+  let writeFileMock: jest.Mock;
+  let loggerInfoMock: jest.Mock;
+  let loggerErrorMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    promptMock = require('inquirer').prompt;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    writeFileMock = require('fs').writeFile;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    loggerInfoMock = require('../scripts/helpers/logger').logger.info;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    loggerErrorMock = require('../scripts/helpers/logger').logger.error;
+  });
+
+  it('generates the blog post file with front matter for the happy path', async () => {
+    promptMock.mockResolvedValue(defaultAnswers);
+    writeFileMock.mockImplementation((_filePath, _content, _options, callback) => callback(null));
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    require('../scripts/compose');
+    await flushPromises();
+
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    const [filePath, content, options] = writeFileMock.mock.calls[0];
+
+    expect(filePath).toBe('pages/blog/my-first-blog-post.md');
+    expect(options).toEqual({ flag: 'wx' });
+    expect(content).toContain('title: My First Blog Post!');
+    expect(content).toContain("tags: ['asyncapi','tutorial']");
+    expect(content).toContain('date: 2021-05-01T10:00:00+02:00');
+    expect(content).toContain('canonical: https://example.com');
+    expect(loggerInfoMock).toHaveBeenCalledWith('Blog post generated successfully at pages/blog/my-first-blog-post.md');
+  });
+
+  it.each([
+    ['Hello   World??', 'pages/blog/hello-world.md'],
+    ['My-Second_Post (v2)', 'pages/blog/mysecondpost-v2.md'],
+    ['', 'pages/blog/untitled.md'],
+    ['!!!', 'pages/blog/untitled.md']
+  ])('slugifies the title "%s" into the file path "%s"', async (title, expectedPath) => {
+    promptMock.mockResolvedValue({ ...defaultAnswers, title });
+    writeFileMock.mockImplementation((_filePath, _content, _options, callback) => callback(null));
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    require('../scripts/compose');
+    await flushPromises();
+
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    expect(writeFileMock.mock.calls[0][0]).toBe(expectedPath);
+  });
+
+  it('logs an error when the file cannot be written', async () => {
+    promptMock.mockResolvedValue(defaultAnswers);
+    writeFileMock.mockImplementation((_filePath, _content, _options, callback) => callback(new Error('EEXIST')));
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    require('../scripts/compose');
+    await flushPromises();
+
+    expect(loggerErrorMock).toHaveBeenCalled();
+    const errorArg = loggerErrorMock.mock.calls.find((call) => call[0] instanceof Error)?.[0] as Error;
+    expect(errorArg.message).toBe('EEXIST');
+  });
+});


### PR DESCRIPTION
## What changed

Adds Jest unit tests for the blog post composition script ([scripts/compose.ts](https://github.com/asyncapi/website/blob/master/scripts/compose.ts)), covering the interactive CLI flow and file generation behavior, as requested in #5096.

- Happy path: verifies the generated file path, front matter content (title, tags, canonical, date) and the success log message.
- Slug generation: verifies that titles are normalized to kebab-case file names, including empty and special-character-only titles falling back to \untitled\.
- Error handling: verifies the error is logged when the file cannot be written.

## How it works

The script runs its inquirer prompt chain at module load, so the tests mock \inquirer\, \s\, \dayjs\, and the logger, then import the script and flush the promise chain. Deterministic date via a mocked \dayjs\.

## Testing

Ran locally with jest: 6 tests passing.

## Certification

- [x] I changed only test files (tests/compose.test.ts).
- [x] My commits include a Signed-off-by line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for the content composition workflow.
  * Verified successful blog post generation with mocked dependencies.
  * Added validation for converting post titles into URL-friendly slugs.
  * Added coverage for handling and logging file-write errors.
  * Improved confidence that content generation behaves consistently across success and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->