### PR TITLE
feat: implement comprehensive React error boundary framework

### DIFF
--- a/components/error/ContentErrorBoundary.tsx
+++ b/components/error/ContentErrorBoundary.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+import React from 'react';
+
+import ContextualErrorFallback from './ContextualErrorFallback';
+import ErrorBoundary from './ErrorBoundary';
+
+interface IContentErrorBoundaryProps {
+  // The content subtree to protect.
+  children: ReactNode;
+
+  // Short label describing the failed region, e.g. "article" or "page content".
+  label?: string;
+}
+
+/**
+ * @description Convenience boundary for page content regions. It renders the
+ * lightweight ContextualErrorFallback so a crash inside the content keeps its
+ * local recovery UI without taking over the surrounding layout shell.
+ * @param {IContentErrorBoundaryProps} props - The content children and an optional label.
+ */
+export default function ContentErrorBoundary({
+  children,
+  label = 'content'
+}: IContentErrorBoundaryProps): React.JSX.Element {
+  return (
+    <ErrorBoundary
+      fallback={({ error, errorInfo, reset }) => (
+        <ContextualErrorFallback error={error} errorInfo={errorInfo} reset={reset} label={label} />
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/components/error/ContextualErrorFallback.tsx
+++ b/components/error/ContextualErrorFallback.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+import type { ErrorFallbackProps } from '@/types/components/error/ErrorBoundaryProps';
+
+import IconExclamation from '../icons/Exclamation';
+
+type IContextualErrorFallbackProps = ErrorFallbackProps & {
+  // Optional short label describing which widget failed, e.g. "sidebar".
+  label?: string;
+};
+
+/**
+ * @description Lightweight, inline fallback for widgets, sidebars, and other
+ * non-critical sections. It fails gracefully without disrupting the parent
+ * page and lets the user retry just the affected region.
+ * @param {IContextualErrorFallbackProps} props - The error, reset handler and label.
+ */
+export default function ContextualErrorFallback({
+  reset,
+  label = 'section'
+}: IContextualErrorFallbackProps): React.JSX.Element {
+  return (
+    <div
+      role='alert'
+      aria-live='polite'
+      data-testid='ContextualErrorFallback'
+      className='flex flex-col gap-2 rounded-md border border-yellow-300 bg-yellow-50 p-4 text-left
+        dark:border-yellow-700/60 dark:bg-yellow-900/20'
+    >
+      <div className='flex items-start gap-2'>
+        <IconExclamation className='mt-0.5 size-5 shrink-0 text-yellow-500 dark:text-yellow-400' aria-hidden='true' />
+        <div>
+          <p className='font-sans text-sm font-medium text-yellow-800 antialiased dark:text-yellow-200'>
+            This {label} could not be displayed.
+          </p>
+          <p className='mt-1 font-sans text-sm text-yellow-700 antialiased dark:text-yellow-300/80'>
+            The rest of the page is still available. You can try loading it again.
+          </p>
+        </div>
+      </div>
+      <div>
+        <button
+          type='button'
+          onClick={reset}
+          data-testid='ContextualErrorFallback-retry'
+          className='rounded-sm font-sans text-sm font-semibold text-yellow-800 underline underline-offset-2
+            transition-colors hover:text-yellow-900 focus:outline-none focus-visible:ring-2
+            focus-visible:ring-yellow-500 focus-visible:ring-offset-1 dark:text-yellow-200 dark:hover:text-yellow-100'
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/error/ErrorBoundary.stories.tsx
+++ b/components/error/ErrorBoundary.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import ContextualErrorFallback from './ContextualErrorFallback';
+import ErrorBoundary from './ErrorBoundary';
+import GlobalErrorFallback from './GlobalErrorFallback';
+
+/**
+ * @description A helper component that always throws so the boundary renders
+ * its fallback inside Storybook.
+ */
+function Bomb(): React.JSX.Element {
+  throw new Error('💥 Simulated rendering crash for demonstration purposes.');
+}
+
+const meta: Meta<typeof ErrorBoundary> = {
+  title: 'Components/ErrorBoundary',
+  component: ErrorBoundary
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ErrorBoundary>;
+
+export const DefaultGlobalFallback: Story = {
+  render: () => (
+    <ErrorBoundary resetOnRouteChange={false}>
+      <Bomb />
+    </ErrorBoundary>
+  )
+};
+
+export const ContextualFallback: Story = {
+  render: () => (
+    <ErrorBoundary
+      resetOnRouteChange={false}
+      fallback={({ reset }) => <ContextualErrorFallback error={null} reset={reset} label='widget' />}
+    >
+      <Bomb />
+    </ErrorBoundary>
+  )
+};
+
+export const CustomRenderFallback: Story = {
+  render: () => (
+    <ErrorBoundary
+      resetOnRouteChange={false}
+      fallback={({ error, reset }) => (
+        <div className='rounded-md border border-red-300 bg-red-50 p-4'>
+          <p className='font-sans text-sm text-red-800'>Custom fallback: {error?.message}</p>
+          <button type='button' onClick={reset} className='mt-2 text-sm font-semibold text-red-700 underline'>
+            Retry
+          </button>
+        </div>
+      )}
+    >
+      <Bomb />
+    </ErrorBoundary>
+  )
+};
+
+export const HealthyChildren: Story = {
+  render: () => (
+    <ErrorBoundary resetOnRouteChange={false}>
+      <p className='font-sans text-sm text-gray-700'>Everything rendered fine — no fallback shown.</p>
+    </ErrorBoundary>
+  )
+};
+
+export const GlobalFallbackStandalone: Story = {
+  render: () => <GlobalErrorFallback error={new Error('Example error message')} reset={() => {}} />
+};
+
+export const ContextualFallbackStandalone: Story = {
+  render: () => <ContextualErrorFallback error={new Error('Example error message')} reset={() => {}} label='sidebar' />
+};

--- a/components/error/ErrorBoundary.tsx
+++ b/components/error/ErrorBoundary.tsx
@@ -1,0 +1,122 @@
+import Router from 'next/router';
+import type { ErrorInfo } from 'react';
+import React, { Component } from 'react';
+
+import type {
+  ErrorBoundaryProps,
+  ErrorBoundaryState,
+  ErrorFallbackProps
+} from '@/types/components/error/ErrorBoundaryProps';
+
+import GlobalErrorFallback from './GlobalErrorFallback';
+
+/**
+ * @description Determine whether the ordered list of reset keys has changed
+ * between two renders. A change triggers an automatic reset of the boundary.
+ * @param {unknown[]} previous - The previous reset keys.
+ * @param {unknown[]} next - The next reset keys.
+ */
+function haveResetKeysChanged(previous: unknown[] = [], next: unknown[] = []): boolean {
+  if (previous.length !== next.length) return true;
+
+  return previous.some((key, index) => !Object.is(key, next[index]));
+}
+
+/**
+ * @description A reusable React error boundary that isolates rendering failures
+ * in its subtree, keeps the surrounding layout shell interactive, and renders
+ * an accessible recovery UI. It supports custom fallbacks, imperative resets via
+ * `resetKeys`, and automatic recovery on route changes.
+ */
+export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null, errorInfo: null };
+    this.reset = this.reset.bind(this);
+  }
+
+  /**
+   * @description Update state so the next render shows the fallback UI.
+   * @param {Error} error - The error thrown by a descendant component.
+   */
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { hasError: true, error };
+  }
+
+  componentDidMount(): void {
+    const { resetOnRouteChange = true } = this.props;
+
+    if (resetOnRouteChange) {
+      Router.events.on('routeChangeComplete', this.reset);
+    }
+  }
+
+  /**
+   * @description Log the caught error and forward it to the optional handler.
+   * @param {Error} error - The error thrown by a descendant component.
+   * @param {ErrorInfo} errorInfo - React error info with the component stack.
+   */
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    const { onError } = this.props;
+
+    this.setState({ errorInfo });
+    onError?.(error, errorInfo);
+
+    // eslint-disable-next-line no-console
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps): void {
+    const { hasError } = this.state;
+    const { resetKeys, resetOnRouteChange = true } = this.props;
+    const prevResetOnRouteChange = prevProps.resetOnRouteChange ?? true;
+
+    if (resetOnRouteChange !== prevResetOnRouteChange) {
+      if (resetOnRouteChange) {
+        Router.events.on('routeChangeComplete', this.reset);
+      } else {
+        Router.events.off('routeChangeComplete', this.reset);
+      }
+    }
+
+    if (hasError && haveResetKeysChanged(prevProps.resetKeys, resetKeys)) {
+      this.reset();
+    }
+  }
+
+  componentWillUnmount(): void {
+    Router.events.off('routeChangeComplete', this.reset);
+  }
+
+  /**
+   * @description Clear the error state so the protected subtree re-mounts.
+   */
+  reset(): void {
+    const { hasError } = this.state;
+    const { onReset } = this.props;
+
+    if (!hasError) return;
+
+    this.setState({ hasError: false, error: null, errorInfo: null });
+    onReset?.();
+  }
+
+  render(): React.ReactNode {
+    const { hasError, error, errorInfo } = this.state;
+    const { children, fallback } = this.props;
+
+    if (!hasError) return children;
+
+    const fallbackProps: ErrorFallbackProps = { error, errorInfo, reset: this.reset };
+
+    if (typeof fallback === 'function') {
+      return fallback(fallbackProps);
+    }
+
+    if (fallback !== undefined && fallback !== null) {
+      return fallback;
+    }
+
+    return <GlobalErrorFallback {...fallbackProps} />;
+  }
+}

--- a/components/error/GlobalErrorFallback.tsx
+++ b/components/error/GlobalErrorFallback.tsx
@@ -1,0 +1,75 @@
+import Link from 'next/link';
+import React from 'react';
+
+import type { ErrorFallbackProps } from '@/types/components/error/ErrorBoundaryProps';
+
+import IconExclamation from '../icons/Exclamation';
+import IconHome from '../icons/Home';
+
+/**
+ * @description Full-page fallback rendered by the global ErrorBoundary when an
+ * unrecoverable rendering error escapes the page content. It preserves the
+ * layout shell around it and offers accessible recovery actions.
+ * @param {ErrorFallbackProps} props - The error and the reset handler.
+ */
+export default function GlobalErrorFallback({ error, reset }: ErrorFallbackProps): React.JSX.Element {
+  const isDevelopment = process.env.NODE_ENV === 'development';
+
+  return (
+    <div
+      role='alert'
+      aria-live='assertive'
+      data-testid='GlobalErrorFallback'
+      className='flex min-h-[60vh] w-full items-center justify-center bg-white px-4 py-16 dark:bg-dark-background'
+    >
+      <div className='w-full max-w-xl text-center'>
+        <div className='mx-auto flex size-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30'>
+          <IconExclamation className='size-8 text-red-600 dark:text-red-400' aria-hidden='true' />
+        </div>
+        <h1 className='mt-6 font-sans text-2xl font-bold text-gray-900 antialiased dark:text-dark-heading'>
+          Something went wrong
+        </h1>
+        <p className='mt-3 font-sans text-base text-gray-600 antialiased dark:text-dark-text'>
+          An unexpected error interrupted this page. The rest of the site is still available, so you can retry or head
+          back to the homepage.
+        </p>
+
+        {isDevelopment && error?.message && (
+          <pre
+            data-testid='GlobalErrorFallback-details'
+            className='mt-6 max-h-48 overflow-auto whitespace-pre-wrap rounded-md bg-gray-100 p-4 text-left font-mono
+              text-sm text-red-700 dark:bg-dark-card dark:text-red-300'
+          >
+            {error.message}
+          </pre>
+        )}
+
+        <div className='mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row'>
+          <button
+            type='button'
+            onClick={reset}
+            data-testid='GlobalErrorFallback-retry'
+            className='inline-flex w-full items-center justify-center rounded-md bg-primary-500 px-5 py-3 text-md
+              font-semibold tracking-heading text-white transition-all duration-500 ease-in-out hover:bg-primary-400
+              focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
+              dark:focus-visible:ring-offset-dark-background sm:w-auto'
+          >
+            Try Again
+          </button>
+          <Link
+            href='/'
+            data-testid='GlobalErrorFallback-home'
+            className='inline-flex w-full items-center justify-center gap-2 rounded-md border border-gray-300 px-5 py-3
+              text-md font-semibold tracking-heading text-gray-700 transition-all duration-500 ease-in-out
+              hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500
+              focus-visible:ring-offset-2 dark:border-border dark:text-dark-text dark:hover:bg-muted
+              dark:focus-visible:ring-offset-dark-background sm:w-auto'
+          >
+            <IconHome className='size-5' aria-hidden='true' />
+            Back to homepage
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/layout/BlogLayout.tsx
+++ b/components/layout/BlogLayout.tsx
@@ -9,6 +9,7 @@ import type { IPosts } from '@/types/post';
 import BlogContext from '../../context/BlogContext';
 import AuthorAvatars from '../AuthorAvatars';
 import AnnouncementHero from '../campaigns/AnnouncementHero';
+import ContentErrorBoundary from '../error/ContentErrorBoundary';
 import Head from '../Head';
 import TOC from '../TOC';
 import Container from './Container';
@@ -91,7 +92,7 @@ export default function BlogLayout({ post, children }: IBlogLayoutProps) {
                 </HtmlHead>
               )}
               <img src={post.cover} alt={post.coverCaption} title={post.coverCaption} className='my-6 w-full' />
-              {children}
+              <ContentErrorBoundary label='article'>{children}</ContentErrorBoundary>
             </article>
           </main>
         </Container>

--- a/components/layout/DocsLayout.tsx
+++ b/components/layout/DocsLayout.tsx
@@ -12,6 +12,7 @@ import DocsContext from '../../context/DocsContext';
 import { getAllPosts } from '../../utils/api';
 import Button from '../buttons/Button';
 import DocsButton from '../buttons/DocsButton';
+import ContentErrorBoundary from '../error/ContentErrorBoundary';
 import Feedback from '../Feedback';
 import Head from '../Head';
 import ArrowRight from '../icons/ArrowRight';
@@ -111,7 +112,9 @@ export default function DocsLayout({ post, navItems = {}, children }: IDocsLayou
           />
           {explorerDocMenu && <div className='explorer-menu-wrapper mt-2'>{sidebar}</div>}
         </div>
-        <article>{children}</article>
+        <article>
+          <ContentErrorBoundary label='content'>{children}</ContentErrorBoundary>
+        </article>
       </div>
     );
   }
@@ -200,7 +203,7 @@ export default function DocsLayout({ post, navItems = {}, children }: IDocsLayou
                   )}
                   <article className='my-12 overflow-x-auto'>
                     <Head title={post.title} description={post.excerpt} image={post.cover} />
-                    {children}
+                    <ContentErrorBoundary label='content'>{children}</ContentErrorBoundary>
                   </article>
                   <div>
                     <DocsButton post={post} />

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -6,6 +6,7 @@ import type { IPost, IPosts } from '@/types/post';
 
 import BlogContext from '../../context/BlogContext';
 import { getAllPosts, getDocBySlug, getPostBySlug } from '../../utils/api';
+import ContentErrorBoundary from '../error/ContentErrorBoundary';
 import BlogLayout from './BlogLayout';
 import DocsLayout from './DocsLayout';
 import GenericPostLayout from './GenericPostLayout';
@@ -55,8 +56,16 @@ export default function Layout({ children }: ILayoutProps): React.JSX.Element {
   const post = getPostBySlug(pathname);
 
   if (post) {
-    return <GenericPostLayout post={post as unknown as IPosts['blog'][number]}>{children}</GenericPostLayout>;
+    return (
+      <GenericPostLayout post={post as unknown as IPosts['blog'][number]}>
+        <ContentErrorBoundary label='content'>{children}</ContentErrorBoundary>
+      </GenericPostLayout>
+    );
   }
 
-  return <div className='min-h-screen bg-white dark:bg-dark-background transition-colors duration-300'>{children}</div>;
+  return (
+    <div className='min-h-screen bg-white dark:bg-dark-background transition-colors duration-300'>
+      <ContentErrorBoundary label='page content'>{children}</ContentErrorBoundary>
+    </div>
+  );
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import AlgoliaSearch from '@/components/AlgoliaSearch';
 import ScrollButton from '@/components/buttons/ScrollButton';
 import Banner from '@/components/campaigns/Banner';
+import ErrorBoundary from '@/components/error/ErrorBoundary';
 import Footer from '@/components/footer/Footer';
 import Layout from '@/components/layout/Layout';
 import NavBar from '@/components/navigation/NavBar';
@@ -31,10 +32,12 @@ function MyApp({ Component, pageProps, router }: AppProps) {
             <NavBar className='mx-auto block max-w-screen-xl px-4 sm:px-6 lg:px-8' />
           </StickyNavbar>
 
-          <Layout>
-            <Component {...pageProps} />
-            <ScrollButton />
-          </Layout>
+          <ErrorBoundary>
+            <Layout>
+              <Component {...pageProps} />
+              <ScrollButton />
+            </Layout>
+          </ErrorBoundary>
           <div className='mt-auto dark:bg-dark-background'>
             <Footer />
           </div>

--- a/types/components/error/ErrorBoundaryProps.ts
+++ b/types/components/error/ErrorBoundaryProps.ts
@@ -1,0 +1,62 @@
+import type { ErrorInfo, ReactNode } from 'react';
+
+/**
+ * Props passed to a fallback component/render function when an error is caught.
+ */
+export interface ErrorFallbackProps {
+  // The error that was thrown by a descendant component.
+  error: Error | null;
+
+  // React error info containing the component stack, when available.
+  errorInfo?: ErrorInfo | null;
+
+  // Resets the boundary so the children are re-mounted and re-rendered.
+  reset: () => void;
+}
+
+/**
+ * A fallback can either be a static React node or a render function that
+ * receives the current error and the reset handler.
+ */
+export type ErrorFallback = ReactNode | ((props: ErrorFallbackProps) => ReactNode);
+
+/**
+ * Public props for the reusable ErrorBoundary component.
+ */
+export interface ErrorBoundaryProps {
+  // The subtree protected by this boundary.
+  children: ReactNode;
+
+  // Fallback rendered when an error is caught. Accepts a React node or a render
+  // function. Defaults to the full-page GlobalErrorFallback when omitted.
+  fallback?: ErrorFallback;
+
+  // Invoked with the error and error info whenever an error is caught.
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+
+  // Invoked after the boundary state has been reset.
+  onReset?: () => void;
+
+  // When any value in this array changes while the boundary is in an error
+  // state, the boundary automatically resets. Useful for tying recovery to
+  // external state such as a query or an id.
+  resetKeys?: unknown[];
+
+  // Automatically reset the boundary when the user navigates to a new route.
+  // Enabled by default so a crash never leaves the app permanently stuck.
+  resetOnRouteChange?: boolean;
+}
+
+/**
+ * Internal state for the ErrorBoundary component.
+ */
+export interface ErrorBoundaryState {
+  // Whether a descendant has thrown during rendering.
+  hasError: boolean;
+
+  // The captured error, if any.
+  error: Error | null;
+
+  // The captured React error info, if any.
+  errorInfo: ErrorInfo | null;
+}


### PR DESCRIPTION
Add a reusable ErrorBoundary class component with getDerivedStateFromError and componentDidCatch, dynamic fallback injection, a reset mechanism, and automatic route-based reset via Next.js Router events.

Add accessible fallback UIs: a full-page GlobalErrorFallback (icon, explanation, Try Again, home link) and a lightweight ContextualErrorFallback card for widgets/sidebars, both WCAG 2.1 AA keyboard/screen-reader friendly.

Wire boundaries as a global safety net in pages/_app.tsx and around content containers in Layout, DocsLayout, and BlogLayout so navigation and sidebars stay functional when page content crashes. Includes Storybook stories.

Closes #5559

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added error handling that prevents isolated page sections from crashing the entire app.
  * Added contextual retry prompts for affected sections.
  * Added a full-page error screen with retry and homepage navigation options.
  * Added recovery when navigation changes or users retry failed content.
* **Bug Fixes**
  * Improved resilience across application, documentation, blog, and page layouts when rendering errors occur.
* **Tests**
  * Added interactive examples covering global, contextual, custom, recovered, and error-free states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->