### PR TITLE
fix(blog): preserve pagination state on navigation

### DIFF
--- a/components/navigation/Filter.tsx
+++ b/components/navigation/Filter.tsx
@@ -34,7 +34,16 @@ export default function Filter<T extends DataObject = DataObject>({
   const [routeQuery, setQuery] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    setQuery(route.query as Record<string, string>);
+    const validKeys = new Set(checks.map((check) => check.name));
+    const filteredQuery: Record<string, string> = {};
+
+    Object.entries(route.query).forEach(([key, value]) => {
+      if (validKeys.has(key) && typeof value === 'string') {
+        filteredQuery[key] = value;
+      }
+    });
+
+    setQuery(filteredQuery);
     applyFilterList(checks, data, setFilters);
     // route.asPath is used as a proxy for route.query because route.query is an object
     // that Next.js recreates on each render, which would cause infinite re-renders.
@@ -73,19 +82,21 @@ export default function Filter<T extends DataObject = DataObject>({
             ...query
           };
 
+          delete newQuery.page;
+
           if (e) {
             newQuery[check.name] = e;
           } else {
             // Remove a specific filter upon clicking Select Placeholder option
             delete newQuery[check.name];
           }
-          if (newQuery) {
-            const queryParams = new URLSearchParams(newQuery as { [key: string]: string }).toString();
 
-            route.push(`${route.pathname}?${queryParams}`, undefined, {
-              shallow: true
-            });
-          }
+          const queryParams = new URLSearchParams(newQuery as { [key: string]: string }).toString();
+          const targetUrl = queryParams ? `${route.pathname}?${queryParams}` : route.pathname;
+
+          route.push(targetUrl, undefined, {
+            shallow: true
+          });
         }}
         selected={selected}
         className={`${className} md:mr-4`}

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -17,6 +17,19 @@ import type { IBlogPost } from '@/types/post';
 import { HeadingLevel, HeadingTypeStyle } from '@/types/typography/Heading';
 import { ParagraphTypeStyle } from '@/types/typography/Paragraph';
 
+const toFilter = [
+  {
+    name: 'type'
+  },
+  {
+    name: 'authors',
+    unique: 'name'
+  },
+  {
+    name: 'tags'
+  }
+];
+
 /**
  * @description The BlogIndexPage is the blog index page of the website.
  */
@@ -39,38 +52,53 @@ export default function BlogIndexPage() {
   );
   const [isClient, setIsClient] = useState(false);
   const [activeTab, setActiveTab] = useState<string>('All Posts');
-  const [currentPage, setCurrentPage] = useState(1);
+  const queryPage = router.isReady && typeof router.query.page === 'string' ? parseInt(router.query.page, 10) : 1;
+  const currentPage = Number.isNaN(queryPage) || queryPage < 1 ? 1 : queryPage;
   const [postsPerPage, setPostsPerPage] = useState(9);
+
+  const handlePageChange = useCallback(
+    (page: number) => {
+      const nextQuery = { ...router.query };
+
+      if (page <= 1) {
+        delete nextQuery.page;
+      } else {
+        nextQuery.page = page.toString();
+      }
+
+      router.push(
+        {
+          pathname: router.pathname,
+          query: nextQuery
+        },
+        undefined,
+        {
+          shallow: true
+        }
+      );
+    },
+    [router]
+  );
 
   const onFilter = useCallback(
     (data: IBlogPost[]) => {
       setPosts(data);
       // Reset tab filter to "All Posts" when dropdown filters are applied
-      if (Object.keys(router.query).length > 0) {
+      const hasFilters = Object.keys(router.query).some((key) => key !== 'page');
+
+      if (hasFilters) {
         setActiveTab('All Posts');
       }
     },
     [router.query]
   );
-  const toFilter = [
-    {
-      name: 'type'
-    },
-    {
-      name: 'authors',
-      unique: 'name'
-    },
-    {
-      name: 'tags'
-    }
-  ];
   const clearFilters = () => {
-    router.push(`${router.pathname}`, undefined, {
+    router.push(router.pathname, undefined, {
       shallow: true
     });
     setActiveTab('All Posts');
   };
-  const showClearFilters = Object.keys(router.query).length > 0;
+  const showClearFilters = Object.keys(router.query).some((key) => key !== 'page');
 
   const description = 'Find the latest and greatest stories from our community';
   const image = '/img/social/blog.webp';
@@ -93,7 +121,7 @@ export default function BlogIndexPage() {
   }, []);
 
   // Filter posts by active tab (only if no dropdown filters are active)
-  const hasDropdownFilters = Object.keys(router.query).length > 0;
+  const hasDropdownFilters = Object.keys(router.query).some((key) => key !== 'page');
   const filteredByTab = posts.filter((post) => {
     // If dropdown filters are active, show all posts (dropdown takes priority)
     if (hasDropdownFilters) return true;
@@ -109,17 +137,30 @@ export default function BlogIndexPage() {
   const indexOfFirstPost = indexOfLastPost - postsPerPage;
   const currentPosts = filteredByTab.slice(indexOfFirstPost, indexOfLastPost);
 
-  // Reset to page 1 when changing tabs, filters, or posts per page
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [activeTab, posts, postsPerPage]);
-
   // Reset tab to "All Posts" when dropdown filters change
   useEffect(() => {
     if (hasDropdownFilters) {
       setActiveTab('All Posts');
     }
   }, [router.query, hasDropdownFilters]);
+
+  // Reset page to 1 (and clean URL) when changing tabs or when filtered posts change
+  const prevActiveTab = React.useRef(activeTab);
+  const prevPosts = React.useRef(posts);
+
+  useEffect(() => {
+    const tabChanged = prevActiveTab.current !== activeTab;
+    const postsChanged = prevPosts.current !== posts;
+
+    prevActiveTab.current = activeTab;
+    prevPosts.current = posts;
+
+    if (tabChanged || postsChanged) {
+      if (router.query.page) {
+        handlePageChange(1);
+      }
+    }
+  }, [activeTab, posts, handlePageChange, router.query.page]);
 
   const tabs = ['All Posts', 'Community', 'Conference', 'Communication', 'Engineering', 'Strategy'];
 
@@ -182,7 +223,14 @@ export default function BlogIndexPage() {
                 {tabs.map((tab) => (
                   <button
                     key={tab}
-                    onClick={() => !hasDropdownFilters && setActiveTab(tab)}
+                    onClick={() => {
+                      if (!hasDropdownFilters) {
+                        setActiveTab(tab);
+                        if (router.query.page) {
+                          handlePageChange(1);
+                        }
+                      }
+                    }}
                     disabled={hasDropdownFilters}
                     className={`rounded-md px-3 py-2 text-sm font-medium transition-all duration-200 
                       whitespace-nowrap ${
@@ -221,7 +269,7 @@ export default function BlogIndexPage() {
                     {/* Mobile Pagination */}
                     <div className='flex sm:hidden items-center justify-between gap-2'>
                       <button
-                        onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
+                        onClick={() => handlePageChange(Math.max(currentPage - 1, 1))}
                         disabled={currentPage === 1}
                         className='flex-1 rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-dark-card px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-dark-background disabled:opacity-50 disabled:cursor-not-allowed'
                       >
@@ -231,7 +279,7 @@ export default function BlogIndexPage() {
                         Page {currentPage} of {totalPages}
                       </span>
                       <button
-                        onClick={() => setCurrentPage((prev) => Math.min(prev + 1, totalPages))}
+                        onClick={() => handlePageChange(Math.min(currentPage + 1, totalPages))}
                         disabled={currentPage === totalPages}
                         className='flex-1 rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-dark-card px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-dark-background disabled:opacity-50 disabled:cursor-not-allowed'
                       >
@@ -244,7 +292,7 @@ export default function BlogIndexPage() {
                       <PaginationComponent
                         currentPage={currentPage}
                         totalPages={totalPages}
-                        onPageChange={setCurrentPage}
+                        onPageChange={handlePageChange}
                         variant='compact'
                       />
                     </div>

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -144,23 +144,38 @@ export default function BlogIndexPage() {
     }
   }, [router.query, hasDropdownFilters]);
 
-  // Reset page to 1 (and clean URL) when changing tabs or when filtered posts change
+  // Reset page to 1 when the actual filters or tab change (not when only page changes or on initial load)
   const prevActiveTab = React.useRef(activeTab);
-  const prevPosts = React.useRef(posts);
+  const prevFilterQuery = React.useRef<string | null>(null);
 
   useEffect(() => {
+    if (!router.isReady) return;
+
+    const currentFilterEntries = Object.entries(router.query)
+      .filter(([key]) => key !== 'page')
+      .sort(([a], [b]) => a.localeCompare(b));
+    const currentFilterQuery = JSON.stringify(currentFilterEntries);
+
+    // On initial ready, record the current filter query without triggering a reset
+    if (prevFilterQuery.current === null) {
+      prevFilterQuery.current = currentFilterQuery;
+      prevActiveTab.current = activeTab;
+
+      return;
+    }
+
     const tabChanged = prevActiveTab.current !== activeTab;
-    const postsChanged = prevPosts.current !== posts;
+    const filterChanged = prevFilterQuery.current !== currentFilterQuery;
 
     prevActiveTab.current = activeTab;
-    prevPosts.current = posts;
+    prevFilterQuery.current = currentFilterQuery;
 
-    if (tabChanged || postsChanged) {
+    if (tabChanged || filterChanged) {
       if (router.query.page) {
         handlePageChange(1);
       }
     }
-  }, [activeTab, posts, handlePageChange, router.query.page]);
+  }, [activeTab, router.isReady, router.query, handlePageChange]);
 
   const tabs = ['All Posts', 'Community', 'Conference', 'Communication', 'Engineering', 'Strategy'];
 

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -52,7 +52,7 @@ export default function BlogIndexPage() {
   );
   const [isClient, setIsClient] = useState(false);
   const [activeTab, setActiveTab] = useState<string>('All Posts');
-  const queryPage = router.isReady && typeof router.query.page === 'string' ? parseInt(router.query.page, 10) : 1;
+  const queryPage = router.isReady && typeof router.query.page === 'string' ? Number.parseInt(router.query.page, 10) : 1;
   const currentPage = Number.isNaN(queryPage) || queryPage < 1 ? 1 : queryPage;
   const [postsPerPage, setPostsPerPage] = useState(9);
 


### PR DESCRIPTION
**Description**

* Fixes the blog pagination state being reset to page 1 when navigating back from a blog post.
* Preserves the selected blog page in the URL so browser Back/Forward navigation restores the previous page.
* Prevents the `page` query parameter from being treated as a blog filter.
* Keeps existing blog filters working with pagination.

**Before**

When a user navigates to a page such as page 3, opens a blog post, and clicks the browser Back button, the blog returns to page 1 instead of page 3.

<img width="1906" height="976" alt="BeforePagination" src="https://github.com/user-attachments/assets/0099f714-01ea-4c9a-a38d-505ac0eeb381" />









**After**

The selected page is preserved in the URL. For example, returning from a blog post brings the user back to `/blog?page=3`.


<img width="1905" height="976" alt="AfterPagination (1) (1)" src="https://github.com/user-attachments/assets/1b671fa1-f689-4115-8cae-1ae99f8f4e81" />



**Testing**

* Tested blog pagination.
* Tested browser Back/Forward navigation.
* Tested pagination with type, author, and tag filters.
* Tested changing and clearing filters.
* Ran ESLint on the changed files successfully.


## Related issue(s)

Fixes #5747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements

- Blog pagination is now reflected in the URL across mobile and desktop controls.
- Invalid, negative, or out-of-range page values are automatically corrected.
- Applying a filter clears the current page and starts results from the beginning.
- Switching blog tabs resets pagination appropriately.
- Changing dropdown filters returns the view to “All Posts” when applicable.
- Filter and pagination URLs remain clean when no query parameters are selected.
- Blog filters and pagination stay synchronized with the URL during navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->